### PR TITLE
chore: align LICENSE with canonical ASF Apache-2.0 text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -48,7 +48,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
@@ -60,7 +60,7 @@
       designated in writing by the copyright owner as "Not a Contribution."
 
       "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by the Licensor and
+      on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
@@ -106,7 +106,7 @@
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding any notices that do not
+          within such NOTICE file, excluding those notices that do not
           pertain to any part of the Derivative Works, in at least one
           of the following places: within a NOTICE text file distributed
           as part of the Derivative Works; within the Source form or


### PR DESCRIPTION
## Summary

Closes #114. Fix 3 word-level deviations from the canonical ASF Apache-2.0 text:

| Section | Before | After |
|---|---|---|
| §1 Contribution | `submitted to **the** Licensor` | `submitted to Licensor` |
| §1 Contributor | `received by **the** Licensor` | `received by Licensor` |
| §4(d) NOTICE | `excluding **any** notices` | `excluding **those** notices` |

## Test plan

- [ ] GitHub license detection recognizes canonical Apache-2.0
- [ ] SPDX identifier matches unchanged
- [ ] Diff is minimal (3 lines)

Generated with Claude <noreply@anthropic.com>