### PR TITLE
docs: docs map URL, /remote-env promoted to documented

### DIFF
--- a/docs/cc-native/CC-first-party-docs-index.md
+++ b/docs/cc-native/CC-first-party-docs-index.md
@@ -29,6 +29,7 @@ validated_links: 2026-04-13
 | Plugins reference | <https://code.claude.com/docs/en/plugins-reference> |
 | Channels | <https://code.claude.com/docs/en/channels> |
 | Chrome extension | <https://code.claude.com/docs/en/chrome> |
+| Docs map (LLM sitemap) | <https://code.claude.com/docs/en/claude_code_docs_map.md> |
 | LLMs.txt | <https://code.claude.com/docs/llms.txt> |
 
 ## Agent SDK (platform.claude.com)

--- a/docs/cc-native/ci-remote/CC-cloud-sessions-analysis.md
+++ b/docs/cc-native/ci-remote/CC-cloud-sessions-analysis.md
@@ -61,6 +61,7 @@ pip install -r requirements.txt
 - **Setup scripts**: Run only on new sessions (not resume). Non-zero exit = session fails ([source][cc-cloud])
 - **SessionStart hooks**: Run on every session start (local + cloud). Use `CLAUDE_CODE_REMOTE` env var to scope ([source][cc-hooks])
 - **Environment variables**: Configured in UI as `.env` format key-value pairs ([source][cc-cloud])
+- **`/remote-env`**: Configure the default remote environment for web sessions started with `--remote`. Sets up setup scripts, network policy, and environment variables for cloud VMs. Was undocumented in CC 2.1.87; now listed in the [commands reference][cc-commands]
 
 ### Network Access Levels
 
@@ -138,6 +139,7 @@ ephemeral vs stateful, checkpoint/restore), see
 - [CC Hooks docs][cc-hooks]
 - [CC Settings docs][cc-settings]
 
+[cc-commands]: https://code.claude.com/docs/en/commands
 [cc-cloud]: https://code.claude.com/docs/en/claude-code-on-the-web
 [cc-rc]: https://code.claude.com/docs/en/remote-control
 [cc-hooks]: https://code.claude.com/docs/en/hooks

--- a/docs/cc-native/configuration/CC-tools-inventory.md
+++ b/docs/cc-native/configuration/CC-tools-inventory.md
@@ -107,6 +107,7 @@ Commands extracted via `grep -oP` from CLI binary. **Documented** commands are l
 | `/model` | Switch model | [model-config][model-config] |
 | `/review-pr` | Review pull request | [cli-ref][cli-ref] |
 | `/remote-control`, `/rc` | Enable Remote Control on current session | [remote-control][remote-control] |
+| `/remote-env` | Configure default remote environment for `--remote` web sessions | [commands][commands] |
 | `/schedule` | Manage scheduled remote agents | [remote-control][remote-control] |
 | `/status` | Show session status | [cli-ref][cli-ref] |
 
@@ -121,7 +122,7 @@ Commands extracted via `grep -oP` from CLI binary. **Documented** commands are l
 | `/chrome` | Chrome extension related | String extraction, CC 2.1.87 |
 | `/commit-push-pr` | Combined commit+push+PR workflow | String extraction, CC 2.1.87 |
 | `/issue` | Create/reference GitHub issue | String extraction, CC 2.1.87 |
-| `/remote-env` | Configure cloud session environment (setup scripts, network policy) | String extraction; undocumented; open issue reports it as unavailable |
+
 | `/ultrareview` | Unknown — enhanced review? | String extraction, CC 2.1.87 |
 
 ## Configuration Surface (CC 2.1.87)
@@ -269,6 +270,7 @@ Cross-ref: [CC-agent-teams-orchestration.md](../agents-skills/CC-agent-teams-orc
 | [CLAURST README][claurst] | Internal/gated tool registry, feature flags |
 
 [tools-ref]: https://code.claude.com/docs/en/tools-reference
+[commands]: https://code.claude.com/docs/en/commands
 [cli-ref]: https://code.claude.com/docs/en/cli-reference
 [settings]: https://code.claude.com/docs/en/settings
 [permissions]: https://code.claude.com/docs/en/permissions#tool-specific-permission-rules


### PR DESCRIPTION
## Summary

- **CC-first-party-docs-index.md**: add `claude_code_docs_map.md` (auto-generated LLM sitemap with all page headings)
- **CC-tools-inventory.md**: move `/remote-env` from undocumented to documented section (now in [commands reference](https://code.claude.com/docs/en/commands) as of v2.1.100)
- **CC-cloud-sessions-analysis.md**: add `/remote-env` description with first-party source link

## Validation

- markdownlint: 0 errors
- lychee: 66 links, 0 errors

## Test plan

- [ ] `make check_docs` passes
- [ ] `make check_links` passes

Generated with Claude <noreply@anthropic.com>