### PR TITLE
docs: refresh README, CHANGELOG, CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Makefile`: build tooling for docs linting — sudo-less install recipes for Node.js, lychee, markdownlint-cli2 (`setup_node`, `setup_lychee`, `setup_mdlint`, `setup_all`), plus `check_links`, `check_docs`, `autofix`, `lint` targets; adapted from the authoritative `qte77/so101-biolab-automation` Makefile conventions (PR #98)
+- `docs/cc-native/agents-skills/CC-skills-adoption-analysis.md`: new Skill Context Budgets subsection documenting three-level progressive disclosure (~100 tokens metadata / <5k SKILL.md body / unlimited bundled), shared 25k-token auto-compaction budget with 5k per-skill preservation, 1% / 8000-char description budget with 250-char per-skill cap and `SLASH_COMMAND_TOOL_CHAR_BUDGET` override, and the framing quote on skills as the replacement for procedural CLAUDE.md content (PR #96)
 - `docs/cc-community/CC-community-tooling-landscape.md`: Graphify (16.5K stars, code→knowledge graph, CC hooks/MCP), MemPalace (33.6K stars, palace-metaphor memory, 19 MCP tools), Code-Review-Graph (7.1K stars, AST blast-radius, 22 MCP tools)
 - `docs/non-cc/feynman-analysis.md`: Companion AI Feynman research agent (3.8K stars, 4 sub-agents, experiment replication)
 - `docs/non-cc/insforge-analysis.md`: InsForge agent backend platform (7.3K stars, auth/DB/storage/functions semantic layer)
@@ -20,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/non-cc/rowboat-analysis.md`: Rowboat AI coworker (11.1K stars, knowledge graph from communications, Obsidian-compatible)
 - `docs/non-cc/hermes-agent-analysis.md`: Nous Research Hermes Agent (43.2K stars, self-improving skills, 7 platforms)
 - `CONTRIBUTING.md`: classification guidance for cc-community vs non-cc placement, `platform_scope` frontmatter field
+
+### Fixed
+
+- `docs/cc-community/CC-repo-to-docs-tools-landscape.md`: typo `CC-llmstxt-analysis.md` → `CC-llms-txt-analysis.md` (broken relative link regression from the URL triage batches PR); opportunistic markdownlint cleanup (MD031 / MD032 / MD040) in the same file (PR #97)
+- `docs/cc-native/configuration/CC-changelog-feature-scan.md`: relative path `plugins-ecosystem/` → `../plugins-ecosystem/` (pre-existing broken internal link), resolve two permanent redirects `docs.anthropic.com/en/docs/claude-code/{hooks-guide,sdk}` → `code.claude.com/docs/en/{hooks-guide,agent-sdk/overview}` (PR #97)
+- `docs/cc-native/agents-skills/CC-agent-teams-orchestration.md`: remove Aura Frog guide row + link def (external repo returned 404); resolve `docs.arize.com/phoenix` → `arize.com/docs/phoenix` permanent redirect (PR #97)
+- `docs/non-cc/{hermes-agent,insforge}-analysis.md`, `docs/cc-native/plugins-ecosystem/CC-cowork-skills-api-workflows.md`: resolve permanent redirects on `agentskills.io` and `docs.insforge.dev` (PR #97)
 
 ### Changed
 
@@ -82,7 +91,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 
 ### Added
-
 
 - `docs/cc-native/plugins-ecosystem/CC-connectors-overview.md`: MCP connectors analysis — prebuilt integrations (Google Drive/Gmail/Calendar, GitHub, Slack, M365), custom connector types, platform availability, Google connector deep-dives, applicability to coding agent workflows
 - `docs/cc-native/plugins-ecosystem/CC-cowork-skills-api-workflows.md`: Cowork, Skills API, CC Web, Chrome extension programmatic workflow analysis — API endpoints, cross-surface availability, community orchestration tools, multi-repo cloud execution patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,3 +174,20 @@ This prevents misreading a `cc-community` placement as "CC-exclusive."
 - Duplicating content across docs — cross-reference the authoritative doc
 - Missing Sources section — every doc must cite its sources
 - Stale `validated_links` dates — re-check URLs when updating findings
+
+## Auto-generated content
+
+The `triage/` directory contains **auto-generated monitor outputs** (changelog triage, community triage, outage archive). It is populated exclusively by the GitHub Actions monitors in `.github/workflows/` and is **not a source of hand-written analysis**. Do not treat triage files as content candidates for promotion into `docs/` — findings of interest should be re-researched from their first-party sources and written as new analysis docs under the appropriate `docs/` subdirectory. The directory is intentionally excluded from link checking via `lychee.toml`.
+
+## Local development
+
+Doc linting is wired into the top-level `Makefile`. All tools install user-locally with zero sudo.
+
+```bash
+make setup_all   # install lychee, Node.js (user-local), markdownlint-cli2
+make lint        # run lychee + markdownlint-cli2 over the full repo
+make autofix     # mechanical markdownlint --fix pass
+make help        # list all recipes grouped by section
+```
+
+Run `make lint` against any PR that touches docs before requesting review. `lychee` reads `lychee.toml`; `markdownlint-cli2` reads `.markdownlint.json`.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Standalone deep-dive analyses of CC features, each following a consistent format
 
 Three automated monitors poll external sources on cron and open triage PRs when new content is found. See [`.github/README.md`](.github/README.md) for details.
 
+## Local development
+
+Doc linting is wired into a `Makefile` that installs everything user-locally with zero sudo:
+
+```bash
+make setup_all   # install lychee, Node.js, markdownlint-cli2 under ~/.local
+make lint        # run both link checker (lychee) and markdown linter
+make autofix     # mechanical markdownlint --fix pass
+make help        # show all recipes grouped by section
+```
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for document standards and [`CHANGELOG.md`](CHANGELOG.md) for release history.
+
 ## Related Repos
 
 Research from this repository feeds into these downstream implementation repos:


### PR DESCRIPTION
## Summary

Bundles WS4 (README/CHANGELOG refresh) + WS6 (triage/ decision) per the approved plan.

### README.md

Adds a "Local development" section documenting the Makefile recipes landed in PR #98:

- \`make setup_all\` — zero-sudo install of lychee + Node.js + markdownlint-cli2 under \`~/.local\`
- \`make lint\` — run both linters
- \`make autofix\` — mechanical markdown fix pass
- \`make help\` — recipe catalogue

Also adds explicit links to \`CONTRIBUTING.md\` and \`CHANGELOG.md\` from the README (previously no discovery path to either).

### CHANGELOG.md

Populates \`[Unreleased]\` with entries for the 3 PRs not yet reflected on main:

- **#96** Skill Context Budgets subsection in \`CC-skills-adoption-analysis.md\`
- **#97** lychee link error fixes + permanent redirects resolved
- **#98** Makefile with sudo-less lint tooling install

Note: PR #95 (URL triage batches) was already reflected in the existing \`[Unreleased]\` block — earlier agent report that "all 4 recent PRs are missing" was incorrect on this point, verified by direct read.

Also fixes a pre-existing MD012 (consecutive blank lines) in the older \`[Unreleased]\` block that the new \`make check_docs\` gate surfaced.

### CONTRIBUTING.md (bundles WS6)

Two new sections:

1. **\"Auto-generated content\"** — codifies that \`triage/\` is a monitor sink, populated by GHA workflows, **not a source of hand-written analysis**. Explicitly tells future contributors (and agents) not to try to promote triage files into \`docs/\`. Survey confirmed 10 triage files across \`cc-changelog/\`, \`community/\`, \`status-monitor/\` — all auto-generated, zero promotion candidates.
2. **\"Local development\"** — mirror of the README section with make commands.

## Verification

\`\`\`
$ lychee --config lychee.toml README.md CHANGELOG.md CONTRIBUTING.md
  🔍 17 Total ✅ 17 OK 🚫 0 Errors
$ markdownlint-cli2 --config .markdownlint.json README.md CHANGELOG.md CONTRIBUTING.md
  Summary: 0 error(s)
\`\`\`

## Commits

- \`69bcce8\` docs: refresh README, CHANGELOG, CONTRIBUTING for recent PRs

Generated with Claude <noreply@anthropic.com>