### PR TITLE
docs: add recursive spawning, permissions bypass, /loop analyses

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ when to use it, and when to skip it.
 
 | Directory | Analyses |
 |---|---|
-| [`agents-skills/`](docs/cc-native/agents-skills/) | Agent Teams, Skills adoption, Ralph loop enhancements, CLI-Anything analysis, plans as skill/rule templates |
-| [`ci-execution/`](docs/cc-native/ci-execution/) | Sandboxing, cloud sessions, remote control, remote access landscape, version pinning & self-hosted runners, GitHub Actions & Claude App |
+| [`agents-skills/`](docs/cc-native/agents-skills/) | Agent Teams, Skills adoption, Ralph loop enhancements, recursive spawning patterns, CLI-Anything analysis, plans as skill/rule templates |
+| [`ci-execution/`](docs/cc-native/ci-execution/) | Sandboxing, permissions bypass, cloud sessions, remote control, remote access landscape, version pinning & self-hosted runners, GitHub Actions & Claude App |
 | [`context-memory/`](docs/cc-native/context-memory/) | Extended context (1M tokens), memory system (with path-scoped rules deep dive), llms.txt |
-| [`configuration/`](docs/cc-native/configuration/) | Model/provider configuration, fast mode, hooks system, bash mode (with SDK & community refs) |
+| [`configuration/`](docs/cc-native/configuration/) | Model/provider configuration, fast mode, hooks system, bash mode (with SDK & community refs), /loop cron system |
 | [`plugins-ecosystem/`](docs/cc-native/plugins-ecosystem/) | Plugin packaging, cowork/enterprise plugins, Chrome extension, web scraping plugins, official plugins landscape |
 | [`CC-changelog-feature-scan.md`](docs/cc-native/CC-changelog-feature-scan.md) | Changelog triage of new CC features (v2.1.0–2.1.71) |
 

--- a/docs/cc-native/agents-skills/CC-recursive-spawning-patterns.md
+++ b/docs/cc-native/agents-skills/CC-recursive-spawning-patterns.md
@@ -1,0 +1,140 @@
+---
+title: CC Recursive Spawning Patterns
+source: https://code.claude.com/docs/en/sub-agents, https://github.com/anthropics/claude-agent-sdk-python/issues/573, https://forem.com/jungjaehoon/why-claude-code-subagents-waste-50k-tokens-per-turn-and-how-to-fix-it-41ma
+purpose: Analysis of recursive claude -p invocation patterns, the CLAUDECODE=1 session guard, and spawning method trade-offs for autonomous agent orchestration.
+created: 2026-03-17
+updated: 2026-03-17
+---
+
+**Status**: Research (informational)
+
+## What Recursive Spawning Is
+
+Running `claude -p` as a subprocess from within a Claude Code session or an
+external harness. Each invocation starts with a fresh context window -- no
+session state carries over. This is the primitive behind autonomous development
+loops (Ralph pattern) and CI/CD integrations.
+
+```bash
+claude -p "your prompt"
+claude -p "your prompt" --output-format json
+git diff main...HEAD | claude -p "Write a PR description..."
+```
+
+## The `CLAUDECODE=1` Session Guard
+
+Claude Code sets `CLAUDECODE=1` in its process environment. Child processes
+inherit this variable. When a spawned `claude` CLI detects `CLAUDECODE=1`, it
+rejects the session:
+
+```text
+Error: Claude Code cannot be launched inside another Claude Code session.
+```
+
+The guard prevents accidental infinite recursion but must be explicitly cleared
+for intentional recursive patterns:
+
+```bash
+# From INSIDE a Claude Code session (hook, plugin, subagent, Bash tool):
+CLAUDECODE= claude -p "your prompt"          # clears guard for child
+# or:
+unset CLAUDECODE; claude -p "your prompt"    # removes it entirely
+```
+
+In the Claude Agent SDK (`subprocess_cli.py`), filter the environment before
+spawning:
+
+```python
+env = {**os.environ}
+del env["CLAUDECODE"]
+subprocess.run(["claude", "-p", prompt], env=env)
+```
+
+**Without clearing `CLAUDECODE`, recursive spawning from within CC is
+impossible.**
+
+**Source**: [claude-agent-sdk-python#573](https://github.com/anthropics/claude-agent-sdk-python/issues/573) --
+SDK bug where `subprocess_cli.py` inherited `CLAUDECODE=1` without filtering,
+breaking hooks/plugins that spawn child CC instances.
+
+## Token Cost Warning
+
+Each `claude -p` subprocess re-ingests the full system prompt:
+`~/.claude/settings.json`, all MCP tool descriptions, plugins, skills,
+`CLAUDE.md`. A single subprocess turn can consume **~50K tokens** before doing
+any work.
+
+**Mitigations**:
+
+- Use isolated config (`--no-plugins`, minimal MCP) for child processes
+- Set `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+- Set `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` to skip git context
+- Set `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` to prevent extended context
+
+**Source**: [DEV Community -- "Why Each Subprocess Burns 50K Tokens"](https://forem.com/jungjaehoon/why-claude-code-subagents-waste-50k-tokens-per-turn-and-how-to-fix-it-41ma)
+
+## Key Environment Variables
+
+<!-- markdownlint-disable MD013 -->
+
+| Variable | Purpose |
+|---|---|
+| `CLAUDECODE=1` | **Session guard** -- set by CC; blocks nested launches. Clear with `CLAUDECODE=` or `unset CLAUDECODE` for recursive spawning |
+| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` | Enable agent teams |
+| `CLAUDE_CODE_SUBAGENT_MODEL` | Model for subagents/teammates |
+| `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` | Save context in headless loops |
+| `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` | Prevent extended context in headless runs |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` | Reduce API calls |
+
+<!-- markdownlint-enable MD013 -->
+
+## Spawning Methods Comparison
+
+<!-- markdownlint-disable MD013 -->
+
+| Method | How | Nested? | `CLAUDECODE` guard | Session |
+|---|---|---|---|---|
+| `claude -p` (external harness) | Shell subprocess | Yes (unlimited) | N/A -- parent isn't CC | Fresh each call |
+| `claude -p` (from within CC) | `CLAUDECODE= claude -p` | Yes (unlimited) | **Must clear** | Fresh each call |
+| Agent Teams (in-process) | `TeamCreate` + `Agent` | **No** -- can't spawn sub-teams | Handled internally | Persistent within team |
+| Agent Teams (tmux) | `--teammate-mode tmux` | Teammates get Agent tool | Handled internally | Persistent within team |
+| Subagents (`Agent` tool) | Within single session | 1 level deep | Handled internally | Shared parent session |
+| Claude Agent SDK | `subprocess_cli.py` | Yes | **Must filter** `os.environ` | Fresh per call |
+
+<!-- markdownlint-enable MD013 -->
+
+## Relationship to Agent Teams and Ralph
+
+**Agent Teams** ([CC-agent-teams-orchestration.md](CC-agent-teams-orchestration.md))
+spawn teammates as in-process CC instances with shared task lists. Key
+constraint: **no nested teams** -- teammates cannot spawn their own teams.
+Known bugs: teammates lack the Agent tool in `in-process` mode
+([#31977](https://github.com/anthropics/claude-code/issues/31977));
+`--print` mode + teams hangs
+([#30008](https://github.com/anthropics/claude-code/issues/30008), fixed in
+recent versions).
+
+**Ralph loop** ([CC-ralph-enhancement-research.md](CC-ralph-enhancement-research.md))
+is the battle-tested external harness pattern: a shell script calls `claude -p`
+once per story with fresh context. Filesystem (prd.json, git state) provides
+continuity. Each call is independent -- no session coupling.
+
+**No true "recursive team mode" exists yet.** The closest pattern is a shell
+harness (Ralph) calling `claude -p` with
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` per iteration, but each iteration's
+teams are independent.
+
+## Sources
+
+<!-- markdownlint-disable MD013 -->
+
+| Source | Content |
+|---|---|
+| [Official sub-agents docs](https://code.claude.com/docs/en/sub-agents) | Subagent architecture |
+| [claude-agent-sdk-python#573](https://github.com/anthropics/claude-agent-sdk-python/issues/573) | `CLAUDECODE=1` guard bug in SDK |
+| [DEV Community](https://forem.com/jungjaehoon/why-claude-code-subagents-waste-50k-tokens-per-turn-and-how-to-fix-it-41ma) | 50K token cost per subprocess |
+| [haasonsaas/claude-recursive-spawn](https://github.com/haasonsaas/claude-recursive-spawn) | Bash script with depth control, JSON parsing |
+| [#31977](https://github.com/anthropics/claude-code/issues/31977) | No Agent tool in in-process teammates |
+| [#30008](https://github.com/anthropics/claude-code/issues/30008) | Teams + print mode hang |
+
+<!-- markdownlint-enable MD013 -->

--- a/docs/cc-native/ci-execution/CC-permissions-bypass-analysis.md
+++ b/docs/cc-native/ci-execution/CC-permissions-bypass-analysis.md
@@ -1,0 +1,134 @@
+---
+title: CC Permissions Bypass Analysis
+source: https://code.claude.com/docs/en/settings, https://code.claude.com/docs/en/security
+purpose: Analysis of --dangerously-skip-permissions flag, permission modes, team inheritance, and safer alternatives for headless/CI execution.
+created: 2026-03-17
+updated: 2026-03-17
+---
+
+**Status**: Research (informational)
+
+## What `--dangerously-skip-permissions` Does
+
+Bypasses **all** permission checks -- file edits, bash commands, network
+requests, MCP tools, subagent spawning. Every action auto-approves without
+confirmation.
+
+```bash
+claude --dangerously-skip-permissions
+# Combined with print mode (standard headless pattern):
+claude --dangerously-skip-permissions -p "your prompt"
+```
+
+This is the most common autonomous usage: CI/CD pipelines, Ralph-style loops,
+GitHub Actions. The flag removes all interactive prompts that would block
+non-interactive mode.
+
+## Permission Inheritance in Teams
+
+If the lead is run with `--dangerously-skip-permissions`, **all teammates also
+bypass permission checks**. Individual teammate modes can be adjusted after
+spawning, but not at spawn time.
+
+```text
+Lead (--dangerously-skip-permissions)
+  |-- Teammate A (inherits bypass)
+  |-- Teammate B (inherits bypass)
+  |-- Teammate C (inherits bypass -- can be changed post-spawn)
+```
+
+See [CC-agent-teams-orchestration.md](../agents-skills/CC-agent-teams-orchestration.md)
+for team architecture details.
+
+## The 5 Permission Modes
+
+<!-- markdownlint-disable MD013 -->
+
+| Mode | Behavior | Risk |
+|---|---|---|
+| **Default** | Asks for everything | Lowest -- blocks on every action |
+| **`acceptEdits`** | Auto-approves file edits, asks for bash/network | Low |
+| **`plan`** | Requires plan approval before implementation | Low |
+| **`dontAsk`** | Auto-approves everything matching `settings.json` allowlist | Medium -- granular control |
+| **`bypassPermissions`** | Auto-approves ALL actions | Highest -- no guardrails |
+
+<!-- markdownlint-enable MD013 -->
+
+## Safer Alternative: `settings.json` Allowlists
+
+The `dontAsk` mode with explicit allowlists gives ~90% of the speed without
+the risk:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(make *)",
+      "Bash(git *)",
+      "Bash(uv run *)",
+      "Write",
+      "Edit"
+    ]
+  }
+}
+```
+
+This auto-approves listed patterns while still prompting for unlisted actions
+(e.g., network requests, MCP tool calls).
+
+## Disabling Organization-Wide
+
+Server-managed settings can force-disable bypass mode:
+
+```json
+{
+  "disableBypassPermissionsMode": "disable"
+}
+```
+
+## Known Bugs
+
+<!-- markdownlint-disable MD013 -->
+
+| Bug | Description | Status |
+|---|---|---|
+| [#29110](https://github.com/anthropics/claude-code/issues/29110) | `bypassPermissions` mode on spawned agents (via Task tool) is ineffective -- agents still can't use Write/Edit/Bash | Open (2026-03) |
+| [#29064](https://github.com/anthropics/claude-code/issues/29064) | Teammates spawned with `mode: "plan"` get stuck in infinite plan-approval loops -- never exit plan mode | Open (2026-03) |
+
+<!-- markdownlint-enable MD013 -->
+
+## Security Considerations
+
+| Risk | Mitigation |
+|---|---|
+| Cascading destructive ops | Use in disposable environments (Docker, Codespaces) |
+| Infinite resource loops | Set timeouts on `claude -p` calls |
+| Credential exposure | Don't mount secrets; use `.env` deny rules |
+| Unintended file deletion | Git commit before each iteration (Ralph pattern) |
+
+## `dangerouslyDisableSandbox` vs `--dangerously-skip-permissions`
+
+These are **separate mechanisms**:
+
+- **`--dangerously-skip-permissions`** (CLI flag): Bypasses the permission
+  prompt system -- all tool calls auto-approve.
+- **`dangerouslyDisableSandbox`** (Bash tool parameter): Per-command escape
+  hatch from the filesystem/network sandbox. Can be disabled via
+  `sandbox.allowUnsandboxedCommands: false`.
+
+The sandbox ([CC-sandboxing-analysis.md](CC-sandboxing-analysis.md)) enforces
+OS-level filesystem and network isolation regardless of permission mode.
+Bypassing permissions does not bypass the sandbox.
+
+## Sources
+
+<!-- markdownlint-disable MD013 -->
+
+| Source | Content |
+|---|---|
+| [Official settings docs](https://code.claude.com/docs/en/settings) | Permission modes, allowlists |
+| [Official security docs](https://code.claude.com/docs/en/security) | Security model, sandbox separation |
+| [#29110](https://github.com/anthropics/claude-code/issues/29110) | Bypass ineffective on Task tool agents |
+| [#29064](https://github.com/anthropics/claude-code/issues/29064) | Plan mode infinite loop |
+
+<!-- markdownlint-enable MD013 -->

--- a/docs/cc-native/configuration/CC-loop-cron-analysis.md
+++ b/docs/cc-native/configuration/CC-loop-cron-analysis.md
@@ -1,0 +1,141 @@
+---
+title: CC /loop Command and Cron System Analysis
+source: https://code.claude.com/docs/en/slash-commands (inferred), gist by @sorrycc (v2.1.71 cli.js decompilation)
+purpose: Analysis of the /loop slash command for recurring autonomous tasks, its CronCreate/List/Delete internals, and comparison with external scheduling approaches.
+created: 2026-03-17
+updated: 2026-03-17
+---
+
+**Status**: Generally available (v2.1.71+, feature gate `tengu_kairos_cron`)
+
+## What `/loop` Is
+
+Built-in slash command that schedules recurring prompts within an **interactive**
+CC session:
+
+```text
+/loop 5m check if the deployment finished
+/loop 20m /review-pr 1234
+/loop 1h run make test and report results
+/loop check the build every 2 hours
+```
+
+- **Default interval**: 10 minutes
+- **Units**: seconds, minutes, hours, days -- natural language intervals also work
+- **Max**: 50 scheduled jobs per session
+- **Feature gate**: `tengu_kairos_cron` (polled every 5 min)
+
+## Implementation
+
+Under the hood, `/loop` is syntactic sugar over three internal tools:
+
+- `CronCreate` -- schedule a recurring prompt
+- `CronList` -- view active schedules
+- `CronDelete` -- remove a schedule
+
+These tools are available to the model within the session but are not exposed
+as user-facing slash commands beyond `/loop`.
+
+## Critical Limitation: Session-Bound Only
+
+**`/loop` is incompatible with `-p` (print mode).** Print mode exits on
+completion -- there's no persistent session for the cron scheduler to fire in.
+`/loop` only works in interactive terminal sessions.
+
+```bash
+# DOES NOT WORK -- -p exits immediately, /loop never fires
+claude --dangerously-skip-permissions -p "/loop 5m check deploy"
+
+# WORKS -- interactive session with bypass
+claude --dangerously-skip-permissions
+# then inside the session:
+/loop 5m check deploy
+```
+
+## `/loop` + `--dangerously-skip-permissions`
+
+This combination works in interactive mode and is the most autonomous CC
+configuration:
+
+```bash
+# Start interactive session with no permission checks
+claude --dangerously-skip-permissions
+# Inside session:
+/loop 5m /review-pr 1234
+/loop 10m run make test and fix any failures
+/loop 1h check CI status and report
+```
+
+Each loop iteration fires with full bypass permissions -- Claude can read,
+write, execute, and network without any prompts. See
+[CC-permissions-bypass-analysis.md](../ci-execution/CC-permissions-bypass-analysis.md)
+for security implications.
+
+## Comparison: `/loop` vs Ralph Loop vs GitHub Actions
+
+<!-- markdownlint-disable MD013 -->
+
+| Feature | `/loop` | Ralph (`claude -p` loop) | GitHub Actions |
+|---|---|---|---|
+| State persistence | Session only (lost on exit) | External files (prd.json, git) | Workflow artifacts |
+| Context management | Single accumulating context | Fresh context per iteration | Fresh per run |
+| TDD enforcement | None | Built-in | Custom |
+| Story dependencies | None | `depends:` in prd.json | `needs:` in workflow |
+| Permission control | Inherits session mode | Per-invocation flag | Per-step |
+| Survives disconnection | No | Yes (script continues) | Yes (cloud) |
+| Nested teams | Yes (if teams enabled) | N/A (subprocess) | N/A |
+| Best for | Monitoring, polling, light automation | Structured multi-story dev | CI/CD, scheduled builds |
+
+<!-- markdownlint-enable MD013 -->
+
+See [CC-ralph-enhancement-research.md](../agents-skills/CC-ralph-enhancement-research.md)
+for Ralph loop details and
+[CC-github-actions-analysis.md](../ci-execution/CC-github-actions-analysis.md)
+for GitHub Actions integration.
+
+## Practical Patterns
+
+**Deploy monitoring:**
+
+```text
+/loop 5m check if the deployment on staging finished. If it did, run the smoke tests and report results.
+```
+
+**PR babysitting:**
+
+```text
+/loop 10m check PR #42 CI status. If all checks pass, post "Ready for review" comment.
+```
+
+**Iterative code review:**
+
+```text
+/loop 20m /code-review src/app/
+```
+
+## When to Use `/loop` vs External Schedulers
+
+**Use `/loop` when:**
+
+- Task is monitoring/polling (deployment status, CI checks, PR reviews)
+- Single session is acceptable (no disconnection survival needed)
+- Context accumulation is desired (each iteration builds on previous)
+- Quick setup matters more than durability
+
+**Use external schedulers (cron, GitHub Actions, Ralph) when:**
+
+- Task must survive disconnection or machine sleep
+- Fresh context per iteration is preferred (prevents context rot)
+- Structured workflows with dependencies are needed
+- Audit trail or artifact persistence is required
+
+## Sources
+
+<!-- markdownlint-disable MD013 -->
+
+| Source | Content |
+|---|---|
+| gist by @sorrycc (v2.1.71 cli.js decompilation) | `/loop` internals, CronCreate/List/Delete tools, feature gate |
+| [Official agent teams docs](https://code.claude.com/docs/en/agent-teams) | Permission inheritance for recurring tasks |
+
+<!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
## Summary

- **agents-skills/CC-recursive-spawning-patterns.md**: CLAUDECODE=1 guard, recursive claude -p patterns, token cost, spawning methods comparison
- **ci-execution/CC-permissions-bypass-analysis.md**: --dangerously-skip-permissions, 5 permission modes, team inheritance, safer allowlist alternatives
- **configuration/CC-loop-cron-analysis.md**: /loop command, CronCreate/List/Delete internals, session-bound limitation, comparison vs Ralph and GH Actions
- **README.md**: Updated contents table with new analyses

Generated with Claude <noreply@anthropic.com>