### PR TITLE
chore: rename plugin references to claude-code-plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,13 +4,13 @@
     "pr": "Generated with Claude <noreply@anthropic.com>"
   },
   "enabledPlugins": {
-    "commit-helper@qte77-claude-code-utils": true
+    "commit-helper@qte77-claude-code-plugins": true
   },
   "extraKnownMarketplaces": {
-    "qte77-claude-code-utils": {
+    "qte77-claude-code-plugins": {
       "source": {
         "source": "github",
-        "repo": "qte77/claude-code-utils-plugin"
+        "repo": "qte77/claude-code-plugins"
       }
     }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_Store
 Thumbs.db
 
-# Plugin-deployed files (source of truth: claude-code-utils-plugin)
+# Plugin-deployed files (source of truth: claude-code-plugins)
 .claude/rules/
 .claude/scripts/
 .claude/skills/

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ endif
 # Source plugin providing skills (docs-governance, cc-meta).
 # Default: clone from GitHub to an XDG cache path. Override
 # UTILS_PLUGIN_DIR to point at an existing local clone.
-UTILS_PLUGIN_URL ?= https://github.com/qte77/claude-code-utils-plugin
-UTILS_PLUGIN_DIR ?= $(HOME)/.cache/claude-code-utils-plugin
+UTILS_PLUGIN_URL ?= https://github.com/qte77/claude-code-plugins
+UTILS_PLUGIN_DIR ?= $(HOME)/.cache/claude-code-plugins
 SKILLS_DIR       := .claude/skills
 
 
@@ -119,7 +119,7 @@ setup_mdlint: setup_node ## Install markdownlint-cli2 via user-local npm (no sud
 		fi
 	fi
 
-setup_skills: ## Clone claude-code-utils-plugin (if missing) and symlink its skills into .claude/skills (gitignored; zero sudo)
+setup_skills: ## Clone claude-code-plugins (if missing) and symlink its skills into .claude/skills (gitignored; zero sudo)
 	if [ ! -d "$(UTILS_PLUGIN_DIR)/.git" ]; then
 		echo "Cloning $(UTILS_PLUGIN_URL) to $(UTILS_PLUGIN_DIR) ..."
 		mkdir -p $$(dirname $(UTILS_PLUGIN_DIR))

--- a/docs/cc-native/examples/settings.json
+++ b/docs/cc-native/examples/settings.json
@@ -70,14 +70,14 @@
     "command": "bash .claude/scripts/statusline.sh"
   },
   "enabledPlugins": {
-    "docs-generator@qte77-claude-code-utils": true,
+    "docs-generator@qte77-claude-code-plugins": true,
     "context7@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
-    "qte77-claude-code-utils": {
+    "qte77-claude-code-plugins": {
       "source": {
         "source": "github",
         "repo": "qte77/claude-code-utils"

--- a/docs/cc-native/plugins-ecosystem/CC-plugin-packaging-research.md
+++ b/docs/cc-native/plugins-ecosystem/CC-plugin-packaging-research.md
@@ -156,8 +156,8 @@ Based on external research on plugin adoption patterns:
 ## Common Pitfalls
 
 Observed failure modes when packaging plugins, derived from production experience
-with the [qte77/claude-code-utils-plugin](https://github.com/qte77/claude-code-utils-plugin)
-marketplace ([PR #16](https://github.com/qte77/claude-code-utils-plugin/pull/16))
+with the [qte77/claude-code-plugins](https://github.com/qte77/claude-code-plugins)
+marketplace ([PR #16](https://github.com/qte77/claude-code-plugins/pull/16))
 and cross-referencing official Anthropic plugins ([source][cc-plugins-official]).
 
 ### 1. Duplicate Hooks from Explicit Manifest Reference

--- a/docs/learnings/contribution-sprint/plugin-safety-matrix.md
+++ b/docs/learnings/contribution-sprint/plugin-safety-matrix.md
@@ -70,4 +70,4 @@ These repos do NOT exclude Claude Code config directories from version control. 
 | [cc-plugins-utils][plugins] | Plugin inventory, all branches, 2026-03-30 |
 | [style-cheatsheets.md](style-cheatsheets.md) | Per-repo .gitignore observations |
 
-[plugins]: https://github.com/qte77/claude-code-utils-plugin
+[plugins]: https://github.com/qte77/claude-code-plugins

--- a/docs/learnings/cross-repo-digest.md
+++ b/docs/learnings/cross-repo-digest.md
@@ -128,7 +128,7 @@ Patterns that recur across two or more repos. Each entry is distilled from AGENT
 - **Context**: Multi-manifest systems (CC plugins: `plugin.json` + `marketplace.json`)
 - **Problem**: Bumping version in one manifest but not the other causes CI validation failures.
 - **Solution**: Grep for old version string across all manifest files and update all occurrences atomically.
-- **References**: AGENT_LEARNINGS.md (Agents-eval, claude-code-utils-plugin)
+- **References**: AGENT_LEARNINGS.md (Agents-eval, claude-code-plugins)
 
 ---
 


### PR DESCRIPTION
## Summary
- Rename `claude-code-utils-plugin` → `claude-code-plugins` and `qte77-claude-code-utils` → `qte77-claude-code-plugins`

Follows GitHub repo rename qte77/claude-code-utils-plugin → qte77/claude-code-plugins.

🤖 Generated with Claude <noreply@anthropic.com>