### PR TITLE
chore: upgrade actions/checkout v4→v6 and actions/setup-python v5→v6

### DIFF
--- a/.github/workflows/cc-changelog-community-monitor.yaml
+++ b/.github/workflows/cc-changelog-community-monitor.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/cc-changelog-monitor.yaml
+++ b/.github/workflows/cc-changelog-monitor.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/cc-status-monitor.yaml
+++ b/.github/workflows/cc-status-monitor.yaml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` v4 → v6 and `actions/setup-python` v5 → v6 across all 3 workflows
- Resolves Node.js 20 deprecation warning (Node.js 24 forced from June 2, 2026)

## Files changed

- `.github/workflows/cc-status-monitor.yaml`
- `.github/workflows/cc-changelog-monitor.yaml`
- `.github/workflows/cc-changelog-community-monitor.yaml`

## Test plan

- [ ] Trigger `workflow_dispatch` on `cc-status-monitor.yaml` — verify no Node.js 20 warning

Generated with Claude <noreply@anthropic.com>