### PR TITLE
chore: standardize repo scaffold

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "attribution": {
+    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
+    "pr": "Generated with Claude <noreply@anthropic.com>"
+  },
+  "enabledPlugins": {
+    "commit-helper@qte77-claude-code-utils": true
+  },
+  "extraKnownMarketplaces": {
+    "qte77-claude-code-utils": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/claude-code-utils-plugin"
+      }
+    }
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a problem with monitors, workflows, or documentation
+about: Report a problem
 title: ''
 labels: bug
 assignees: ''
@@ -25,8 +25,8 @@ assignees: ''
 
 ## Environment
 
-- Workflow run URL (if applicable):
-- Browser (if rendering issue):
+- OS/Runner:
+- Version:
 
 ## Additional Context
 

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Documentation
-    url: https://github.com/qte77/ai-agents-research/blob/main/README.md
-    about: Check the documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,8 +8,7 @@ assignees: ''
 
 **Have you checked the docs?**
 
-- [ ] [README.md](https://github.com/qte77/ai-agents-research/blob/main/README.md)
-- [ ] [.github/README.md](https://github.com/qte77/ai-agents-research/blob/main/.github/README.md)
+- [ ] README.md
 
 ## Question
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,27 +19,19 @@ Closes <!-- #issue-number or N/A -->
 - [ ] `style` — formatting, whitespace (no logic change)
 - [ ] `revert` — reverts a previous commit
 - [ ] `chore` — tooling, config, maintenance
-- [ ] **Breaking change** — add `!` after commit type, e.g. `feat!:` or `feat(scope)!:`
+- [ ] **Breaking change** — add `!` after commit type
 
 ## Self-Review
 
 - [ ] I have reviewed my own diff and removed debug/dead code
-- [ ] Commit messages follow conventional commits format: `type[(scope)][!]: description`
+- [ ] Commit messages follow conventional commits format
 
 ## Testing
 
-- [ ] Markdown renders correctly on GitHub
-- [ ] All reference links resolve
-- [ ] No broken internal cross-references
-- [ ] CI workflows pass (if `.github/` files modified)
-
-## Documentation
-
-- [ ] README updated if new analysis added or structure changed
-- [ ] `.github/README.md` updated if workflows or scripts changed
+- [ ] Tests pass locally
+- [ ] CI workflows pass
 
 ## Security
 
 - [ ] No hardcoded secrets, API keys, or credentials
 - [ ] No new injection vectors in workflow `run:` steps
-- [ ] Sensitive data not logged or exposed in workflow outputs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/qte77/coding-agents-research/security/advisories/new).
+
+Do not open a public issue for security vulnerabilities.


### PR DESCRIPTION
## Summary

Standardize repository scaffold to match the qte77 org-wide pattern.

## Changes

- `.gitmessage` — conventional commits template
- `.claude/settings.json` — attribution config + commit-helper plugin
- `SECURITY.md` — GitHub Security Advisories reporting link
- `.github/PULL_REQUEST_TEMPLATE.md` — conventional commits PR checklist
- `.github/ISSUE_TEMPLATE/` — bug report + question templates
- CodeQL workflow (where applicable)
- Dependabot config (where applicable)
- `LICENSE` (BSD-3-Clause, where missing)
- `.gitignore` (where missing / fixed)

Generated with Claude <noreply@anthropic.com>