### PR TITLE
chore: increase cron to 4h, document webhook format incompatibility

### DIFF
--- a/.github/workflows/cc-status-monitor.yaml
+++ b/.github/workflows/cc-status-monitor.yaml
@@ -2,10 +2,17 @@ name: Status Monitor
 
 on:
   schedule:
-    - cron: '0 8 * * *'  # Daily 08:00 UTC (backup collector)
+    - cron: '0 */4 * * *'  # Every 4 hours — replaces webhook for near-real-time collection.
+    # Reason: Statuspage webhooks use a proprietary payload format incompatible
+    # with GitHub repository_dispatch (which requires {"event_type": "...",
+    # "client_payload": {...}} + auth header). A proxy (e.g. Cloudflare Worker)
+    # would be needed to transform the payload. Frequent cron polling achieves
+    # the same result with zero additional infrastructure.
+    # See: https://support.atlassian.com/statuspage/docs/enable-webhook-notifications/
+    # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch
   workflow_dispatch:
   repository_dispatch:
-    types: [status-change]  # Statuspage webhook
+    types: [status-change]  # Retained for future webhook proxy integration
 
 permissions:
   contents: write

--- a/docs/cc-native/ci-execution/CC-status-monitoring-analysis.md
+++ b/docs/cc-native/ci-execution/CC-status-monitoring-analysis.md
@@ -85,7 +85,7 @@ To connect Statuspage webhooks to GitHub Actions:
 
 3. **PAT requirements** — Fine-grained token with `contents: write` on the target repo, stored as a secret in the proxy service
 
-**Recommendation**: Start with daily cron only. The JSON API returns full incident history, so nothing is missed. Add webhook proxy later if sub-day latency matters.
+**Decision**: Use 4-hour cron polling instead of webhook. The JSON API returns full incident history, so nothing is missed. A webhook proxy adds infrastructure complexity for marginal latency gain. See [Statuspage webhook docs](https://support.atlassian.com/statuspage/docs/enable-webhook-notifications/) and [GitHub repository_dispatch docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch) for the format incompatibility.
 
 ## API Error Correlation
 
@@ -125,8 +125,8 @@ Generated from the archive as `data/outage-stats.md`, covering:
 ### Workflow
 
 `cc-status-monitor.yaml` runs on:
-- **Daily cron** (08:00 UTC) — baseline collection, catches everything
-- **`repository_dispatch`** (`status-change` event) — webhook-driven, near-real-time
+- **4-hour cron** — primary collection mechanism, catches everything
+- **`repository_dispatch`** (`status-change` event) — retained for future webhook proxy
 - **`workflow_dispatch`** — manual trigger for testing
 
 Changes are committed directly to `main` (append-only factual data, not content requiring triage).


### PR DESCRIPTION
## Summary

- Increase status monitor cron from daily to every 4 hours for near-real-time collection
- Document why Statuspage webhooks can't connect directly to GitHub `repository_dispatch` (payload format mismatch, auth header requirement)
- Add source URLs for the incompatibility claim
- Retain `repository_dispatch` trigger for future webhook proxy integration

## Test plan

- [ ] Verify workflow YAML syntax valid
- [ ] Verify research doc links resolve

Generated with Claude <noreply@anthropic.com>