### PR TITLE
chore: change outage monitor to weekly schedule

### DIFF
--- a/.github/scripts/status-collector.py
+++ b/.github/scripts/status-collector.py
@@ -6,7 +6,7 @@ and upserts them into a local JSONL archive. Can also process webhook payloads
 from repository_dispatch events.
 
 Usage:
-    # Fetch from API (daily cron)
+    # Fetch from API (weekly cron)
     python status-collector.py --archive triage/status-monitor/outages.jsonl
 
     # Process webhook payload (repository_dispatch)

--- a/.github/workflows/cc-status-monitor.yaml
+++ b/.github/workflows/cc-status-monitor.yaml
@@ -5,14 +5,7 @@ name: Status Monitor
 
 on:
   schedule:
-    - cron: '0 */4 * * *'  # Every 4 hours — replaces webhook for near-real-time collection.
-    # Reason: Statuspage webhooks use a proprietary payload format incompatible
-    # with GitHub repository_dispatch (which requires {"event_type": "...",
-    # "client_payload": {...}} + auth header). A proxy (e.g. Cloudflare Worker)
-    # would be needed to transform the payload. Frequent cron polling achieves
-    # the same result with zero additional infrastructure.
-    # See: https://support.atlassian.com/statuspage/docs/enable-webhook-notifications/
-    # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch
+    - cron: '0 9 * * 1'  # Weekly Monday 09:00 UTC
   workflow_dispatch:
   repository_dispatch:
     types: [status-change]  # Retained for future webhook proxy integration


### PR DESCRIPTION
Change from 4-hourly to weekly (Monday 09:00 UTC). Reduces PR noise.