### PR TITLE
docs: add SDLC and LCM research specs

### DIFF
--- a/docs/sdlc-lcm/README.md
+++ b/docs/sdlc-lcm/README.md
@@ -1,0 +1,37 @@
+---
+title: SDLC & LCM Research
+purpose: Research overview for Software Development Lifecycle (SDLC) and Lifecycle Management (LCM) applied to AI coding agent ecosystems.
+created: 2026-03-24
+---
+
+# SDLC & LCM Research
+
+Lifecycle management specs for the qte77 coding agent ecosystem.
+
+## Two Tracks
+
+| Track | Scope | Applies To | Key Question |
+|-------|-------|------------|--------------|
+| **SDLC** | Dev process phases (plan, build, test, release, deploy, maintain) | All repos via Ralph + Polyforge | "What dev phase is this repo/feature in?" |
+| **LCM** | Product lifecycle phases (incubation, active, maintenance, deprecated, retired) | Products/projects via CABIO | "What lifecycle stage is this product in?" |
+
+## Documents
+
+| Document | Content |
+|----------|---------|
+| [sdlc-spec.md](sdlc-spec.md) | SDLC phase definitions with entry/exit gates, mapped to NIST AI RMF + ISO 42001 |
+| [lcm-spec.md](lcm-spec.md) | Product lifecycle phase definitions with SLA expectations and allowed changes |
+| [lcm-release-runbook.md](lcm-release-runbook.md) | Release management checklist bridging SDLC release phase to LCM transitions |
+| [oss-alm-landscape.md](oss-alm-landscape.md) | OSS ALM tool comparison (Tuleap, OpenProject, Redmine, GitLab) |
+| [agentic-sdlc-patterns.md](agentic-sdlc-patterns.md) | Emerging patterns: ADLC, Agentic SDLC, Spec-Driven Development |
+
+## Framework Grounding
+
+Specs build on [Agents-eval: ai-security-governance-frameworks.md](https://github.com/qte77/Agents-eval/blob/main/docs/analysis/ai-security-governance-frameworks.md)
+(NIST AI RMF, ISO 42001 A.6, ISO 23894, OWASP MAESTRO). See sdlc-spec.md cross-framework summary table.
+
+## Target Repo
+
+Implementation code (state machines, gates, config) will live in
+[qte77/sdlc-lcm-manager](https://github.com/qte77/sdlc-lcm-manager) (future),
+consumed as a git submodule by downstream repos.

--- a/docs/sdlc-lcm/agentic-sdlc-patterns.md
+++ b/docs/sdlc-lcm/agentic-sdlc-patterns.md
@@ -1,0 +1,88 @@
+---
+title: Agentic SDLC Patterns
+purpose: Emerging lifecycle patterns for AI agent-driven development.
+created: 2026-03-24
+sources:
+  - https://www.epam.com/insights/ai/blogs/agentic-development-lifecycle-explained
+  - https://techcommunity.microsoft.com/blog/appsonazureblog/an-ai-led-sdlc-building-an-end-to-end-agentic-software-development-lifecycle-wit/4491896
+  - https://www.amplifypartners.com/blog-posts/the-agent-first-developer-toolchain-how-ai-will-radically-transform-the-sdlc
+  - https://www.pwc.com/m1/en/publications/2026/docs/future-of-solutions-dev-and-delivery-in-the-rise-of-gen-ai.pdf
+  - https://about.gitlab.com/blog/agentic-sdlc-gitlab-and-tcs-deliver-intelligent-orchestration-across-the-enterprise/
+  - https://www.cio.com/article/4134741/how-agentic-ai-will-reshape-engineering-workflows-in-2026.html
+---
+
+# Agentic SDLC Patterns
+
+Lifecycle patterns designed for AI agent-driven development, not traditional
+human-driven SDLC.
+
+## 1. ADLC (Agentic Development Lifecycle)
+
+**Source:** EPAM
+
+A lifecycle for systems where LLMs are core product behavior, not just assistants.
+
+| Dimension | Traditional SDLC | ADLC |
+|-----------|-----------------|------|
+| Behavior | Fully specified at build time | Emergent, non-deterministic |
+| Testing | Pass/fail against spec | Observation and correction loops |
+| Failure mode | Bug (deviation from spec) | Drift (behavior changes without code change) |
+| Lifecycle focus | Build -> Ship | Build -> Observe -> Correct -> Repeat |
+
+**Phases:** Define -> Build -> Evaluate -> Deploy -> Observe -> Correct
+
+**qte77 mapping:** Ralph = Build+Evaluate, CABIO = Define+Evaluate.
+Gap: no formal Observe+Correct phases (post-deployment feedback loop).
+
+## 2. Agentic SDLC (Microsoft/GitLab/PwC)
+
+Specialized agents per SDLC phase, orchestrated in parallel.
+
+```
+Orchestrator
+  +-- Requirements Agent    (Ralph: CABIO BRD->PRD->FRD)
+  +-- Coding Agent          (Ralph: TDD loop)
+  +-- Review Agent          (gap: no formal review agent)
+  +-- Deploy Agent          (gap: manual CI/CD)
+  +-- Monitor Agent         (gap: no monitoring agent)
+```
+
+**Measured impact (early 2026):** ~55% faster task completion, 38.7% of AI
+review comments lead to code fixes (Atlassian RovoDev).
+
+## 3. Spec-Driven Development (SDD)
+
+"Version control for your thinking" — specs are the primary artifact.
+
+- Specs version-controlled alongside code
+- Agents consume specs, produce code
+- Spec changes trigger agent re-execution (like code changes trigger CI)
+- Human review shifts from code to specs
+
+**qte77 mapping:** CABIO pipeline + Ralph prd.json already spec-driven.
+Gap: no automated spec-change -> agent-trigger pipeline.
+
+## 4. Agent-First Developer Toolchain (Amplify Partners)
+
+Traditional SDLC artifacts reimagined as coordination layers for agents.
+
+| Traditional | Agent-First | qte77 Status |
+|------------|-------------|-------------|
+| IDE | Agent workspace | Claude Code |
+| VCS branches | Agent task boundaries | Polyforge, Ralph worktrees |
+| CI/CD | Continuous validation | Gap: manual `make validate` |
+| Code review | Agent review + human oversight | Gap: no review agent |
+
+## Synthesis
+
+| Pattern | Have | Gap |
+|---------|------|-----|
+| ADLC Observe+Correct | -- | Post-deployment feedback loop |
+| Parallel agents | Ralph (build), CABIO (req) | Review, Monitor agents |
+| SDD spec-as-trigger | CABIO, prd.json | Automated trigger pipeline |
+| Agent-first toolchain | CC, worktrees, Polyforge | Agent-triggered CI/CD |
+
+**sdlc-lcm-manager priorities:**
+1. Codify Observe+Correct as formal phases (extend maintain)
+2. Gate predicates agents can evaluate programmatically
+3. Phase inference from repo artifacts (SDD alignment)

--- a/docs/sdlc-lcm/lcm-release-runbook.md
+++ b/docs/sdlc-lcm/lcm-release-runbook.md
@@ -1,0 +1,99 @@
+---
+title: Release Management Runbook
+purpose: Checklist bridging SDLC release phase to LCM phase transitions.
+created: 2026-03-24
+---
+
+# Release Management Runbook
+
+Checklist for executing the SDLC **Release** phase and triggering LCM phase
+transitions when applicable.
+
+## Standard Release Checklist
+
+### Pre-Release (SDLC: Test -> Release gate)
+
+- [ ] All tests pass: `make validate`
+- [ ] CHANGELOG.md updated with `## [Unreleased]` entries
+- [ ] No critical or high security findings open
+- [ ] Documentation reflects current state
+- [ ] Dependencies audited (no known CVEs in pinned versions)
+
+### Release Execution
+
+- [ ] Determine version bump (semver): patch / minor / major
+- [ ] Update version in `pyproject.toml`
+- [ ] Move CHANGELOG entries from `[Unreleased]` to `[x.y.z] - YYYY-MM-DD`
+- [ ] Create git tag: `git tag -a vx.y.z -m "Release vx.y.z"`
+- [ ] Push tag: `git push origin vx.y.z`
+- [ ] Create GitHub release from tag (with release notes from CHANGELOG)
+
+### Post-Release
+
+- [ ] Verify tag and release visible on GitHub
+- [ ] Update downstream consumers if needed (submodule refs, dependency pins)
+- [ ] Add `## [Unreleased]` section to CHANGELOG.md for next cycle
+
+## LCM Phase Transition Releases
+
+These releases mark lifecycle phase changes, not just version increments.
+
+### Incubation -> Alpha
+
+- [ ] Standard release checklist above
+- [ ] Version format: `x.y.z-alpha.1`
+- [ ] README updated with alpha status notice
+- [ ] Core functionality documented
+
+### Alpha -> Beta
+
+- [ ] Standard release checklist above
+- [ ] Version format: `x.y.z-beta.1`
+- [ ] Integration tests exist and pass
+- [ ] API surface documented
+- [ ] Known limitations documented
+
+### Beta -> Active (GA)
+
+- [ ] Standard release checklist above
+- [ ] Version format: `x.y.z` (no pre-release suffix)
+- [ ] Security review completed
+- [ ] Performance acceptable under expected load
+- [ ] README reflects production status
+- [ ] Support expectations documented
+
+### Active -> Maintenance
+
+- [ ] Announcement: development wind-down notice
+- [ ] README updated with maintenance-only status
+- [ ] CI/CD simplified (remove feature-related workflows if any)
+- [ ] Document allowed change types (security, critical bugs only)
+
+### Maintenance -> Deprecated
+
+- [ ] Deprecation notice with sunset date published
+- [ ] README banner: `[DEPRECATED] — use [successor] instead`
+- [ ] `deprecated` classifier added to `pyproject.toml` if applicable
+- [ ] Migration guide published (if successor exists)
+- [ ] Downstream consumers notified
+
+### Deprecated -> Retired
+
+- [ ] Sunset date reached
+- [ ] Verify no active dependents (check submodule refs, import references)
+- [ ] Archive repo on GitHub
+- [ ] Update references in ecosystem docs (coding-agents-research, profile README)
+- [ ] Retain docs and release artifacts for reference
+
+## Automation Candidates
+
+For future implementation in `qte77/sdlc-lcm-manager`:
+
+| Step | Automation | Priority |
+|------|-----------|----------|
+| Version bump | `bumpversion` or `uv version` | High |
+| CHANGELOG formatting | `git-cliff` or custom script | Medium |
+| Tag + release creation | `gh release create` in gate predicate | High |
+| Phase inference | Read `pyproject.toml` version + repo signals | High |
+| Downstream notification | GitHub Actions workflow dispatch | Low |
+| Deprecation banner | PR auto-generated from phase transition | Low |

--- a/docs/sdlc-lcm/lcm-spec.md
+++ b/docs/sdlc-lcm/lcm-spec.md
@@ -1,0 +1,133 @@
+---
+title: Product Lifecycle Management (LCM) Specification
+purpose: Product/project lifecycle phases for CABIO-managed products in the qte77 ecosystem.
+created: 2026-03-24
+authority: This document is the specification. Implementation lives in qte77/sdlc-lcm-manager.
+---
+
+# Product Lifecycle Management (LCM) Specification
+
+Lifecycle phases for products and projects managed through CABIO. Applies at the
+product/project level (cross-repo), not per-feature.
+
+## Phase Definitions
+
+### 1. Incubation
+
+| Attribute | Value |
+|-----------|-------|
+| **Version convention** | `0.x.y` (pre-release) |
+| **Support level** | Best-effort, no SLA |
+| **Allowed changes** | Any (breaking changes expected) |
+| **Entry criteria** | BRD approved, initial repo created |
+| **Exit criteria** | Core functionality works, first users onboarded |
+| **ISO 42001** | A.6.1 (specification), A.6.2 (data assessment) |
+
+### 2. Alpha
+
+| Attribute | Value |
+|-----------|-------|
+| **Version convention** | `x.y.z-alpha.N` |
+| **Support level** | Internal feedback only |
+| **Allowed changes** | Breaking changes with notice, rapid iteration |
+| **Entry criteria** | Core features functional, basic tests exist |
+| **Exit criteria** | Feature-complete for MVP scope, integration tests pass |
+| **ISO 42001** | A.6.3 (design), A.6.4 (build) |
+
+### 3. Beta
+
+| Attribute | Value |
+|-----------|-------|
+| **Version convention** | `x.y.z-beta.N` |
+| **Support level** | Bug reports accepted, fixes on best-effort |
+| **Allowed changes** | Non-breaking preferred, breaking with migration guide |
+| **Entry criteria** | Feature-complete, integration tests pass, docs exist |
+| **Exit criteria** | No critical bugs, performance acceptable, security review done |
+| **ISO 42001** | A.6.5 (verification and validation) |
+
+### 4. Active
+
+| Attribute | Value |
+|-----------|-------|
+| **Version convention** | `x.y.z` (semver, no pre-release suffix) |
+| **Support level** | Full support, defined response times |
+| **Allowed changes** | Semver-compliant (patch: fixes, minor: features, major: breaking) |
+| **Entry criteria** | Beta exit criteria met, release runbook executed |
+| **Exit criteria** | Superseded by successor OR usage drops below threshold |
+| **ISO 42001** | A.6.6 (deployment), A.6.7 (operation and monitoring) |
+
+### 5. Maintenance
+
+| Attribute | Value |
+|-----------|-------|
+| **Version convention** | `x.y.z` (patch increments only) |
+| **Support level** | Security patches and critical bugs only |
+| **Allowed changes** | Security fixes, critical bug fixes, dependency updates |
+| **Entry criteria** | Decision to wind down active development |
+| **Exit criteria** | Deprecation notice published, migration path documented |
+| **ISO 42001** | A.6.7 (monitoring), A.7.3 (transparency) |
+
+### 6. Deprecated
+
+| Attribute | Value |
+|-----------|-------|
+| **Version convention** | No new versions |
+| **Support level** | No support, security advisories only |
+| **Allowed changes** | None (read-only) |
+| **Entry criteria** | Deprecation notice published with sunset date |
+| **Exit criteria** | Sunset date reached, no active dependents |
+| **ISO 42001** | A.7.3 (transparency) |
+
+### 7. Retired
+
+| Attribute | Value |
+|-----------|-------|
+| **Version convention** | Archived |
+| **Support level** | None |
+| **Allowed changes** | None (archived) |
+| **Entry criteria** | Sunset date passed, dependents migrated |
+| **Exit criteria** | N/A (terminal state) |
+| **ISO 42001** | A.6.7 (decommissioning) |
+| **Actions** | Archive repo, update downstream references, retain docs |
+
+## Phase Transition Rules
+
+```
+incubation --> alpha --> beta --> active --> maintenance --> deprecated --> retired
+                                   ^            |
+                                   +-- (reactivate, rare, re-enter via beta gate)
+```
+
+- **Forward only** in normal flow
+- **Skip allowed**: incubation -> beta (small utilities with clear scope)
+- **No skipping** active -> retired (must go through deprecation notice period)
+
+## State Inference
+
+| Signal | Inferred Phase |
+|--------|---------------|
+| `version: 0.x.y` in pyproject.toml | Incubation |
+| Version contains `-alpha` | Alpha |
+| Version contains `-beta` | Beta |
+| Stable semver, active commits in last 30 days | Active |
+| Stable semver, only dependency/security commits | Maintenance |
+| `[DEPRECATED]` in README or `deprecated` classifier | Deprecated |
+| Repo archived on GitHub | Retired |
+
+Optional explicit override in `pyproject.toml`:
+
+```toml
+[tool.lcm]
+phase = "active"
+```
+
+## Risk Register (ISO 23894)
+
+| Risk | Phase | Likelihood | Impact | Treatment |
+|------|-------|------------|--------|-----------|
+| Inadequate specification | Incubation | HIGH | HIGH | PRD review gates in CABIO |
+| Undetected defects | Beta | MEDIUM | HIGH | Security review + `make validate` |
+| Dependency vulnerabilities | Active, Maintenance | HIGH | MEDIUM | Dependabot + `exclude-newer` awareness |
+| Knowledge loss | Maintenance | MEDIUM | HIGH | AGENT_LEARNINGS.md, architecture docs |
+| Continued use after deprecation | Deprecated | LOW | MEDIUM | Deprecation notices, migration guides |
+| Orphaned dependencies | Retired | LOW | LOW | Audit downstream refs before archiving |

--- a/docs/sdlc-lcm/oss-alm-landscape.md
+++ b/docs/sdlc-lcm/oss-alm-landscape.md
@@ -1,0 +1,48 @@
+---
+title: OSS ALM Landscape
+purpose: Comparison of open-source Application Lifecycle Management tools for potential Phase 3 adoption.
+created: 2026-03-24
+sources:
+  - https://www.tuleap.com/alm/
+  - https://www.tuleap.com/comparisons/
+  - https://sg1883472.medium.com/top-7-open-source-alm-application-lifecycle-management-tools-bc88e277ffb1
+  - https://www.devopsschool.com/blog/top-10-application-lifecycle-management-alm-tools-in-2025-features-pros-cons-comparison/
+  - https://thectoclub.com/tools/best-alm-software/
+---
+
+# OSS ALM Landscape
+
+OSS ALM platforms evaluated as Phase 3 candidates. Phase 1-2 use lightweight
+Python + docs; Phase 3 may need a UI dashboard or multi-user access.
+
+## Comparison Matrix
+
+| Tool | License | Weight | ALM Coverage | CI/CD | Test Mgmt | API |
+|------|---------|--------|-------------|-------|-----------|-----|
+| **Tuleap CE** | GPL | Heavy (PHP) | Full | Jenkins | Built-in | Yes |
+| **OpenProject** | GPL | Heavy (Rails) | Partial (PM) | Limited | Plugins | Yes |
+| **Redmine** | Open | Light (Ruby) | Minimal | Plugins | Plugins | Yes |
+| **GitLab CE** | MIT | Heavy (Rails) | Partial (DevOps) | Built-in | Limited | Yes |
+| **Zentao** | Open | Medium (PHP) | Good | Limited | Built-in | Yes |
+
+## Fit Assessment
+
+| Tool | Fit | Reason |
+|------|-----|--------|
+| **Tuleap CE** | Phase 3 candidate | Full ALM, traceability, compliance. Overkill now. |
+| **GitLab CE** | Poor | Already on GitHub. Would require migration. |
+| **Redmine** | Poor | Aging, plugin-dependent for ALM features. |
+| **OpenProject** | Poor | PM-focused, weak on requirements/test traceability. |
+| **Zentao** | Marginal | Good coverage but less mature community. |
+
+## Decision
+
+**None fit the current need.** All are designed for human-driven UI workflows,
+not agent-driven pipelines where state is inferred from repo artifacts.
+
+**Phase 3 trigger conditions:**
+- Multiple human users need lifecycle visibility
+- Audit/compliance requirements demand formal traceability
+- CABIO cockpit needs a persistent UI beyond CLI/TUI
+
+**If triggered:** Tuleap CE via REST API integration with sdlc-lcm-manager.

--- a/docs/sdlc-lcm/sdlc-spec.md
+++ b/docs/sdlc-lcm/sdlc-spec.md
@@ -1,0 +1,116 @@
+---
+title: SDLC Phase Specification
+purpose: Standardized dev process phases for all repos in the qte77 ecosystem, mapped to governance frameworks.
+created: 2026-03-24
+authority: This document is the specification. Implementation lives in qte77/sdlc-lcm-manager.
+---
+
+# SDLC Phase Specification
+
+Dev lifecycle phases for all repos using Ralph, Polyforge, or manual workflows.
+
+## Phase Definitions
+
+### 1. Plan
+
+| Attribute | Value |
+|-----------|-------|
+| **Entry criteria** | Business requirement or user story exists |
+| **Required artifacts** | PRD.md or UserStory.md with acceptance criteria |
+| **Responsible tool** | CABIO (BRD -> PRD -> FRD) |
+| **Exit gate** | PRD approved, FRD generated, prd.json initialized |
+
+### 2. Design
+
+| Attribute | Value |
+|-----------|-------|
+| **Entry criteria** | FRD/PRD approved with clear scope |
+| **Required artifacts** | Architecture decision records, data model specs |
+| **Responsible tool** | Architect agent (via Ralph or manual) |
+| **Exit gate** | Technical spec reviewed, dependencies identified |
+
+### 3. Build
+
+| Attribute | Value |
+|-----------|-------|
+| **Entry criteria** | Design spec exists, dependencies available |
+| **Required artifacts** | Source code, inline documentation |
+| **Responsible tool** | Ralph TDD loop |
+| **Exit gate** | Code compiles/imports, basic smoke test passes |
+
+### 4. Test
+
+| Attribute | Value |
+|-----------|-------|
+| **Entry criteria** | Build phase complete, code importable |
+| **Required artifacts** | Unit tests, integration tests, security tests |
+| **Responsible tool** | `make validate` (lint + type check + test) |
+| **Exit gate** | All tests pass, coverage meets threshold, no critical findings |
+
+### 5. Release
+
+| Attribute | Value |
+|-----------|-------|
+| **Entry criteria** | Test phase passed, CHANGELOG.md updated |
+| **Required artifacts** | Version bump, git tag, release notes |
+| **Responsible tool** | Release runbook (see [lcm-release-runbook.md](lcm-release-runbook.md)) |
+| **Exit gate** | Tag pushed, release created, artifacts published |
+
+### 6. Deploy
+
+| Attribute | Value |
+|-----------|-------|
+| **Entry criteria** | Release tag exists, deployment target configured |
+| **Required artifacts** | Deployment manifest, environment config |
+| **Responsible tool** | CI/CD pipeline or manual deployment |
+| **Exit gate** | Service healthy, smoke tests pass in target environment |
+
+### 7. Maintain
+
+| Attribute | Value |
+|-----------|-------|
+| **Entry criteria** | Deployed and operational |
+| **Required artifacts** | Monitoring dashboards, incident response plan |
+| **Responsible tool** | Ops tooling, Polyforge cross-repo visibility |
+| **Exit gate** | Transitions to LCM `deprecated` or `retired` phase |
+| **Allowed changes** | Bug fixes, security patches, dependency updates only |
+
+## Phase Transition Rules
+
+```
+plan --> design --> build --> test --> release --> deploy --> maintain
+                      ^        ^                              |
+                      |        |                              v
+                      +--------+ (TDD iteration)     LCM phase transition
+```
+
+- **Forward only** in normal flow
+- **Rework loops**: build <-> test (TDD), design -> build (spec change)
+- **No skipping**: every phase must be entered
+- **Maintain -> LCM**: transition to product lifecycle (see [lcm-spec.md](lcm-spec.md))
+
+## State Inference
+
+Phase is inferred from repo artifacts, not stored explicitly:
+
+| Signal | Inferred Phase |
+|--------|---------------|
+| Open PRD/FRD, no implementation branch | Plan |
+| Architecture docs updated, no code changes | Design |
+| Feature branch active, tests not passing | Build |
+| Feature branch active, tests passing, no release | Test |
+| Version bumped, tag created, not deployed | Release |
+| Deployed to target environment | Deploy |
+| Stable, no active development | Maintain |
+
+## Cross-Framework Mapping
+
+| Phase | NIST RMF | ISO 42001 A.6 | MAESTRO Layers |
+|-------|----------|---------------|----------------|
+| Plan | MAP | A.6.1 | L7 |
+| Design | MAP | A.6.2, A.6.3 | L2, L3 |
+| Build | MANAGE | A.6.4 | L1, L5 |
+| Test | MEASURE | A.6.5 | L1-L7 |
+| Release | MANAGE | A.6.6 | L6 |
+| Deploy | MANAGE | A.6.6 | L4, L6 |
+| Maintain | GOVERN+MEASURE | A.6.7 | L4 |


### PR DESCRIPTION
## Summary

- SDLC phase spec (plan through maintain) with entry/exit gates, mapped to NIST AI RMF + ISO 42001 + MAESTRO
- Product lifecycle (LCM) spec (incubation through retired) with ISO 23894 risk register
- Release runbook bridging SDLC release phase to LCM transitions
- OSS ALM landscape comparison (Tuleap, OpenProject, Redmine, GitLab, Zentao)
- Agentic SDLC patterns survey (ADLC, SDD, agent-first toolchain)

All docs in `docs/sdlc-lcm/`. Foundation for future `qte77/sdlc-lcm-manager` repo.

## Test plan

- [ ] Review specs for completeness: every phase has entry/exit criteria
- [ ] Verify no broken relative links between docs
- [ ] Confirm no Agents-eval files were modified

Generated with Claude <noreply@anthropic.com>