### PR TITLE
build: add Makefile with sudo-less lint tooling install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,121 @@
+# Requires GNU Make >= 3.82 for .ONESHELL
+# macOS ships 3.81 as of Sequoia 15.4 (2025-03, Apple avoids GPLv3).
+# Ref: https://opensource.apple.com/releases/ (validated 2026-04-10)
+# Fix: brew install make → use gmake (not make)
+ifeq ($(filter oneshell,$(.FEATURES)),)
+$(error GNU Make >= 3.82 required. macOS: brew install make, then use gmake)
+endif
+
+.SILENT:
+.ONESHELL:
+.PHONY: \
+	setup_node setup_lychee setup_mdlint setup_all \
+	check_links check_docs autofix lint \
+	help
+.DEFAULT_GOAL := help
+
+
+# -- config --
+NODE_VERSION ?= 22.11.0
+NODE_DIR     := $(HOME)/.local/share/node
+NODE_BIN     := $(NODE_DIR)/bin
+LOCAL_BIN    := $(HOME)/.local/bin
+
+
+# MARK: SETUP
+
+
+setup_node: ## Install Node.js user-locally to ~/.local/share/node (no sudo)
+	if [ -x "$(NODE_BIN)/node" ]; then
+		echo "node already installed: $$($(NODE_BIN)/node --version) (at $(NODE_DIR))"
+	elif command -v node > /dev/null 2>&1; then
+		echo "node already installed on PATH: $$(node --version)"
+	else
+		echo "Installing Node.js $(NODE_VERSION) to $(NODE_DIR) ..."
+		mkdir -p $(NODE_DIR)
+		curl -sSfL https://nodejs.org/dist/v$(NODE_VERSION)/node-v$(NODE_VERSION)-linux-x64.tar.xz \
+			| tar -xJ --strip-components=1 -C $(NODE_DIR) \
+			&& echo "node installed — add to PATH: export PATH=$(NODE_BIN):\$$PATH" \
+			|| echo "Install failed — download manually from https://nodejs.org/dist/v$(NODE_VERSION)/"
+	fi
+
+setup_lychee: ## Install lychee link checker user-locally to ~/.local/bin (no sudo)
+	if command -v lychee > /dev/null 2>&1; then
+		echo "lychee already installed: $$(lychee --version)"
+	else
+		mkdir -p $(LOCAL_BIN)
+		curl -sSfL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
+			| tar xz -C $(LOCAL_BIN) \
+			&& echo "lychee installed to $(LOCAL_BIN) — ensure it is on PATH" \
+			|| echo "Install failed — download manually from https://github.com/lycheeverse/lychee/releases"
+	fi
+
+setup_mdlint: setup_node ## Install markdownlint-cli2 via user-local npm (no sudo)
+	export PATH="$(NODE_BIN):$$PATH"
+	if [ -x "$(NODE_BIN)/markdownlint-cli2" ]; then
+		echo "markdownlint-cli2 already installed: $$(markdownlint-cli2 --version 2>&1 | head -1)"
+	elif command -v markdownlint-cli2 > /dev/null 2>&1; then
+		echo "markdownlint-cli2 already installed (system PATH): $$(markdownlint-cli2 --version 2>&1 | head -1)"
+	else
+		echo "Installing markdownlint-cli2 into $(NODE_DIR) ..."
+		if [ -x "$(NODE_BIN)/npm" ] || command -v npm > /dev/null 2>&1; then
+			npm install -g markdownlint-cli2
+		else
+			echo "ERROR: npm not found after setup_node — check Node install"
+			exit 1
+		fi
+	fi
+
+setup_all: setup_lychee setup_mdlint ## Install all tooling (lychee + node + markdownlint-cli2)
+
+
+# MARK: DEV
+
+
+check_links: ## Check links with lychee
+	if command -v lychee > /dev/null 2>&1; then
+		lychee --config lychee.toml .
+	else
+		echo "lychee not installed — run: make setup_lychee"
+		exit 1
+	fi
+
+check_docs: ## Lint markdown files (reads .markdownlint.json)
+	export PATH="$(NODE_BIN):$$PATH"
+	if command -v markdownlint-cli2 > /dev/null 2>&1; then
+		markdownlint-cli2 "README.md" "CHANGELOG.md" "CONTRIBUTING.md" "docs/**/*.md"
+	else
+		echo "markdownlint-cli2 not installed — run: make setup_mdlint"
+		exit 1
+	fi
+
+autofix: ## Auto-fix markdown lint issues (markdownlint --fix)
+	export PATH="$(NODE_BIN):$$PATH"
+	if command -v markdownlint-cli2 > /dev/null 2>&1; then
+		markdownlint-cli2 --fix "README.md" "CHANGELOG.md" "CONTRIBUTING.md" "docs/**/*.md"
+	else
+		echo "markdownlint-cli2 not installed — run: make setup_mdlint"
+		exit 1
+	fi
+
+lint: check_links check_docs ## Run all linters (links + markdown)
+
+
+# MARK: HELP
+
+
+help: ## Show available recipes grouped by section
+	echo "Usage: make [recipe]"
+	echo ""
+	awk '/^# MARK:/ { \
+		section = substr($$0, index($$0, ":")+2); \
+		printf "\n\033[1m%s\033[0m\n", section \
+	} \
+	/^[a-zA-Z0-9_-]+:.*?##/ { \
+		helpMessage = match($$0, /## (.*)/); \
+		if (helpMessage) { \
+			recipe = $$1; \
+			sub(/:/, "", recipe); \
+			printf "  \033[36m%-22s\033[0m %s\n", recipe, substr($$0, RSTART + 3, RLENGTH) \
+		} \
+	}' $(MAKEFILE_LIST)


### PR DESCRIPTION
## Summary

Adds a \`Makefile\` adapted from the authoritative [\`so101-biolab-automation\`](https://github.com/qte77/so101-biolab-automation) version, scoped to \`ai-agents-research\` (docs-only). Installs \`lychee\` and \`markdownlint-cli2\` fully user-locally with **zero sudo**.

## What's in the box

| Recipe | Purpose |
|---|---|
| \`setup_node\` | Node.js 22.11.0 tarball → \`~/.local/share/node\` |
| \`setup_lychee\` | lychee GitHub release → \`~/.local/bin\` |
| \`setup_mdlint\` | markdownlint-cli2 via user-local \`npm install -g\` (depends on \`setup_node\`) |
| \`setup_all\` | All three |
| \`check_links\` | \`lychee --config lychee.toml .\` |
| \`check_docs\` | markdownlint-cli2 on README/CHANGELOG/CONTRIBUTING/docs/ using existing \`.markdownlint.json\` |
| \`autofix\` | \`markdownlint-cli2 --fix\` |
| \`lint\` | check_links + check_docs |
| \`help\` | AWK-colored help grouped by \`# MARK:\` sections |

## Inherited so101 conventions

\`.SILENT\`, \`.ONESHELL\`, GNU Make ≥3.82 guard (macOS 3.81 warning),
explicit \`.PHONY\` list, \`## \` help-comment convention, \`# MARK: SECTION\`
grouping, \`setup_*\` / \`check_*\` naming.

## Divergences from so101

1. **No sudo fallback on \`setup_lychee\`.** so101 tries \`sudo tar → /usr/local/bin\` first, falls back to \`~/.local/bin\`. This version is user-local only per project preference.
2. **\`setup_mdlint\` also installs Node.js.** so101 assumes pre-existing \`npm\` from system tooling; this version auto-installs Node.js first so the recipe is self-sufficient on a clean machine.
3. **No Python/hardware recipes** (\`setup_uv\`, \`render_parts\`, \`record_episodes\`, \`train_policy\`, etc.) — this is a docs-only research repo.

## Verification

\`\`\`
$ make help              # recipes render with ANSI color + MARK groups
$ make setup_all         # installs lychee 0.23.0, node v22.11.0, markdownlint-cli2 v0.22.0
$ make setup_all         # idempotent — all three report "already installed"
$ markdownlint-cli2 --config .markdownlint.json README.md
  Summary: 0 error(s)    # confirms MD041 front_matter_title + MD024 siblings_only work
\`\`\`

## Out of scope (follow-up work)

First full-repo \`make check_docs\` run exposes **282 pre-existing markdownlint findings** across the docs tree. Mostly \`MD040/fenced-code-language\` and \`MD025/single-h1\`. These are long-standing tech debt unrelated to this PR and should be addressed incrementally.

Similarly, \`make check_links\` on the full repo exposes pre-existing broken links. PR #97 (sibling PR) resolves 3 of them.

## Commits

- \`35a9ae4\` build: add Makefile with sudo-less lint tooling install

Generated with Claude <noreply@anthropic.com>