### PR TITLE
docs: Remote Control prerequisites, env blockers, server mode flags

### DIFF
--- a/docs/cc-native/ci-remote/CC-remote-control-analysis.md
+++ b/docs/cc-native/ci-remote/CC-remote-control-analysis.md
@@ -3,8 +3,8 @@ title: CC Remote Control Analysis
 source: https://code.claude.com/docs/en/remote-control
 purpose: Analysis of Claude Code Remote Control for mobile monitoring of long-running CC sessions and cross-device session continuity.
 created: 2026-03-07
-updated: 2026-03-12
-validated_links: 2026-03-12
+updated: 2026-04-13
+validated_links: 2026-04-13
 ---
 
 **Status**: Generally available (all plans)
@@ -34,7 +34,17 @@ claude remote-control --sandbox  # Enable filesystem/network sandboxing
 /rc
 ```
 
-Press spacebar to show QR code for quick phone access. Session URL is displayed for browser access.
+Server mode flags ([source][cc-rc]):
+
+| Flag | Description |
+|---|---|
+| `--name "My Project"` | Custom session title visible in claude.ai/code session list |
+| `--spawn <mode>` | `same-dir` (default), `worktree` (isolated per session), `session` (single-session, rejects others) |
+| `--capacity <N>` | Max concurrent sessions (default: 32; not with `--spawn=session`) |
+| `--verbose` | Detailed connection and session logs |
+| `--sandbox` / `--no-sandbox` | Enable/disable filesystem and network sandboxing (off by default) |
+
+Press spacebar to show QR code for quick phone access. Press `w` to toggle between `same-dir` and `worktree` spawn modes at runtime. Session URL is displayed for browser access.
 
 To download the Claude mobile app, use the `/mobile` slash command inside Claude Code — it displays a QR code for iOS/Android ([source][cc-rc-guide]).
 
@@ -54,9 +64,41 @@ Enable for all sessions automatically:
 
 ### Requirements
 
-- **Plans**: Pro, Max, Team, Enterprise (Team/Enterprise: admin must enable CC) ([source][cc-rc])
-- **Auth**: Must be logged in via `/login` ([source][cc-rc])
-- **Workspace trust**: Must have accepted workspace trust dialog at least once ([source][cc-rc])
+| Requirement | Detail | Source |
+|---|---|---|
+| **Plan** | Pro, Max, Team, Enterprise. API-key-only billing does not qualify | [rc][cc-rc] |
+| **Auth** | OAuth via `/login` — API keys and `setup-token` long-lived tokens are not supported | [rc][cc-rc] |
+| **Team/Enterprise admin** | Admin must enable Remote Control toggle at `claude.ai/admin-settings/claude-code` (off by default) | [rc][cc-rc] |
+| **Version** | CC v2.1.51+ | [rc][cc-rc] |
+| **Workspace trust** | Must have run `claude` in the project dir at least once to accept the trust dialog | [rc][cc-rc] |
+
+### Environment Variable Blockers
+
+These env vars **break the Remote Control eligibility check** and cause "Remote Control is not yet enabled for your account" ([source][cc-rc]):
+
+| Variable | Effect on Remote Control |
+|---|---|
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | **Blocks** — blanket flag that includes telemetry suppression; eligibility check goes through this path |
+| `DISABLE_TELEMETRY` | **Blocks** — eligibility check fails when telemetry is suppressed |
+| `CLAUDE_CODE_USE_BEDROCK` | **Blocks** — Remote Control requires claude.ai auth, not third-party providers |
+| `CLAUDE_CODE_USE_VERTEX` | **Blocks** — same reason |
+| `CLAUDE_CODE_USE_FOUNDRY` | **Blocks** — same reason |
+
+**Workaround**: Replace `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` with the individual flags that don't block Remote Control:
+
+```json
+{
+  "env": {
+    "DISABLE_AUTOUPDATER": "1",
+    "DISABLE_FEEDBACK_COMMAND": "1",
+    "DISABLE_ERROR_REPORTING": "1"
+  }
+}
+```
+
+This preserves most traffic reduction while keeping Remote Control functional. Omit `DISABLE_TELEMETRY` — that's the specific flag that blocks the eligibility check.
+
+Cross-ref: [CC-env-vars-reference.md](../configuration/CC-env-vars-reference.md) for full variable definitions
 
 ### Limitations
 

--- a/docs/cc-native/ci-remote/CC-remote-control-analysis.md
+++ b/docs/cc-native/ci-remote/CC-remote-control-analysis.md
@@ -34,7 +34,7 @@ claude remote-control --sandbox  # Enable filesystem/network sandboxing
 /rc
 ```
 
-Server mode flags ([source][cc-rc]):
+Server mode flags ([source][cc-rc-start]):
 
 | Flag | Description |
 |---|---|
@@ -66,15 +66,15 @@ Enable for all sessions automatically:
 
 | Requirement | Detail | Source |
 |---|---|---|
-| **Plan** | Pro, Max, Team, Enterprise. API-key-only billing does not qualify | [rc][cc-rc] |
-| **Auth** | OAuth via `/login` — API keys and `setup-token` long-lived tokens are not supported | [rc][cc-rc] |
-| **Team/Enterprise admin** | Admin must enable Remote Control toggle at `claude.ai/admin-settings/claude-code` (off by default) | [rc][cc-rc] |
+| **Plan** | Pro, Max, Team, Enterprise. API-key-only billing does not qualify | [requirements][cc-rc-req] |
+| **Auth** | OAuth via `/login` — API keys and `setup-token` long-lived tokens are not supported | [requirements][cc-rc-req], [troubleshooting][cc-rc-troubleshoot] |
+| **Team/Enterprise admin** | Admin must enable Remote Control toggle at `claude.ai/admin-settings/claude-code` (off by default) | [requirements][cc-rc-req], [troubleshooting][cc-rc-troubleshoot] |
 | **Version** | CC v2.1.51+ | [rc][cc-rc] |
-| **Workspace trust** | Must have run `claude` in the project dir at least once to accept the trust dialog | [rc][cc-rc] |
+| **Workspace trust** | Must have run `claude` in the project dir at least once to accept the trust dialog | [requirements][cc-rc-req] |
 
 ### Environment Variable Blockers
 
-These env vars **break the Remote Control eligibility check** and cause "Remote Control is not yet enabled for your account" ([source][cc-rc]):
+These env vars **break the Remote Control eligibility check** and cause "Remote Control is not yet enabled for your account" ([source][cc-rc-troubleshoot]):
 
 | Variable | Effect on Remote Control |
 |---|---|
@@ -97,6 +97,23 @@ These env vars **break the Remote Control eligibility check** and cause "Remote 
 ```
 
 This preserves most traffic reduction while keeping Remote Control functional. Omit `DISABLE_TELEMETRY` — that's the specific flag that blocks the eligibility check.
+
+**Per-project override**: If `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` is set globally in `~/.claude/settings.json`, override it at project level in `.claude/settings.local.json` (gitignored):
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "",
+    "DISABLE_AUTOUPDATER": "1",
+    "DISABLE_FEEDBACK_COMMAND": "1",
+    "DISABLE_ERROR_REPORTING": "1"
+  }
+}
+```
+
+Project-level env vars override user-level per [settings scope precedence][cc-settings].
+
+Source: [CC settings — configuration scopes][cc-settings]
 
 Cross-ref: [CC-env-vars-reference.md](../configuration/CC-env-vars-reference.md) for full variable definitions
 
@@ -149,7 +166,11 @@ loop_remote:
 - [CC Security][cc-sec]
 
 [cc-rc]: https://code.claude.com/docs/en/remote-control
+[cc-rc-req]: https://code.claude.com/docs/en/remote-control#requirements
+[cc-rc-start]: https://code.claude.com/docs/en/remote-control#start-a-remote-control-session
+[cc-rc-troubleshoot]: https://code.claude.com/docs/en/remote-control#troubleshooting
 [cc-rc-guide]: https://claudefa.st/blog/guide/development/remote-control-guide "Claude Code Remote Control: Complete Setup Guide"
 [cc-web]: https://code.claude.com/docs/en/claude-code-on-the-web
 [cc-cli]: https://code.claude.com/docs/en/cli-reference
 [cc-sec]: https://code.claude.com/docs/en/security
+[cc-settings]: https://code.claude.com/docs/en/settings#configuration-scopes

--- a/docs/cc-native/configuration/CC-env-vars-reference.md
+++ b/docs/cc-native/configuration/CC-env-vars-reference.md
@@ -51,7 +51,7 @@ Cross-ref: [CC-extended-context-analysis.md](../context-memory/CC-extended-conte
 
 | Variable | Default | Purpose | Source |
 |---|---|---|---|
-| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `0` | Equivalent of `DISABLE_AUTOUPDATER` + `DISABLE_FEEDBACK_COMMAND` + `DISABLE_ERROR_REPORTING` + `DISABLE_TELEMETRY` | [env-vars][env-vars] |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `0` | Equivalent of `DISABLE_AUTOUPDATER` + `DISABLE_FEEDBACK_COMMAND` + `DISABLE_ERROR_REPORTING` + `DISABLE_TELEMETRY`. **Blocks Remote Control** — eligibility check uses this path. Use individual flags instead if Remote Control is needed. See [CC-remote-control-analysis.md](../ci-remote/CC-remote-control-analysis.md#environment-variable-blockers) | [env-vars][env-vars] |
 | `CLAUDE_CODE_ENABLE_TELEMETRY` | `0` | Enable OTel metrics/logs export | [env-vars][env-vars], [monitoring][monitoring] |
 | `DISABLE_AUTOUPDATER` | `0` | Prevent automatic CC updates | [env-vars][env-vars] |
 | `DISABLE_COST_WARNINGS` | `0` | Suppress cost warning messages | [env-vars][env-vars] |

--- a/docs/cc-native/configuration/CC-tools-inventory.md
+++ b/docs/cc-native/configuration/CC-tools-inventory.md
@@ -2,8 +2,8 @@
 title: CC Tools Inventory
 purpose: Point-in-time snapshot of all CC built-in tools, slash commands, and configuration surfaces with permission requirements and categories.
 created: 2026-03-27
-updated: 2026-04-05
-validated_links: 2026-04-05
+updated: 2026-04-13
+validated_links: 2026-04-13
 ---
 
 **Status**: Adopt
@@ -106,6 +106,7 @@ Commands extracted via `grep -oP` from CLI binary. **Documented** commands are l
 | `/mcp` | Manage MCP servers | [mcp-docs][mcp-docs] |
 | `/model` | Switch model | [model-config][model-config] |
 | `/review-pr` | Review pull request | [cli-ref][cli-ref] |
+| `/remote-control`, `/rc` | Enable Remote Control on current session | [remote-control][remote-control] |
 | `/schedule` | Manage scheduled remote agents | [remote-control][remote-control] |
 | `/status` | Show session status | [cli-ref][cli-ref] |
 
@@ -120,7 +121,7 @@ Commands extracted via `grep -oP` from CLI binary. **Documented** commands are l
 | `/chrome` | Chrome extension related | String extraction, CC 2.1.87 |
 | `/commit-push-pr` | Combined commit+push+PR workflow | String extraction, CC 2.1.87 |
 | `/issue` | Create/reference GitHub issue | String extraction, CC 2.1.87 |
-| `/remote-control` | Remote session management | String extraction, CC 2.1.87 |
+| `/remote-env` | Configure cloud session environment (setup scripts, network policy) | String extraction; undocumented; open issue reports it as unavailable |
 | `/ultrareview` | Unknown — enhanced review? | String extraction, CC 2.1.87 |
 
 ## Configuration Surface (CC 2.1.87)


### PR DESCRIPTION
## Summary

- **CC-remote-control-analysis.md**: full requirements table (plan, OAuth auth, admin toggle, version), env variable blockers (`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_TELEMETRY`, provider vars), workaround using individual flags, server mode flags (`--spawn`, `--capacity`, `--sandbox`)
- **CC-env-vars-reference.md**: warning that `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` blocks Remote Control with cross-ref
- **CC-tools-inventory.md**: promote `/remote-control` + `/rc` from undocumented to documented section, add `/remote-env` as undocumented

## Validation

- markdownlint: 0 errors across 3 files
- lychee: 52 links, 0 errors

## Test plan

- [ ] `make check_docs` passes
- [ ] `make check_links` passes
- [ ] Cross-ref links navigate correctly

Generated with Claude <noreply@anthropic.com>