### PR TITLE
docs: fix lychee link errors and permanent redirects

### DIFF
--- a/docs/cc-community/CC-repo-to-docs-tools-landscape.md
+++ b/docs/cc-community/CC-repo-to-docs-tools-landscape.md
@@ -37,6 +37,7 @@ Three tools represent an emerging category of **AI-powered repo-to-documentation
 **Maker**: [Cognition Labs](https://cognition.ai) (the company behind Devin AI)
 
 AI indexes an entire GitHub repository and generates hierarchical wiki-style documentation with:
+
 - Table of contents with subsections and cross-links
 - Mermaid-format architecture diagrams (flowcharts, dependency graphs, lifecycle hierarchies)
 - Source file references with GitHub links including line ranges
@@ -73,7 +74,8 @@ Published examples: [FastAPI](https://the-pocket.github.io/PocketFlow-Tutorial-C
 **GitHub**: [antarixxx/gitsummarize](https://github.com/antarixxx/gitsummarize) | **Stars**: 444 | **License**: Apache-2.0
 
 One-click AI documentation generator. URL rewrite workflow:
-```
+
+```text
 github.com/user/repo  -->  gitsummarize.com/user/repo
 ```
 
@@ -85,7 +87,7 @@ Three output levels: system architecture, directory-level summaries, file-level 
 
 All three tools share a common pipeline:
 
-```
+```text
 GitHub URL --> Clone/Fetch --> AI Analysis --> Structured Output
 ```
 
@@ -105,7 +107,7 @@ Differentiation happens at the output stage:
 |-------|------|
 | Knowledge graphs from code (CC-integrated) | [CC-community-tooling-landscape.md — Graphify](CC-community-tooling-landscape.md#graphify-safishamsi) |
 | AST-based code analysis (CC-integrated) | [CC-community-tooling-landscape.md — Code-Review-Graph](CC-community-tooling-landscape.md#code-review-graph-tirth8205) |
-| llms.txt documentation standard | [CC-llmstxt-analysis.md](../cc-native/context-memory/CC-llmstxt-analysis.md) |
+| llms.txt documentation standard | [CC-llms-txt-analysis.md](../cc-native/context-memory/CC-llms-txt-analysis.md) |
 | Context engineering for agents | [CC-community-skills-landscape.md — agent-skills](CC-community-skills-landscape.md) |
 | OpenViking L0/L1/L2 tiering | [openviking-analysis.md](../non-cc/openviking-analysis.md) |
 

--- a/docs/cc-native/agents-skills/CC-agent-teams-orchestration.md
+++ b/docs/cc-native/agents-skills/CC-agent-teams-orchestration.md
@@ -203,7 +203,7 @@ CC OTel integrates at the infrastructure level (env vars + Phoenix endpoint), se
 [cc-bed]: https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/blob/main/assets/docs/MONITORING.md
 [otel-spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
 [langfuse]: https://langfuse.com/integrations/other/claude-code
-[phoenix-docs]: https://docs.arize.com/phoenix
+[phoenix-docs]: https://arize.com/docs/phoenix
 
 ## Recommendation
 
@@ -433,7 +433,6 @@ Cross-ref: [CC-community-reimplementations-landscape.md](../../cc-community/CC-c
 | [Agent Orchestration Analysis][linkedin-trace] | Sigrid Jin | `~/.claude/teams` structure analysis |
 | [Agent Teams Guide][claudefast] | Community | Multi-session orchestration guide |
 | [Porting to OpenCode][dev-opencode] | Uenyioha | Architecture comparison |
-| [Aura Frog Guide][aura-frog] | Community | Structured workflow integration |
 | [C Compiler with 16 Agents][compiler-case] | Anthropic/Register | 2,000 sessions, 100k-line compiler |
 
 [cc-teams-docs]: https://code.claude.com/docs/en/agent-teams
@@ -443,7 +442,6 @@ Cross-ref: [CC-community-reimplementations-landscape.md](../../cc-community/CC-c
 [linkedin-trace]: https://www.linkedin.com/pulse/how-claude-code-orchestrate-team-agents-sigrid-jin--msedc
 [claudefast]: https://claudefa.st/blog/guide/agents/agent-teams
 [dev-opencode]: https://dev.to/uenyioha/porting-claude-codes-agent-teams-to-opencode-4hol
-[aura-frog]: https://github.com/nguyenthienthanh/aura-frog/blob/main/aura-frog/docs/AGENT_TEAMS_GUIDE.md
 [compiler-case]: https://www.theregister.com/2026/02/09/claude_opus_46_compiler/
 [register-leak]: https://www.theregister.com/2026/03/31/anthropic_claude_code_source_code/
 [techsy-leaked]: https://techsy.io/blog/claude-code-leaked-features-2026

--- a/docs/cc-native/configuration/CC-changelog-feature-scan.md
+++ b/docs/cc-native/configuration/CC-changelog-feature-scan.md
@@ -135,7 +135,7 @@ Tracked from changelog/native-sources triage monitors. Not shipped features — 
 - [ ] **`WriteTemp()` tool** ([#34939][writetemp], 2026-03-18) — Medium. Temporary file creation without permission prompts. Would simplify headless scripts that generate intermediate files
 - [ ] **Compaction-proof `INVARIANT.md`** ([#34716][invariant], 2026-03-17) — Medium. `~/.claude/INVARIANT.md` that survives context compaction. Would guarantee critical instructions persist in long sessions
 - [ ] **riscv64 architecture support** ([#35016][riscv64], 2026-03-18) — Low. Linux RISC-V support. Niche — only relevant if deploying CC on RISC-V hardware
-- [ ] **Dispatch for CLI** ([#36011][dispatch-cli], 2026-03-19) — Medium. Cowork dispatch for CC CLI. See [CC-cowork-plugins-enterprise-analysis.md](plugins-ecosystem/CC-cowork-plugins-enterprise-analysis.md#open-feature-requests)
+- [ ] **Dispatch for CLI** ([#36011][dispatch-cli], 2026-03-19) — Medium. Cowork dispatch for CC CLI. See [CC-cowork-plugins-enterprise-analysis.md](../plugins-ecosystem/CC-cowork-plugins-enterprise-analysis.md#open-feature-requests)
 
 [writetemp]: https://github.com/anthropics/claude-code/issues/34939
 [invariant]: https://github.com/anthropics/claude-code/issues/34716
@@ -201,8 +201,8 @@ On March 30 2026, [Boris Cherny](https://www.threads.com/@boris_cherny/) (Head o
 - [Boris Cherny original thread](https://www.threads.com/@boris_cherny/post/DWfjnqGFPHE/) (2026-03-30)
 - [howborisusesclaudecode.com](https://howborisusesclaudecode.com) (fan site)
 - [claude-code-best-practice: Boris 15 tips](https://github.com/shanraisshan/claude-code-best-practice/blob/main/tips/claude-boris-15-tips-30-mar-26.md)
-- [Anthropic Hooks Guide](https://docs.anthropic.com/en/docs/claude-code/hooks-guide)
-- [Claude Code SDK Overview](https://docs.anthropic.com/en/docs/claude-code/sdk)
+- [Anthropic Hooks Guide](https://code.claude.com/docs/en/hooks-guide)
+- [Claude Code SDK Overview](https://code.claude.com/docs/en/agent-sdk/overview)
 
 ### References
 

--- a/docs/cc-native/plugins-ecosystem/CC-cowork-skills-api-workflows.md
+++ b/docs/cc-native/plugins-ecosystem/CC-cowork-skills-api-workflows.md
@@ -243,4 +243,4 @@ jobs:
 - [Scheduled Tasks](https://code.claude.com/docs/en/scheduled-tasks)
 - [Cowork Plugins](https://claude.com/blog/cowork-plugins)
 - [Knowledge Work Plugins](https://github.com/anthropics/knowledge-work-plugins)
-- [Agent Skills Open Standard](https://agentskills.io)
+- [Agent Skills Open Standard](https://agentskills.io/home)

--- a/docs/non-cc/hermes-agent-analysis.md
+++ b/docs/non-cc/hermes-agent-analysis.md
@@ -103,4 +103,4 @@ on multi-channel deployment but different architecture.
 [hermes]: https://github.com/nousresearch/hermes-agent
 [hermes-docs]: https://hermes-agent.nousresearch.com/docs/
 [nous]: https://nousresearch.com
-[skills-hub]: https://agentskills.io
+[skills-hub]: https://agentskills.io/home

--- a/docs/non-cc/insforge-analysis.md
+++ b/docs/non-cc/insforge-analysis.md
@@ -102,4 +102,4 @@ goes versus conventional APIs. Skills library is early (12 stars).
 [insforge-py]: https://github.com/InsForge/insforge-python
 [insforge-templates]: https://github.com/InsForge/insforge-templates
 [insforge-cloud]: https://insforge.dev
-[insforge-docs]: https://docs.insforge.dev
+[insforge-docs]: https://docs.insforge.dev/introduction


### PR DESCRIPTION
## Summary

Post-merge lychee scan on \`main\` surfaced 3 link errors and 9 redirects. This PR resolves the 3 errors and the 5 permanent (301/308) redirects. Also folds in opportunistic markdownlint fixes for the file being touched for the llmstxt typo.

### Link errors fixed (3)

| Error | File | Origin |
|---|---|---|
| Typo: \`CC-llmstxt-analysis.md\` (real file is \`CC-llms-txt-analysis.md\`) | \`docs/cc-community/CC-repo-to-docs-tools-landscape.md\` | **PR #95 regression** |
| Relative path \`plugins-ecosystem/\` missing \`../\` prefix | \`docs/cc-native/configuration/CC-changelog-feature-scan.md\` | Pre-existing (#66) |
| 404 on abandoned external repo (\`nguyenthienthanh/aura-frog\`) | \`docs/cc-native/agents-skills/CC-agent-teams-orchestration.md\` | Pre-existing; row + link def removed |

### Permanent redirects resolved (5 of 9)

| From | To | Call sites |
|---|---|---|
| \`agentskills.io\` (308) | \`agentskills.io/home\` | 2 |
| \`docs.anthropic.com/en/docs/claude-code/hooks-guide\` (301) | \`code.claude.com/docs/en/hooks-guide\` | 1 |
| \`docs.anthropic.com/en/docs/claude-code/sdk\` (301 chain) | \`code.claude.com/docs/en/agent-sdk/overview\` | 1 |
| \`docs.insforge.dev\` (308) | \`docs.insforge.dev/introduction\` | 1 |
| \`docs.arize.com/phoenix\` (301) | \`arize.com/docs/phoenix\` | 1 |

### Left untouched: 4 temporary (307) redirects

\`promptpatterns.dev\`, \`conductor.build\`, \`feynman.is\`, \`feynman.is/docs\` — temporary redirects per HTTP semantics; rewriting them upstream is incorrect.

### Opportunistic markdownlint fixes

In \`CC-repo-to-docs-tools-landscape.md\` (already being edited for the llmstxt typo):
- MD032: blank line before a list after a paragraph
- MD040 × 2: added \`text\` language specifier to two fenced code blocks
- MD031: blank line before a fenced code block

Other MD040 findings in unrelated files are left for a separate cleanup PR.

## Verification

\`\`\`
lychee --config lychee.toml <all 6 touched files>
→ 121 total URLs, 120 OK, 0 errors, 1 excluded
\`\`\`

## Commits

- \`6d7cc3c\` docs: fix lychee link errors and resolve permanent redirects

Generated with Claude <noreply@anthropic.com>