### PR TITLE
docs: add .github README, issue templates, and update PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a problem with monitors, workflows, or documentation
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+
+1. Run `...`
+2. ...
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened. Include error traces if applicable -->
+
+## Environment
+
+- Workflow run URL (if applicable):
+- Browser (if rendering issue):
+
+## Additional Context
+
+<!-- Screenshots, logs, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/qte77/coding-agents-research/blob/main/README.md
+    about: Check the documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,16 @@
+---
+name: Question
+about: Ask a question not covered by the documentation
+title: ''
+labels: question
+assignees: ''
+---
+
+**Have you checked the docs?**
+
+- [ ] [README.md](https://github.com/qte77/coding-agents-research/blob/main/README.md)
+- [ ] [.github/README.md](https://github.com/qte77/coding-agents-research/blob/main/.github/README.md)
+
+## Question
+
+<!-- Your question here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,15 @@ Closes <!-- #issue-number or N/A -->
 - [ ] Markdown renders correctly on GitHub
 - [ ] All reference links resolve
 - [ ] No broken internal cross-references
+- [ ] CI workflows pass (if `.github/` files modified)
 
 ## Documentation
 
 - [ ] README updated if new analysis added or structure changed
+- [ ] `.github/README.md` updated if workflows or scripts changed
+
+## Security
+
+- [ ] No hardcoded secrets, API keys, or credentials
+- [ ] No new injection vectors in workflow `run:` steps
+- [ ] Sensitive data not logged or exposed in workflow outputs

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,31 @@
+# .github/ — CI Automation
+
+Automated monitors track Claude Code changes, community content, and platform status, then open triage PRs for human review.
+
+```text
+Sources (Statuspage API, CC CHANGELOG, blogs, Reddit, X)
+  → Cron workflows → Python scripts → Triage PRs
+```
+
+## Monitors
+
+| Workflow | Schedule | Sources | Output |
+|---|---|---|---|
+| [`cc-status-monitor`](workflows/cc-status-monitor.yaml) | Every 4h | Statuspage API | `triage/status-monitor/outages.jsonl` + `outage-stats.md` |
+| [`cc-changelog-monitor`](workflows/cc-changelog-monitor.yaml) | Mon 09:00 UTC | CC CHANGELOG, Anthropic blog, GitHub issues | `triage/cc-changelog/` timestamped reports |
+| [`cc-changelog-community-monitor`](workflows/cc-changelog-community-monitor.yaml) | Mon 10:00 UTC | claudelog.com, awesome-claude-code, Reddit, X | `triage/community/` timestamped reports |
+
+**Manual trigger:** `gh workflow run <workflow>.yaml [--ref <branch>]`
+
+## Key conventions
+
+- **Scripts** (`scripts/`): stdlib-only Python. Exit `0` = no changes, `1` = new content → PR created.
+- **State** (`state/`): JSON cursor files ("last seen"). Committed with triage PRs to persist across runs.
+- **Composite action** (`actions/create-triage-pr/`): Used by changelog + community monitors. Status monitor creates PRs inline (no timestamped report copies).
+
+## Adding a new monitor
+
+1. Add script in `scripts/` following exit code convention
+2. Add workflow in `workflows/` with cron schedule
+3. Use `create-triage-pr` action or inline PR creation for output
+4. Add state file to `state/` if the script needs cursor tracking

--- a/.github/workflows/cc-changelog-community-monitor.yaml
+++ b/.github/workflows/cc-changelog-community-monitor.yaml
@@ -1,3 +1,6 @@
+# Polls community sources (claudelog.com, awesome-claude-code, Reddit, X) for
+# Claude Code tips and features not yet covered by community docs.
+# Opens a triage PR when new uncovered content is found.
 name: Community Monitor
 
 on:

--- a/.github/workflows/cc-changelog-monitor.yaml
+++ b/.github/workflows/cc-changelog-monitor.yaml
@@ -1,3 +1,6 @@
+# Diffs CC CHANGELOG.md against last scanned version and polls Anthropic blog +
+# GitHub issues/discussions for new Claude Code content not yet covered by docs.
+# Opens a triage PR when uncovered features are found.
 name: Changelog Monitor
 
 on:

--- a/.github/workflows/cc-status-monitor.yaml
+++ b/.github/workflows/cc-status-monitor.yaml
@@ -1,3 +1,6 @@
+# Polls Anthropic Statuspage API for Claude platform incidents and upserts
+# into outages.jsonl archive. Opens a PR when new/updated incidents are found.
+# Output: triage/status-monitor/outages.jsonl + outage-stats.md
 name: Status Monitor
 
 on:


### PR DESCRIPTION
## Summary

- Add `.github/README.md` describing the monitor pipeline: workflows → scripts → state → triage PRs
- Add `ISSUE_TEMPLATE/` (bug report, question, config) matching Agents-eval structure
- Update `PULL_REQUEST_TEMPLATE.md` with CI validation and security checklist items

## Test plan

- [ ] Markdown renders correctly on GitHub
- [ ] Issue template chooser works (`/issues/new/choose`)
- [ ] PR template populates on new PR creation

Generated with Claude <noreply@anthropic.com>