### PR TITLE
docs: CLI reference, subagent artifacts, first-party index, Makefile OS detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,15 @@ setup_node: ## Install Node.js user-locally to ~/.local/share/node (no sudo)
 		mkdir -p $(NODE_DIR)
 		curl -sSfL https://nodejs.org/dist/v$(NODE_VERSION)/node-v$(NODE_VERSION)-linux-$(NODE_ARCH).tar.xz \
 			| tar -xJ --strip-components=1 -C $(NODE_DIR) \
-			&& echo "node installed — add to PATH: export PATH=$(NODE_BIN):\$$PATH" \
-			|| echo "Install failed — download manually from https://nodejs.org/dist/v$(NODE_VERSION)/"
+			|| { echo "Install failed — download manually from https://nodejs.org/dist/v$(NODE_VERSION)/"; exit 1; }
 	fi
+	mkdir -p $(LOCAL_BIN)
+	for bin in node npm npx; do \
+		if [ -x "$(NODE_BIN)/$$bin" ] && [ ! -e "$(LOCAL_BIN)/$$bin" ]; then \
+			ln -s "$(NODE_BIN)/$$bin" "$(LOCAL_BIN)/$$bin"; \
+			echo "symlinked $$bin -> $(LOCAL_BIN)/$$bin"; \
+		fi; \
+	done
 
 setup_lychee: ## Install lychee link checker user-locally to ~/.local/bin (no sudo)
 	if command -v lychee > /dev/null 2>&1; then

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,39 @@ NODE_DIR     := $(HOME)/.local/share/node
 NODE_BIN     := $(NODE_DIR)/bin
 LOCAL_BIN    := $(HOME)/.local/bin
 
+# -- OS / arch detection --
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_S),Darwin)
+  PKG_CMD := brew install
+else ifeq ($(shell command -v dnf 2>/dev/null),)
+  ifeq ($(shell command -v apt-get 2>/dev/null),)
+    ifeq ($(shell command -v pacman 2>/dev/null),)
+      PKG_CMD := echo "No supported package manager (brew/dnf/apt-get/pacman)" && exit 1 &&
+    else
+      PKG_CMD := sudo pacman -S --noconfirm
+    endif
+  else
+    PKG_CMD := sudo apt-get install -y -qq
+  endif
+else
+  PKG_CMD := sudo dnf install -y
+endif
+
+ifeq ($(UNAME_M),x86_64)
+  NODE_ARCH   := x64
+  LYCHEE_ARCH := x86_64-unknown-linux-gnu
+else ifeq ($(UNAME_M),aarch64)
+  NODE_ARCH   := arm64
+  LYCHEE_ARCH := aarch64-unknown-linux-gnu
+else ifeq ($(UNAME_M),arm64)
+  NODE_ARCH   := arm64
+  LYCHEE_ARCH := aarch64-apple-darwin
+else
+  NODE_ARCH   := $(UNAME_M)
+  LYCHEE_ARCH := $(UNAME_M)-unknown-linux-gnu
+endif
+
 # Source plugin providing skills (docs-governance, cc-meta).
 # Default: clone from GitHub to an XDG cache path. Override
 # UTILS_PLUGIN_DIR to point at an existing local clone.
@@ -37,10 +70,13 @@ setup_node: ## Install Node.js user-locally to ~/.local/share/node (no sudo)
 		echo "node already installed: $$($(NODE_BIN)/node --version) (at $(NODE_DIR))"
 	elif command -v node > /dev/null 2>&1; then
 		echo "node already installed on PATH: $$(node --version)"
+	elif [ "$(UNAME_S)" = "Darwin" ]; then
+		echo "Installing Node.js via brew ..."
+		brew install node
 	else
-		echo "Installing Node.js $(NODE_VERSION) to $(NODE_DIR) ..."
+		echo "Installing Node.js $(NODE_VERSION) ($(UNAME_S)/$(NODE_ARCH)) to $(NODE_DIR) ..."
 		mkdir -p $(NODE_DIR)
-		curl -sSfL https://nodejs.org/dist/v$(NODE_VERSION)/node-v$(NODE_VERSION)-linux-x64.tar.xz \
+		curl -sSfL https://nodejs.org/dist/v$(NODE_VERSION)/node-v$(NODE_VERSION)-linux-$(NODE_ARCH).tar.xz \
 			| tar -xJ --strip-components=1 -C $(NODE_DIR) \
 			&& echo "node installed — add to PATH: export PATH=$(NODE_BIN):\$$PATH" \
 			|| echo "Install failed — download manually from https://nodejs.org/dist/v$(NODE_VERSION)/"
@@ -49,9 +85,13 @@ setup_node: ## Install Node.js user-locally to ~/.local/share/node (no sudo)
 setup_lychee: ## Install lychee link checker user-locally to ~/.local/bin (no sudo)
 	if command -v lychee > /dev/null 2>&1; then
 		echo "lychee already installed: $$(lychee --version)"
+	elif [ "$(UNAME_S)" = "Darwin" ]; then
+		echo "Installing lychee via brew ..."
+		brew install lychee
 	else
+		echo "Installing lychee ($(LYCHEE_ARCH)) to $(LOCAL_BIN) ..."
 		mkdir -p $(LOCAL_BIN)
-		curl -sSfL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
+		curl -sSfL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-$(LYCHEE_ARCH).tar.gz \
 			| tar xz -C $(LOCAL_BIN) \
 			&& echo "lychee installed to $(LOCAL_BIN) — ensure it is on PATH" \
 			|| echo "Install failed — download manually from https://github.com/lycheeverse/lychee/releases"
@@ -109,11 +149,15 @@ setup_all: setup_lychee setup_mdlint ## Install all tooling (lychee + node + mar
 
 
 check_links: ## Check links with lychee
-	if command -v lychee > /dev/null 2>&1; then
-		lychee --config lychee.toml .
-	else
+	if ! command -v lychee > /dev/null 2>&1; then
 		echo "lychee not installed — run: make setup_lychee"
 		exit 1
+	fi
+	if [ ! -f lychee.toml ]; then
+		echo "lychee.toml not found — running without config"
+		lychee .
+	else
+		lychee --config lychee.toml .
 	fi
 
 check_docs: ## Lint markdown files (reads .markdownlint.json)

--- a/docs/cc-native/CC-first-party-docs-index.md
+++ b/docs/cc-native/CC-first-party-docs-index.md
@@ -2,8 +2,8 @@
 title: CC First-Party Documentation Index
 purpose: Canonical Anthropic URLs for CC, Agent SDK, Anthropic SDK, API, and best practices.
 created: 2026-03-28
-updated: 2026-03-28
-validated_links: 2026-03-28
+updated: 2026-04-13
+validated_links: 2026-04-13
 ---
 
 ## CC First-Party Documentation Index
@@ -14,11 +14,21 @@ validated_links: 2026-03-28
 |-------|-----|
 | Overview | <https://code.claude.com/docs/en/overview> |
 | Quickstart | <https://code.claude.com/docs/en/quickstart> |
+| How Claude Code works | <https://code.claude.com/docs/en/how-claude-code-works> |
+| CLI reference | <https://code.claude.com/docs/en/cli-reference> |
+| .claude directory | <https://code.claude.com/docs/en/claude-directory> |
 | Memory (CLAUDE.md) | <https://code.claude.com/docs/en/memory> |
 | Hooks system | <https://code.claude.com/docs/en/hooks-guide> |
 | Settings & configuration | <https://code.claude.com/docs/en/settings> |
+| Permission modes | <https://code.claude.com/docs/en/permission-modes> |
+| Common workflows | <https://code.claude.com/docs/en/common-workflows> |
+| Headless mode | <https://code.claude.com/docs/en/headless> |
+| Sub-agents | <https://code.claude.com/docs/en/sub-agents> |
 | Agent Teams | <https://code.claude.com/docs/en/agent-teams> |
 | MCP integration | <https://code.claude.com/docs/en/mcp> |
+| Plugins reference | <https://code.claude.com/docs/en/plugins-reference> |
+| Channels | <https://code.claude.com/docs/en/channels> |
+| Chrome extension | <https://code.claude.com/docs/en/chrome> |
 | LLMs.txt | <https://code.claude.com/docs/llms.txt> |
 
 ## Agent SDK (platform.claude.com)

--- a/docs/cc-native/agents-skills/CC-agent-teams-orchestration.md
+++ b/docs/cc-native/agents-skills/CC-agent-teams-orchestration.md
@@ -424,6 +424,11 @@ Coordinator Mode and Agent Teams are complementary:
 
 Cross-ref: [CC-community-reimplementations-landscape.md](../../cc-community/CC-community-reimplementations-landscape.md) — CLAURST documents Coordinator Mode phases and tool registry; [zread.ai Coordinator Mode walkthrough][zread-coordinator] — community breakdown of the unreleased mode.
 
+### Cross-References
+
+- [CC-cli-reference.md](../configuration/CC-cli-reference.md) — canonical flag definitions (`--agent`, `--agents`, `--teammate-mode`, `--worktree`)
+- [CC-subagent-session-artifacts.md](../sessions/CC-subagent-session-artifacts.md) — subagent worktree lifecycle, meta.json, transcript storage
+
 ### Sources
 
 | Source | Author | Key Content |

--- a/docs/cc-native/agents-skills/CC-recursive-spawning-patterns.md
+++ b/docs/cc-native/agents-skills/CC-recursive-spawning-patterns.md
@@ -116,6 +116,11 @@ harness (Ralph) calling `claude -p` with
 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` per iteration, but each iteration's
 teams are independent.
 
+## Cross-References
+
+- [CC-cli-reference.md](../configuration/CC-cli-reference.md) — canonical flag definitions (`-p`, `--output-format`)
+- [CC-subagent-session-artifacts.md](../sessions/CC-subagent-session-artifacts.md) — subagent worktree lifecycle, meta.json, transcript storage
+
 ## Sources
 
 | Source | Content |

--- a/docs/cc-native/ci-remote/CC-cloud-sessions-analysis.md
+++ b/docs/cc-native/ci-remote/CC-cloud-sessions-analysis.md
@@ -122,6 +122,8 @@ Revisit when:
 
 ## See Also
 
+For canonical CLI flag definitions (`--remote`, `--teleport`, `--permission-mode`), see [CC-cli-reference.md](../configuration/CC-cli-reference.md).
+
 For authentication setup (GitHub connection, API keys, headless usage), see [CC-web-auth-setup-analysis.md](CC-web-auth-setup-analysis.md).
 
 For external sandbox platforms (OpenSandbox, E2B, Sprites.dev) that provide

--- a/docs/cc-native/ci-remote/CC-github-actions-analysis.md
+++ b/docs/cc-native/ci-remote/CC-github-actions-analysis.md
@@ -129,15 +129,11 @@ Aggregate merged PR titles/descriptions, filter for user-facing changes, group b
 
 ### Common `claude_args`
 
+See [CC-cli-reference.md](../configuration/CC-cli-reference.md) for canonical flag definitions. Common flags used in GHA workflows:
+
 ```yaml
 claude_args: "--max-turns 5 --model claude-sonnet-4-6 --mcp-config /path/to/config.json"
 ```
-
-- `--max-turns`: Maximum conversation turns (default: 10)
-- `--model`: Model selection (e.g., `claude-sonnet-4-6`, `claude-opus-4-6`)
-- `--mcp-config`: Path to MCP server configuration
-- `--allowed-tools`: Comma-separated tool allowlist
-- `--append-system-prompt`: Additional system instructions
 
 ### Migration from Beta to v1
 
@@ -276,6 +272,7 @@ A Python composite GHA addressing all four gaps is planned at [qte77/gha-issue-t
 
 ## Cross-References
 
+- CLI flag definitions (`--max-turns`, `--model`, `--mcp-config`, `--allowedTools`, `--append-system-prompt`) — [CC-cli-reference.md](../configuration/CC-cli-reference.md)
 - Version pinning and self-hosted runners for GHA — [CC-version-pinning-resilience.md](CC-version-pinning-resilience.md#github-actions)
 - Official plugins (Code Review, Security Guidance) — [CC-official-plugins-landscape.md](../plugins-ecosystem/CC-official-plugins-landscape.md)
 - Bash tool behavior inside GHA — [CC-bash-mode-analysis.md](../configuration/CC-bash-mode-analysis.md)

--- a/docs/cc-native/configuration/CC-binary-architecture.md
+++ b/docs/cc-native/configuration/CC-binary-architecture.md
@@ -2,8 +2,8 @@
 title: CC Binary Architecture
 purpose: Analysis of Claude Code CLI binary and VS Code extension internals — build system, shared codebase proof, internal API endpoints, model IDs, directory map, /stats data flow, /voice timeline.
 created: 2026-03-29
-updated: 2026-03-30
-validated_links: 2026-03-30
+updated: 2026-04-13
+validated_links: 2026-04-13
 ---
 
 **Status**: Research (informational)
@@ -178,7 +178,7 @@ Direct observation, Codespaces, 2026-03-29.
 | Path | Purpose | Evidence |
 |---|---|---|
 | `projects/<hash>/` | Transcripts (`.jsonl`), tool results, subagent logs, memory | Direct observation |
-| `sessions/*.json` | Session index: PID, sessionId, cwd, startedAt, name | Direct observation |
+| `sessions/<pid>.json` | Session index keyed by PID. Fields: `sessionId`, `cwd`, `startedAt`, `name`. **Not listed** in first-party [.claude directory cleanup tables](https://code.claude.com/docs/en/claude-directory#application-data) — appears in neither "cleaned automatically" nor "kept until you delete". Cleanup lifecycle undocumented. Observation: Opus 4.6, 2026-04-13 | Direct observation |
 | `plans/` | Plan mode output files | Verified — `plansDirectory` setting |
 | `file-history/<session>/` | File checkpoints for rewind feature (`fileCheckpointingEnabled`) | Direct observation |
 | `history.jsonl` | User command history with timestamps and session IDs | Direct observation |
@@ -195,7 +195,7 @@ Direct observation, Codespaces, 2026-03-29.
 | `telemetry/` | OTel export staging. **Empty unless `CLAUDE_CODE_ENABLE_TELEMETRY=1`** | Binary: `lH(process.env.CLAUDE_CODE_ENABLE_TELEMETRY)`. Exports at 300s intervals. See [monitoring docs][monitoring] |
 | `session-env/<session>/` | Per-session environment snapshots | Direct observation |
 | `shell-snapshots/` | Bash shell state snapshots (aliases, functions) | Direct observation |
-| `plugins/` | Plugin cache, blocklist, marketplace metadata | Rebuilt on install |
+| `plugins/` | Plugin cache, blocklist, marketplace metadata. Contains `installed_plugins.json` with `projectPath` entries scoping installs to projects — stale paths cause plugins to silently stop loading for that project. See [plugins reference](https://code.claude.com/docs/en/plugins-reference). Observation: Opus 4.6, 2026-04-13 | Rebuilt on install |
 | `mcp-needs-auth-cache.json` | MCP auth state cache | Transient |
 
 ### Not in `~/.claude/` (stored elsewhere)

--- a/docs/cc-native/configuration/CC-changelog-feature-scan.md
+++ b/docs/cc-native/configuration/CC-changelog-feature-scan.md
@@ -179,22 +179,7 @@ On March 30 2026, [Boris Cherny](https://www.threads.com/@boris_cherny/) (Head o
 
 ### CLI Quick Reference
 
-| Flag/Command | Purpose |
-|---|---|
-| `--teleport` / `/teleport` | Pull cloud session to local |
-| `/remote-control` | Control local from browser/phone |
-| `/loop <interval> <cmd>` | Recurring automation (max 1 week) |
-| `/schedule` | Cron-like scheduling |
-| `/branch` | Fork current session |
-| `--fork-session` | Fork when resuming |
-| `-r <id>` | Resume prior session |
-| `/btw <question>` | Side question without interrupting |
-| `-w` | Start in git worktree |
-| `/batch` | Parallel fan-out to worktree agents |
-| `--bare` | Skip config (10x faster) |
-| `--add-dir <path>` | Grant access to additional dirs |
-| `--agent=<name>` | Load custom agent from `.claude/agents/` |
-| `/voice` | Voice input |
+See [CC-cli-reference.md](CC-cli-reference.md) for canonical flag definitions. See [CC-tools-inventory.md](CC-tools-inventory.md) for slash commands.
 
 ### Sources
 

--- a/docs/cc-native/configuration/CC-cli-reference.md
+++ b/docs/cc-native/configuration/CC-cli-reference.md
@@ -1,0 +1,224 @@
+---
+title: CC CLI Reference
+purpose: Single canonical reference for all claude CLI flags, subcommands, and constraints. Other docs cross-ref here for flag definitions.
+created: 2026-04-13
+updated: 2026-04-13
+validated_links: 2026-04-13
+---
+
+**Status**: Adopt
+
+## What It Is
+
+Complete reference for the `claude` CLI. Sourced from the [official CLI reference][cli-ref] and `claude --help` (Opus 4.6). The official docs note that `--help` does not list every flag — this document covers both.
+
+For env vars see [CC-env-vars-reference.md](CC-env-vars-reference.md). For tools see [CC-tools-inventory.md](CC-tools-inventory.md).
+
+## Subcommands
+
+| Command | Description | Source |
+|---|---|---|
+| `claude` | Start interactive session | [cli-ref][cli-ref] |
+| `claude "query"` | Start with initial prompt | [cli-ref][cli-ref] |
+| `claude -p "query"` | Print mode (non-interactive), then exit | [cli-ref][cli-ref] |
+| `cat file \| claude -p "query"` | Process piped content | [cli-ref][cli-ref] |
+| `claude auth login` | Sign in. Accepts `--email`, `--sso`, `--console` | [auth][auth] |
+| `claude auth logout` | Sign out | [cli-ref][cli-ref] |
+| `claude auth status` | Auth status as JSON. `--text` for human-readable | [cli-ref][cli-ref] |
+| `claude agents` | List configured subagents by source | [cli-ref][cli-ref] |
+| `claude auto-mode defaults` | Print built-in auto-mode classifier rules as JSON | [auto-mode][auto-mode] |
+| `claude auto-mode config` | Show effective auto-mode config with settings applied | [auto-mode][auto-mode] |
+| `claude mcp` | Configure MCP servers | [mcp][mcp] |
+| `claude plugin` | Manage plugins. Alias: `claude plugins` | [plugins-ref][plugins-ref] |
+| `claude remote-control` | Start Remote Control server (no local session) | [remote-control][remote-control] |
+| `claude setup-token` | Generate long-lived OAuth token for CI/scripts | [auth][auth] |
+| `claude update` | Update to latest version | [cli-ref][cli-ref] |
+| `claude doctor` | Health check for auto-updater | [cli-ref][cli-ref] |
+| `claude install [target]` | Install native build (`stable`, `latest`, or version) | [cli-ref][cli-ref] |
+
+**Analysis**: [CC-version-pinning-resilience.md](../ci-remote/CC-version-pinning-resilience.md), [CC-web-auth-setup-analysis.md](../ci-remote/CC-web-auth-setup-analysis.md)
+
+## Session Flags
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `-c`, `--continue` | Resume most recent conversation in current directory | — | [cli-ref][cli-ref] |
+| `-r`, `--resume` | Resume session by ID or name, or show picker | — | [cli-ref][cli-ref] |
+| `--fork-session` | Create new session ID when resuming | With `--resume` or `--continue` | [cli-ref][cli-ref] |
+| `-n`, `--name` | Set display name (shown in `/resume`, terminal title) | — | [cli-ref][cli-ref] |
+| `--from-pr` | Resume sessions linked to a GitHub PR by number or URL | — | [cli-ref][cli-ref] |
+| `--session-id` | Use a specific UUID for the session | Must be valid UUID | [cli-ref][cli-ref] |
+| `--no-session-persistence` | Don't save session to disk | `--print` only | [cli-ref][cli-ref] |
+
+**Analysis**: [CC-session-lifecycle-analysis.md](../sessions/CC-session-lifecycle-analysis.md)
+
+## Output & Format Flags
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `-p`, `--print` | Non-interactive mode — print response and exit | — | [cli-ref][cli-ref] |
+| `--output-format` | Output format: `text` (default), `json`, `stream-json` | `--print` only | [cli-ref][cli-ref] |
+| `--input-format` | Input format: `text` (default), `stream-json` | `--print` only | [cli-ref][cli-ref] |
+| `--include-partial-messages` | Include partial streaming events in output | `--print` + `--output-format stream-json` | [cli-ref][cli-ref] |
+| `--include-hook-events` | Include hook lifecycle events in output stream | `--output-format stream-json` | [cli-ref][cli-ref] |
+| `--replay-user-messages` | Echo user messages from stdin back on stdout | `--input-format stream-json` + `--output-format stream-json` | [cli-ref][cli-ref] |
+| `--json-schema` | Validate final output against a JSON Schema | `--print` only | [structured-output][structured-output] |
+| `--verbose` | Enable verbose logging, full turn-by-turn output | — | [cli-ref][cli-ref] |
+
+**Analysis**: [CC-print-mode-gotchas.md](../sessions/CC-print-mode-gotchas.md), [CC-stream-json-protocol.md](CC-stream-json-protocol.md)
+
+## Model & Execution Flags
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--model` | Model alias (`sonnet`, `opus`) or full ID | — | [model-config][model-config] |
+| `--effort` | Reasoning effort: `low`, `medium`, `high`, `max` (Opus 4.6 only) | Session-scoped, not persisted | [model-config][model-config] |
+| `--fallback-model` | Auto-fallback model when primary is overloaded | `--print` only | [cli-ref][cli-ref] |
+| `--max-turns` | Limit agentic turns; exits with error when reached | `--print` only | [cli-ref][cli-ref] |
+| `--max-budget-usd` | Maximum dollar spend before stopping | `--print` only | [cli-ref][cli-ref] |
+| `--betas` | Beta headers for API requests | API key users only | [cli-ref][cli-ref] |
+
+**Analysis**: [CC-model-provider-configuration.md](CC-model-provider-configuration.md), [CC-fast-mode-analysis.md](CC-fast-mode-analysis.md), [CC-session-cost-analysis.md](../sessions/CC-session-cost-analysis.md)
+
+## System Prompt Flags
+
+`--system-prompt` and `--system-prompt-file` are mutually exclusive. Append flags can combine with either replacement flag. For most use cases, prefer append to preserve built-in capabilities.
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--system-prompt` | Replace entire default system prompt | Mutually exclusive with `--system-prompt-file` | [cli-ref][cli-ref] |
+| `--system-prompt-file` | Replace with file contents | Mutually exclusive with `--system-prompt` | [cli-ref][cli-ref] |
+| `--append-system-prompt` | Append text to default prompt | — | [cli-ref][cli-ref] |
+| `--append-system-prompt-file` | Append file contents to default prompt | — | [cli-ref][cli-ref] |
+| `--exclude-dynamic-system-prompt-sections` | Move per-machine sections to first user message for better prompt-cache reuse | Ignored with `--system-prompt`/`--system-prompt-file` | [cli-ref][cli-ref] |
+
+**Analysis**: [CC-prompt-caching-behavior.md](../context-memory/CC-prompt-caching-behavior.md)
+
+## Security & Permissions Flags
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--permission-mode` | Start in mode: `default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions` | Overrides `defaultMode` from settings | [permission-modes][permission-modes] |
+| `--dangerously-skip-permissions` | Skip all permission prompts (alias for `--permission-mode bypassPermissions`) | — | [permission-modes][permission-modes] |
+| `--allow-dangerously-skip-permissions` | Add `bypassPermissions` to Shift+Tab cycle without starting in it | — | [permission-modes][permission-modes] |
+| `--enable-auto-mode` | Unlock auto mode in Shift+Tab cycle | Team/Enterprise/API plan + Sonnet 4.6 or Opus 4.6 | [auto-mode][auto-mode] |
+| `--permission-prompt-tool` | MCP tool to handle permission prompts non-interactively | Non-interactive mode | [cli-ref][cli-ref] |
+| `--allowedTools` | Tools that execute without permission prompts | [Permission rule syntax][perm-syntax] | [cli-ref][cli-ref] |
+| `--disallowedTools` | Tools removed from model context entirely | — | [cli-ref][cli-ref] |
+| `--tools` | Restrict available built-in tools (`""`, `"default"`, or tool names) | — | [cli-ref][cli-ref] |
+
+**Analysis**: [CC-permissions-bypass-analysis.md](../sandboxing/CC-permissions-bypass-analysis.md), [CC-tools-inventory.md](CC-tools-inventory.md)
+
+## Plugins & MCP Flags
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--mcp-config` | Load MCP servers from JSON files or strings | Space-separated | [mcp][mcp] |
+| `--strict-mcp-config` | Only use MCP servers from `--mcp-config`, ignore all others | — | [cli-ref][cli-ref] |
+| `--plugin-dir` | Load plugins from directory (repeatable) | Session only | [cli-ref][cli-ref] |
+| `--channels` | MCP server channel notifications to listen for | Research preview; requires Claude.ai auth | [channels][channels] |
+| `--dangerously-load-development-channels` | Enable non-allowlisted channels for local dev | Prompts for confirmation | [channels-ref][channels-ref] |
+| `--chrome` | Enable Chrome browser integration | — | [chrome][chrome] |
+| `--no-chrome` | Disable Chrome browser integration | — | [chrome][chrome] |
+
+**Analysis**: [CC-chrome-extension-analysis.md](../plugins-ecosystem/CC-chrome-extension-analysis.md), [CC-plugin-packaging-research.md](../plugins-ecosystem/CC-plugin-packaging-research.md), [CC-channels-analysis.md](../plugins-ecosystem/CC-channels-analysis.md)
+
+## Agent & Worktree Flags
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--agent` | Specify agent for the session (overrides `agent` setting) | — | [cli-ref][cli-ref] |
+| `--agents` | Define custom subagents via JSON (same fields as frontmatter + `prompt`) | — | [sub-agents][sub-agents] |
+| `--teammate-mode` | Agent team display: `auto` (default), `in-process`, `tmux` | — | [agent-teams][agent-teams] |
+| `-w`, `--worktree` | Start in isolated git worktree (optional name) | — | [worktrees][worktrees] |
+| `--tmux` | Create tmux session for worktree; `--tmux=classic` for traditional tmux | Requires `--worktree` | [cli-ref][cli-ref] |
+
+**Analysis**: [CC-agent-teams-orchestration.md](../agents-skills/CC-agent-teams-orchestration.md), [CC-recursive-spawning-patterns.md](../agents-skills/CC-recursive-spawning-patterns.md)
+
+## Remote & Cloud Flags
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--remote` | Create new web session on claude.ai with task description | — | [web-sessions][web-sessions] |
+| `--teleport` | Resume a web session in local terminal | — | [web-sessions][web-sessions] |
+| `--remote-control`, `--rc` | Start interactive session with Remote Control enabled | Optional name argument | [remote-control][remote-control] |
+| `--remote-control-session-name-prefix` | Prefix for auto-generated Remote Control session names | Defaults to hostname | [remote-control][remote-control] |
+
+**Analysis**: [CC-cloud-sessions-analysis.md](../ci-remote/CC-cloud-sessions-analysis.md), [CC-remote-control-analysis.md](../ci-remote/CC-remote-control-analysis.md)
+
+## Configuration Flags
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--bare` | Minimal mode: skip hooks, plugins, MCP, auto memory, CLAUDE.md. Sets `CLAUDE_CODE_SIMPLE` | — | [bare-mode][bare-mode] |
+| `--settings` | Load additional settings from JSON file or string | — | [cli-ref][cli-ref] |
+| `--setting-sources` | Comma-separated sources to load: `user`, `project`, `local` | — | [cli-ref][cli-ref] |
+| `--add-dir` | Grant file access to additional directories | Most `.claude/` config not discovered from these | [permissions][permissions] |
+| `--disable-slash-commands` | Disable all skills and commands for session | — | [cli-ref][cli-ref] |
+
+**Analysis**: [CC-print-mode-gotchas.md](../sessions/CC-print-mode-gotchas.md)
+
+## Initialization Flags
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--init` | Run initialization hooks and start interactive mode | — | [cli-ref][cli-ref] |
+| `--init-only` | Run initialization hooks and exit (no session) | — | [cli-ref][cli-ref] |
+| `--maintenance` | Run maintenance hooks and start interactive mode | — | [cli-ref][cli-ref] |
+
+**Analysis**: [CC-hooks-system-analysis.md](CC-hooks-system-analysis.md)
+
+## Debug & Diagnostics Flags
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--debug` | Enable debug mode with optional category filter (e.g. `"api,hooks"`, `"!statsig,!file"`) | — | [cli-ref][cli-ref] |
+| `--debug-file` | Write debug logs to file (implicitly enables debug) | Takes precedence over `CLAUDE_CODE_DEBUG_LOGS_DIR` | [cli-ref][cli-ref] |
+| `-v`, `--version` | Print version number | — | [cli-ref][cli-ref] |
+
+## IDE Flag
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--ide` | Auto-connect to IDE if exactly one valid IDE is available | — | [cli-ref][cli-ref] |
+
+**Analysis**: [CC-ide-integration-protocol.md](CC-ide-integration-protocol.md)
+
+## File Resources Flag
+
+| Flag | Description | Constraints | Source |
+|---|---|---|---|
+| `--file` | Download file resources at startup. Format: `file_id:relative_path` | Repeatable | [cli-ref][cli-ref] |
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [CC CLI reference][cli-ref] | Authoritative flag and subcommand documentation |
+| [CC settings][settings] | `settings.json` keys, permission rules |
+| [CC env vars][env-vars] | Environment variables reference |
+| [CC tools reference][tools-ref] | Built-in tool descriptions and permissions |
+| `claude --help` (Opus 4.6, 2026-04-13) | Runtime flag listing (subset of full reference) |
+
+[cli-ref]: https://code.claude.com/docs/en/cli-reference
+[auth]: https://code.claude.com/docs/en/authentication
+[auto-mode]: https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode
+[permission-modes]: https://code.claude.com/docs/en/permission-modes
+[perm-syntax]: https://code.claude.com/docs/en/settings#permission-rule-syntax
+[permissions]: https://code.claude.com/docs/en/permissions#additional-directories-grant-file-access-not-configuration
+[model-config]: https://code.claude.com/docs/en/model-config
+[mcp]: https://code.claude.com/docs/en/mcp
+[plugins-ref]: https://code.claude.com/docs/en/plugins-reference#cli-commands-reference
+[channels]: https://code.claude.com/docs/en/channels
+[channels-ref]: https://code.claude.com/docs/en/channels-reference#test-during-the-research-preview
+[chrome]: https://code.claude.com/docs/en/chrome
+[remote-control]: https://code.claude.com/docs/en/remote-control
+[web-sessions]: https://code.claude.com/docs/en/claude-code-on-the-web
+[sub-agents]: https://code.claude.com/docs/en/sub-agents
+[agent-teams]: https://code.claude.com/docs/en/agent-teams
+[worktrees]: https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees
+[bare-mode]: https://code.claude.com/docs/en/headless#start-faster-with-bare-mode
+[structured-output]: https://code.claude.com/docs/en/agent-sdk/structured-outputs
+[settings]: https://code.claude.com/docs/en/settings
+[env-vars]: https://code.claude.com/docs/en/env-vars
+[tools-ref]: https://code.claude.com/docs/en/tools-reference

--- a/docs/cc-native/configuration/CC-env-vars-reference.md
+++ b/docs/cc-native/configuration/CC-env-vars-reference.md
@@ -2,8 +2,8 @@
 title: CC Environment Variables Reference
 purpose: Consolidated reference for CLAUDE_CODE_* and related env vars relevant to autonomous agent workflows, including undocumented vars from binary string extraction.
 created: 2026-03-27
-updated: 2026-04-04
-validated_links: 2026-04-04
+updated: 2026-04-13
+validated_links: 2026-04-13
 ---
 
 **Status**: Adopt
@@ -100,6 +100,18 @@ Variables can be set via (in priority order, per [settings docs][settings]):
 4. **`settings.json` `env` block** — persistent per-project or user-level
 
 See [examples/settings.json](../examples/settings.json) for a working `env` block.
+
+### MCP servers and PATH
+
+MCP servers and hook commands are spawned from Claude Code's own process environment — **not** via a login shell. Shell profile files (`.bashrc`, `.zshrc`, `.profile`) are not sourced. If a tool binary (e.g., `npx`, `node`) is installed to a non-standard location, it must be either:
+
+1. Symlinked to a directory already in CC's inherited `PATH` (e.g., `~/.local/bin/`)
+2. Added via the `env` block in `settings.json`: `"PATH": "/custom/bin:${PATH}"`
+3. Specified as an absolute path in the MCP server `command` field
+
+This commonly affects user-local Node.js installs (e.g., `~/.local/share/node/bin/`) that rely on `.bashrc` PATH additions. MCP servers using `npx` will fail with "command not found" unless the symlink or env override is in place.
+
+Source: [CC plugins reference — environment variables](https://code.claude.com/docs/en/plugins-reference), [CC MCP docs](https://code.claude.com/docs/en/mcp). Observation: Opus 4.6, 2026-04-13.
 
 ## Discovery Method
 

--- a/docs/cc-native/configuration/CC-model-provider-configuration.md
+++ b/docs/cc-native/configuration/CC-model-provider-configuration.md
@@ -251,6 +251,11 @@ When routing through gateways, additionally set ([source][cc-settings]):
 | **Enterprise cloud** | Bedrock / Vertex / Foundry | High (cloud config) |
 | **Non-Anthropic models in CC** | LiteLLM or claude-code-proxy | Medium (proxy) |
 
+## Cross-References
+
+- [CC-cli-reference.md](CC-cli-reference.md) — canonical flag definitions (`--model`, `--effort`, `--fallback-model`, `--betas`)
+- [CC-env-vars-reference.md](CC-env-vars-reference.md) — env var reference for `ANTHROPIC_MODEL`, `CLAUDE_CODE_EFFORT_LEVEL`, etc.
+
 ## References
 
 - [CC Settings — Environment Variables][cc-settings]

--- a/docs/cc-native/configuration/CC-stream-json-protocol.md
+++ b/docs/cc-native/configuration/CC-stream-json-protocol.md
@@ -73,6 +73,7 @@ claude -p --output-format stream-json "First task" \
 
 ## Cross-References
 
+- [CC-cli-reference.md](CC-cli-reference.md) — canonical flag definitions (`--output-format`, `--input-format`, `--include-partial-messages`, `--verbose`)
 - [CC-print-mode-gotchas.md](../sessions/CC-print-mode-gotchas.md) — headless mode caveats
 - [CC-env-vars-reference.md](CC-env-vars-reference.md) — `CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK`
 

--- a/docs/cc-native/configuration/README.md
+++ b/docs/cc-native/configuration/README.md
@@ -4,6 +4,7 @@ CC configuration features: hooks, model routing, execution modes.
 
 | Document | Content |
 |----------|---------|
+| [CC-cli-reference.md](CC-cli-reference.md) | Canonical CLI flags, subcommands, constraints, first-party URLs |
 | [CC-hooks-system-analysis.md](CC-hooks-system-analysis.md) | Hook lifecycle events and integration patterns |
 | [CC-model-provider-configuration.md](CC-model-provider-configuration.md) | Model and provider configuration options |
 | [CC-fast-mode-analysis.md](CC-fast-mode-analysis.md) | Fast mode behavior and trade-offs |

--- a/docs/cc-native/sandboxing/CC-permissions-bypass-analysis.md
+++ b/docs/cc-native/sandboxing/CC-permissions-bypass-analysis.md
@@ -123,5 +123,6 @@ Bypassing permissions does not bypass the sandbox.
 
 ## See Also
 
+- [CC-cli-reference.md](../configuration/CC-cli-reference.md) — canonical flag definitions (`--dangerously-skip-permissions`, `--permission-mode`, `--allowedTools`)
 - [CC-web-auth-setup-analysis.md](../ci-remote/CC-web-auth-setup-analysis.md) — authentication methods and API key setup for headless/CI
 - [CC-print-mode-gotchas.md](../sessions/CC-print-mode-gotchas.md) — `--bare` auth breakage, stream-json pitfalls

--- a/docs/cc-native/sessions/CC-print-mode-gotchas.md
+++ b/docs/cc-native/sessions/CC-print-mode-gotchas.md
@@ -80,6 +80,8 @@ This is the most reliable approach.
 
 ## Summary Table
 
+See [CC-cli-reference.md](../configuration/CC-cli-reference.md) for canonical flag definitions. This table covers behavioral gotchas only.
+
 | Flag | Purpose | Gotcha |
 |---|---|---|
 | `--output-format stream-json` | Structured per-event output | Requires `--verbose` in `-p` mode |

--- a/docs/cc-native/sessions/CC-session-lifecycle-analysis.md
+++ b/docs/cc-native/sessions/CC-session-lifecycle-analysis.md
@@ -2,8 +2,8 @@
 title: CC Session Lifecycle — Naming, Persistence, and /rename Bugs
 purpose: Analysis of session creation, naming, persistence, /resume discovery, and known /rename bugs with reproduction evidence.
 created: 2026-03-27
-updated: 2026-03-27
-validated_links: 2026-03-27
+updated: 2026-04-13
+validated_links: 2026-04-13
 ---
 
 **Status**: Research
@@ -25,6 +25,8 @@ The `<key>` is derived from the working directory path with `/` replaced by `-` 
 
 **Critical**: `/resume` only lists sessions that have a `.jsonl` file in the per-project directory. Sessions in `history.jsonl` without a corresponding project JSONL are invisible to `/resume`.
 
+**Path migration risk**: Because `<key>` encodes the absolute working directory, moving a repo (e.g., `/home/user/repos/foo` → `/home/user/repos/org/foo`) orphans all project data. CC auto-creates a new project directory on first session from the new path, so a manual `mv` of the old project dir into the already-existing new one causes double nesting. Observation: Opus 4.6, 2026-04-13.
+
 Source: observed CC 2.1.83, Codespaces, 2026-03-27. `history.jsonl` fields: `["display","pastedContents","project","sessionId","timestamp"]`.
 
 ### Session identification fields
@@ -34,11 +36,20 @@ Each JSONL message carries:
 | Field | Purpose | Set by |
 |---|---|---|
 | `sessionId` | UUID, primary key | CC at session start |
+| `cwd` | Working directory path. Validated against current directory on resume — mismatch prevents session from loading | CC at session start |
 | `slug` | Auto-generated display name (e.g., `stateful-dreaming-donut`) | CC auto-title logic |
 | `version` | CC version | CC |
 | `gitBranch` | Current git branch | CC |
 
-Source: per-project JSONL inspection, CC 2.1.83
+The `cwd` field is the key resumability gate: a session may appear in the `/resume` picker but fail to load if the embedded `cwd` doesn't match the current working directory. This is the primary breakage when repos are moved.
+
+Source: per-project JSONL inspection, CC 2.1.83. `cwd` field observation: Opus 4.6, 2026-04-13.
+
+### Session index files
+
+`~/.claude/sessions/<pid>.json` maps PIDs to session metadata (`sessionId`, `cwd`, `startedAt`, `name`). These files are **not listed** in the first-party [.claude directory cleanup tables][claude-directory] — they appear in neither the "cleaned up automatically" nor "kept until you delete" categories. Observed behavior: index files for dead PIDs may be cleaned up, but the exact lifecycle is undocumented. Synthetic entries with fake PIDs survive across sessions.
+
+Source: [CC-binary-architecture.md](../configuration/CC-binary-architecture.md). Cleanup gap observation: Opus 4.6, 2026-04-13.
 
 ## `/rename` Command
 
@@ -129,6 +140,9 @@ Source: [settings docs][settings]
 
 - [CC-session-cost-analysis.md](CC-session-cost-analysis.md) — JSONL structure, usage fields, cost extraction
 - [CC-session-keepalive-analysis.md](CC-session-keepalive-analysis.md) — Session timeout and keepalive strategies
+- [CC-subagent-session-artifacts.md](CC-subagent-session-artifacts.md) — Subagent worktree lifecycle, meta.json, transcript storage
+- [CC-binary-architecture.md](../configuration/CC-binary-architecture.md) — `~/.claude/` directory map, session index files
+- [CC-cli-reference.md](../configuration/CC-cli-reference.md) — `--name`, `--resume`, `--continue` flag details
 
 ## Sources
 
@@ -143,8 +157,11 @@ Source: [settings docs][settings]
 | [#27195][gh-27195] | CLI resume by name fails |
 | [#34360][gh-34360] | `--resume` + `--print` ignores renamed sessions |
 | CC 2.1.83, session `ea0fa2d5`, Codespaces, 2026-03-27 | Slug-not-updated reproduction |
+| [CC .claude directory][claude-directory] | Application data paths and cleanup rules |
+| Opus 4.6, 2026-04-13 | `cwd` field, path migration, session index lifecycle observations |
 
 [commands]: https://code.claude.com/docs/en/commands
+[claude-directory]: https://code.claude.com/docs/en/claude-directory#application-data
 [cli]: https://code.claude.com/docs/en/cli-reference
 [settings]: https://code.claude.com/docs/en/settings
 [gh-25090]: https://github.com/anthropics/claude-code/issues/25090

--- a/docs/cc-native/sessions/CC-subagent-session-artifacts.md
+++ b/docs/cc-native/sessions/CC-subagent-session-artifacts.md
@@ -1,0 +1,106 @@
+---
+title: CC Subagent Session Artifacts
+purpose: Reference for subagent session artifacts — worktree lifecycle, meta.json tombstones, transcript storage, and cleanup behavior.
+created: 2026-04-13
+updated: 2026-04-13
+validated_links: 2026-04-13
+---
+
+**Status**: Research
+
+## What It Is
+
+When Claude Code spawns subagents via the Agent tool, each subagent produces session artifacts: transcripts, worktree directories (if isolated), and metadata files. This doc covers the artifact structure, worktree lifecycle, and cleanup behavior.
+
+## Worktree Isolation
+
+Subagents can run in their own temporary git worktree by setting `isolation: worktree` in the [subagent frontmatter][sub-agents-frontmatter]. Each subagent gets an isolated copy of the repository at `<repo>/.claude/worktrees/agent-<hash>`, branching from the default remote branch (`origin/HEAD`).
+
+Source: [Sub-agents — Supported frontmatter fields][sub-agents-frontmatter], [Common workflows — Subagent worktrees][subagent-worktrees]
+
+## meta.json Structure
+
+Each subagent worktree session produces a `meta.json` alongside its `.jsonl` transcript. This file is a tombstone recording the subagent's configuration:
+
+```json
+{
+  "agentType": "general-purpose",
+  "worktreePath": "<repo>/.claude/worktrees/agent-<hash>",
+  "description": "<task label passed to the Agent tool>"
+}
+```
+
+| Field | Purpose |
+|---|---|
+| `agentType` | Which [built-in subagent type][sub-agents] was used (`general-purpose`, `Explore`, `Plan`, etc.) |
+| `worktreePath` | Absolute path where the temporary worktree was created on disk |
+| `description` | Task label passed to the Agent tool by the parent conversation |
+
+The `worktreePath` is historical only — worktrees are cleaned up on completion (see below). The path is never re-used; it records where the worktree *was*, not where it *is*.
+
+**Note**: meta.json is **not documented** in any first-party source. Structure observed from Opus 4.6 session artifacts, 2026-04-13.
+
+## Transcript Storage
+
+Subagent transcripts are stored alongside the parent session's transcripts:
+
+```text
+~/.claude/projects/<project-key>/<parent-session-id>/subagents/agent-<hash>.jsonl
+```
+
+The `<project-key>` is the working directory path with `/` replaced by `-` (e.g., `-home-user-repos-my-project`). Each `.jsonl` file contains the full subagent conversation: messages, tool calls, and tool results.
+
+Source: [.claude directory — Application data][claude-directory]
+
+## Cleanup Lifecycle
+
+### Worktree cleanup
+
+When a subagent finishes, worktree cleanup depends on whether changes were made:
+
+| Condition | Behavior |
+|---|---|
+| No changes | Worktree + branch auto-removed |
+| Changes or commits exist | Parent session prompted to keep or remove |
+| Orphaned (crash/interrupt) | Auto-removed at startup after [`cleanupPeriodDays`][settings] if no uncommitted changes, untracked files, or unpushed commits |
+
+User-created worktrees (`--worktree` flag) are **never** removed by the automatic sweep — only subagent worktrees.
+
+Source: [Common workflows — Worktree cleanup][worktree-cleanup]
+
+### Transcript cleanup
+
+Subagent transcripts follow the same cleanup as parent session transcripts: deleted at startup once older than [`cleanupPeriodDays`][settings] (default: 30 days).
+
+Source: [.claude directory — Application data][claude-directory], [Settings — cleanupPeriodDays][settings]
+
+### meta.json cleanup
+
+meta.json files are retained alongside the subagent `.jsonl` transcript for history/debugging. They follow the same `cleanupPeriodDays` lifecycle as transcripts.
+
+## Cross-References
+
+- [CC-session-lifecycle-analysis.md](CC-session-lifecycle-analysis.md) — parent session persistence model
+- [CC-agent-teams-orchestration.md](../agents-skills/CC-agent-teams-orchestration.md) — agent teams (multi-session orchestration)
+- [CC-recursive-spawning-patterns.md](../agents-skills/CC-recursive-spawning-patterns.md) — `CLAUDECODE` guard and recursive spawning
+- [CC-tools-inventory.md](../configuration/CC-tools-inventory.md) — Agent tool permissions
+- [CC-cli-reference.md](../configuration/CC-cli-reference.md) — `--worktree` flag details
+- [CC-binary-architecture.md](../configuration/CC-binary-architecture.md) — `~/.claude/` directory map
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [CC sub-agents — frontmatter][sub-agents-frontmatter] | `isolation: worktree` field documentation |
+| [CC common workflows — subagent worktrees][subagent-worktrees] | Subagent worktree behavior |
+| [CC common workflows — worktree cleanup][worktree-cleanup] | Cleanup rules for worktrees |
+| [CC .claude directory][claude-directory] | `~/.claude/` application data and cleanup |
+| [CC settings][settings] | `cleanupPeriodDays` definition |
+| Opus 4.6 session artifacts, 2026-04-13 | meta.json structure observation |
+
+[sub-agents]: https://code.claude.com/docs/en/sub-agents
+[sub-agents-frontmatter]: https://code.claude.com/docs/en/sub-agents#supported-frontmatter-fields
+[subagent-worktrees]: https://code.claude.com/docs/en/common-workflows#subagent-worktrees
+[worktree-cleanup]: https://code.claude.com/docs/en/common-workflows#worktree-cleanup
+[claude-directory]: https://code.claude.com/docs/en/claude-directory#application-data
+[settings]: https://code.claude.com/docs/en/settings#available-settings

--- a/docs/cc-native/sessions/README.md
+++ b/docs/cc-native/sessions/README.md
@@ -8,4 +8,5 @@ Session lifecycle, persistence, cost analysis, and headless mode.
 | [CC-session-lifecycle-analysis.md](CC-session-lifecycle-analysis.md) | Session naming, /rename bugs, persistence model |
 | [CC-session-keepalive-analysis.md](CC-session-keepalive-analysis.md) | Session timeout and keepalive strategies |
 | [CC-print-mode-gotchas.md](CC-print-mode-gotchas.md) | `claude -p` headless mode pitfalls |
+| [CC-subagent-session-artifacts.md](CC-subagent-session-artifacts.md) | Subagent worktree lifecycle, meta.json, transcript storage, cleanup |
 | [CC-error-messages-reference.md](CC-error-messages-reference.md) | Error catalog: usage limits, login, capacity, BUDDY companion |


### PR DESCRIPTION
## Summary

- **CC-cli-reference.md**: canonical single-source reference for ~50 CLI flags and 16 subcommands with first-party URLs and bidirectional back-ref footers to analysis docs
- **CC-subagent-session-artifacts.md**: worktree isolation lifecycle, meta.json tombstone structure, transcript storage, cleanup rules (meta.json flagged as undocumented observation)
- **CC-first-party-docs-index.md**: 10 newly validated URLs added (cli-reference, claude-directory, sub-agents, common-workflows, permission-modes, headless, plugins-reference, channels, chrome, how-claude-code-works)
- **Session lifecycle + binary architecture enrichment**: cwd field as resumability gate, path migration risk, session index lifecycle gap, installed_plugins.json projectPath scoping
- **Makefile**: OS/arch detection (macOS brew, Linux x86_64/aarch64) for setup_node and setup_lychee; lychee.toml existence guard

## Validation

- lychee: 121 links, 0 errors, 16 redirects (normal)
- markdownlint-cli2: 0 errors across all 5 modified/new docs
- All first-party URLs validated 2026-04-13

## Follow-up (separate PR)

Dedup audit: strip inline flag definitions from ~12 analysis docs and replace with cross-refs to CC-cli-reference.md

## Test plan

- [ ] `make check_links` passes
- [ ] `make check_docs` passes
- [ ] Cross-ref links navigate correctly (forward and back)
- [ ] `make setup_lychee` and `make setup_node` work on macOS (if available)

Generated with Claude <noreply@anthropic.com>