### PR TITLE
chore: markdownlint autofix sweep (phase 2)

### DIFF
--- a/docs/cc-community/CC-office-worker-workflows.md
+++ b/docs/cc-community/CC-office-worker-workflows.md
@@ -110,6 +110,7 @@ tmux session 4: /financial-report   → CC + xlsx skill + QuickBooks MCP + pptx 
 Each session gets its own Claude Code instance with task-specific MCP servers configured. Sessions survive disconnect (tmux persistence), giving business task continuity across the workday.
 
 **Implementation options**:
+
 - **Simplest**: CC Agent Teams (native, zero setup)
 - **Most flexible**: claude-session-driver (fan-out pattern, programmatic control)
 - **Most visual**: Vibe Kanban (kanban board, agent-agnostic)

--- a/docs/cc-community/CC-repo-to-docs-tools-landscape.md
+++ b/docs/cc-community/CC-repo-to-docs-tools-landscape.md
@@ -92,11 +92,13 @@ GitHub URL --> Clone/Fetch --> AI Analysis --> Structured Output
 ```
 
 Differentiation happens at the output stage:
+
 - **Reference** (DeepWiki): architecture-level, developer-to-developer
 - **Educational** (Code2Tutorial): abstraction-level, teacher-to-student
 - **Summary** (GitSummarize): evaluation-level, quick scan
 
 **Agent integration opportunity**: Generated documentation could be:
+
 1. Fed as context to coding agents (replacing expensive runtime analysis)
 2. Used as `llms.txt` equivalent for external repos
 3. Cached as L1/L2 context in OpenViking-style tiered systems

--- a/docs/cc-native/CC-first-party-docs-index.md
+++ b/docs/cc-native/CC-first-party-docs-index.md
@@ -12,49 +12,49 @@ validated_links: 2026-03-28
 
 | Topic | URL |
 |-------|-----|
-| Overview | https://code.claude.com/docs/en/overview |
-| Quickstart | https://code.claude.com/docs/en/quickstart |
-| Memory (CLAUDE.md) | https://code.claude.com/docs/en/memory |
-| Hooks system | https://code.claude.com/docs/en/hooks-guide |
-| Settings & configuration | https://code.claude.com/docs/en/settings |
-| Agent Teams | https://code.claude.com/docs/en/agent-teams |
-| MCP integration | https://code.claude.com/docs/en/mcp |
-| LLMs.txt | https://code.claude.com/docs/llms.txt |
+| Overview | <https://code.claude.com/docs/en/overview> |
+| Quickstart | <https://code.claude.com/docs/en/quickstart> |
+| Memory (CLAUDE.md) | <https://code.claude.com/docs/en/memory> |
+| Hooks system | <https://code.claude.com/docs/en/hooks-guide> |
+| Settings & configuration | <https://code.claude.com/docs/en/settings> |
+| Agent Teams | <https://code.claude.com/docs/en/agent-teams> |
+| MCP integration | <https://code.claude.com/docs/en/mcp> |
+| LLMs.txt | <https://code.claude.com/docs/llms.txt> |
 
 ## Agent SDK (platform.claude.com)
 
 | Topic | URL |
 |-------|-----|
-| Overview | https://platform.claude.com/docs/en/agent-sdk/overview |
-| Quickstart | https://platform.claude.com/docs/en/agent-sdk/quickstart |
-| Python reference | https://platform.claude.com/docs/en/agent-sdk/python |
-| TypeScript reference | https://platform.claude.com/docs/en/agent-sdk/typescript |
-| Agent loop internals | https://platform.claude.com/docs/en/agent-sdk/agent-loop |
-| Subagents | https://platform.claude.com/docs/en/agent-sdk/subagents |
-| Skills | https://platform.claude.com/docs/en/agent-sdk/skills |
-| Hosting | https://platform.claude.com/docs/en/agent-sdk/hosting |
-| Best practices | https://platform.claude.com/docs/en/agent-sdk/best-practices |
+| Overview | <https://platform.claude.com/docs/en/agent-sdk/overview> |
+| Quickstart | <https://platform.claude.com/docs/en/agent-sdk/quickstart> |
+| Python reference | <https://platform.claude.com/docs/en/agent-sdk/python> |
+| TypeScript reference | <https://platform.claude.com/docs/en/agent-sdk/typescript> |
+| Agent loop internals | <https://platform.claude.com/docs/en/agent-sdk/agent-loop> |
+| Subagents | <https://platform.claude.com/docs/en/agent-sdk/subagents> |
+| Skills | <https://platform.claude.com/docs/en/agent-sdk/skills> |
+| Hosting | <https://platform.claude.com/docs/en/agent-sdk/hosting> |
+| Best practices | <https://platform.claude.com/docs/en/agent-sdk/best-practices> |
 
 ## Anthropic SDK (API client)
 
 | Topic | URL |
 |-------|-----|
-| Client SDKs (Python + TypeScript) | https://docs.anthropic.com/en/api/client-sdks |
-| GitHub (Python) | https://github.com/anthropics/anthropic-sdk-python |
-| GitHub (TypeScript) | https://github.com/anthropics/anthropic-sdk-typescript |
+| Client SDKs (Python + TypeScript) | <https://docs.anthropic.com/en/api/client-sdks> |
+| GitHub (Python) | <https://github.com/anthropics/anthropic-sdk-python> |
+| GitHub (TypeScript) | <https://github.com/anthropics/anthropic-sdk-typescript> |
 
 ## Claude API & Best Practices (docs.anthropic.com)
 
 | Topic | URL |
 |-------|-----|
-| Tool use overview | https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview |
-| Text editor tool | https://docs.anthropic.com/en/docs/build-with-claude/tool-use/text-editor-tool |
-| Building effective agents | https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/building-effective-agents |
+| Tool use overview | <https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview> |
+| Text editor tool | <https://docs.anthropic.com/en/docs/build-with-claude/tool-use/text-editor-tool> |
+| Building effective agents | <https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/building-effective-agents> |
 
 ## GitHub Resources
 
 | Topic | URL |
 |-------|-----|
-| Claude Code repo | https://github.com/anthropics/claude-code |
-| Official plugins | https://github.com/anthropics/claude-code/tree/main/plugins |
-| Model Context Protocol | https://modelcontextprotocol.io/ |
+| Claude Code repo | <https://github.com/anthropics/claude-code> |
+| Official plugins | <https://github.com/anthropics/claude-code/tree/main/plugins> |
+| Model Context Protocol | <https://modelcontextprotocol.io/> |

--- a/docs/cc-native/ci-remote/CC-status-monitoring-analysis.md
+++ b/docs/cc-native/ci-remote/CC-status-monitoring-analysis.md
@@ -67,6 +67,7 @@ All endpoints are under `https://status.anthropic.com/api/v2/`.
 Statuspage supports webhook subscriptions that POST on every incident update and component status change.
 
 **Payload format** (POST body):
+
 - `page.status_indicator`, `page.status_description`
 - `incident.*` — full incident object (same structure as JSON API)
 - `component_update.old_status`, `.new_status`, `component.name`
@@ -125,6 +126,7 @@ Generated from the archive as `triage/status-monitor/outage-stats.md`, covering:
 ### Workflow
 
 `cc-status-monitor.yaml` runs on:
+
 - **4-hour cron** — primary collection mechanism, catches everything
 - **`repository_dispatch`** (`status-change` event) — retained for future webhook proxy
 - **`workflow_dispatch`** — manual trigger for testing

--- a/docs/cc-native/configuration/CC-ide-integration-protocol.md
+++ b/docs/cc-native/configuration/CC-ide-integration-protocol.md
@@ -17,6 +17,7 @@ Claude Code communicates with IDE extensions (VS Code, JetBrains) via a **WebSoc
 1. IDE extension starts a WebSocket server on a random high port
 2. Extension sets `CLAUDE_CODE_SSE_PORT=<port>` and `ENABLE_IDE_INTEGRATION=true` in the terminal environment
 3. Lock file written at `~/.claude/ide/<port>.lock`:
+
    ```json
    {
      "workspaceFolders": ["/path/to/project"],
@@ -26,6 +27,7 @@ Claude Code communicates with IDE extensions (VS Code, JetBrains) via a **WebSoc
      "token": "<random-auth-token>"
    }
    ```
+
 4. Lock file: `0600` permissions, directory: `0700`
 5. Server binds to `127.0.0.1` only
 6. Each IDE activation generates a fresh random auth token

--- a/docs/cc-native/context-memory/CC-prompt-caching-behavior.md
+++ b/docs/cc-native/context-memory/CC-prompt-caching-behavior.md
@@ -65,6 +65,7 @@ Source: [prompt caching docs][caching], "How cache lookback works" section
 CC uses `{"type": "ephemeral"}` (default 5-minute TTL) exclusively. The 1-hour tier (`{"type": "ephemeral", "ttl": "1h"}`) is never used.
 
 **Evidence**: Session `9f7de296`, CC 2.1.83, Codespaces, 2026-03-27 — 281 turns:
+
 - `ephemeral_5m_input_tokens`: 1,732,355 (all cache writes)
 - `ephemeral_1h_input_tokens`: 0
 

--- a/docs/non-cc/openviking-analysis.md
+++ b/docs/non-cc/openviking-analysis.md
@@ -71,6 +71,7 @@ The key cost-reduction mechanism. Every piece of content is processed into three
 **Generation**: Asynchronous, bottom-up. SemanticProcessor traverses directory hierarchies from leaf nodes upward. Child abstracts aggregate into parent overviews, creating navigable hierarchy.
 
 **Benchmark (LoCoMo10, 1,540 long-range dialogue cases)**:
+
 - Token reduction: 24.6M -> 4.3M (**80%+ reduction**), or 2.1M with memory-core
 - Average load per retrieval: **550 tokens** (95% cheaper than traditional vector search)
 - Task completion: 35.65% -> 52.08% (**49% improvement**)

--- a/docs/sdlc-lcm/agentic-sdlc-patterns.md
+++ b/docs/sdlc-lcm/agentic-sdlc-patterns.md
@@ -83,6 +83,7 @@ Traditional SDLC artifacts reimagined as coordination layers for agents.
 | Agent-first toolchain | CC, worktrees, Polyforge | Agent-triggered CI/CD |
 
 **sdlc-lcm-manager priorities:**
+
 1. Codify Observe+Correct as formal phases (extend maintain)
 2. Gate predicates agents can evaluate programmatically
 3. Phase inference from repo artifacts (SDD alignment)

--- a/docs/sdlc-lcm/oss-alm-landscape.md
+++ b/docs/sdlc-lcm/oss-alm-landscape.md
@@ -41,6 +41,7 @@ Python + docs; Phase 3 may need a UI dashboard or multi-user access.
 not agent-driven pipelines where state is inferred from repo artifacts.
 
 **Phase 3 trigger conditions:**
+
 - Multiple human users need lifecycle visibility
 - Audit/compliance requirements demand formal traceability
 - RAPID cockpit needs a persistent UI beyond CLI/TUI

--- a/lychee.toml
+++ b/lychee.toml
@@ -14,4 +14,6 @@ exclude = [
     "cuttlesoft.com",
     "linearb.io",
     "hashicorp.com",
+    "epam.com",
+    "thectoclub.com",
 ]


### PR DESCRIPTION
## Summary

Phase 2 WS2-1 per the approved plan. Mechanical \`markdownlint-cli2 --fix\` sweep via \`make autofix\`.

**Result**: 274 → 176 errors (−98, ~36% reduction).

Remaining 176 errors are **MD040** (fenced-code-language — needs manual guess) and **MD025** (multiple-h1 — structural). Neither is autofixable; both are scoped to WS2-2 manual cleanup per the plan.

## Files touched (9 committed, 1 reverted)

\`\`\`
docs/cc-community/CC-office-worker-workflows.md
docs/cc-community/CC-repo-to-docs-tools-landscape.md
docs/cc-native/CC-first-party-docs-index.md
docs/cc-native/ci-remote/CC-status-monitoring-analysis.md
docs/cc-native/configuration/CC-ide-integration-protocol.md
docs/cc-native/context-memory/CC-prompt-caching-behavior.md
docs/non-cc/openviking-analysis.md
docs/sdlc-lcm/agentic-sdlc-patterns.md
docs/sdlc-lcm/oss-alm-landscape.md
lychee.toml
\`\`\`

Fix categories applied: **MD032** (blanks around lists), **MD031** (blanks around fences), **MD034** (bare URLs → angle-bracket autolinks, applied only where syntactically valid — see revert note below).

## Revert: CC-env-vars-reference.md

Autofix incorrectly applied MD034 to **reference-style link definitions**:

\`\`\`diff
- [env-vars]: https://code.claude.com/docs/en/env-vars
+ [env-vars]: <https://code.claude.com/docs/en/env-vars>
\`\`\`

That syntax is invalid for link definitions — the \`<\`/\`>\` become literal characters in the URL, so every \`[foo][env-vars]\` inline reference in the file became a dangling reference. Autofix introduced 100+ new \`MD052/MD055/MD056\` errors as a result.

This is an upstream autofix bug in \`markdownlint-cli2\` or its rule implementation. The file is reverted in this PR and its MD issues move to WS2-2 for manual handling.

Grep for \`\\]: <http\` across the rest of the repo confirms no other file was affected.

## lychee.toml addition

Add \`epam.com\` and \`thectoclub.com\` to the bot-blocked \`exclude\` list. Both return 403 to lychee's HEAD requests despite serving their pages normally in browsers — same pattern as the existing \`medium.com\`, \`hashicorp.com\`, etc. entries. Pre-existing lychee failures on \`docs/sdlc-lcm/agentic-sdlc-patterns.md\` and \`docs/sdlc-lcm/oss-alm-landscape.md\` now pass.

## Verification

\`\`\`
$ make check_docs    # global
  Summary: 176 error(s)   (was 274 before autofix; −98)

$ markdownlint-cli2 --config .markdownlint.json <9 touched files>
  Summary: 12 error(s)    # all pre-existing MD040 / MD025 (scope of WS2-2)

$ lychee --config lychee.toml <9 touched files>
  🚫 0 Errors             # after the epam.com / thectoclub.com excludes
\`\`\`

## Commits

- \`62730ca\` chore: markdownlint autofix sweep (phase 2, WS2-1)

## Note on protected main

Same \`required_signatures\` ruleset blocker as PR #99/#100/#101 — you'll need to handle merge the same way (admin override or rule toggle).

Generated with Claude <noreply@anthropic.com>