### PR TITLE
chore: resolve permanent redirects to canonical URLs (closes #106)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/qte77/coding-agents-research/security/advisories/new).
+If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/qte77/ai-agents-research/security/advisories/new).
 
 Do not open a public issue for security vulnerabilities.

--- a/docs/cc-community/CC-community-plugins-landscape.md
+++ b/docs/cc-community/CC-community-plugins-landscape.md
@@ -168,7 +168,7 @@ CC has native push-to-talk voice dictation via `/voice` — cloud-only, requires
 [tts-ybou]: https://github.com/ybouhjira/claude-code-tts
 [tts-cg]: https://git.sr.ht/~cg/claude-code-tts
 [tts-ktal]: https://github.com/ktaletsk/claude-code-tts
-[tts-laura]: https://github.com/LAURA-agent/Claude-to-Speech
+[tts-laura]: https://github.com/TwinPeaksTownie/Claude-to-Speech
 [tts-voice]: https://github.com/mbailey/voicemode
 [tts-mcp]: https://github.com/johnmatthewtennant/mcp-voice-hooks
 [tts-hooks]: https://github.com/husniadil/cc-hooks
@@ -176,7 +176,7 @@ CC has native push-to-talk voice dictation via `/voice` — cloud-only, requires
 [realtimetts]: https://github.com/KoljaB/RealtimeTTS
 [voice-docs]: https://code.claude.com/docs/en/voice-dictation
 [moonshine]: https://github.com/moonshine-ai/moonshine
-[whispercpp]: https://github.com/ggerganov/whisper.cpp
+[whispercpp]: https://github.com/ggml-org/whisper.cpp
 [vosk]: https://alphacephei.com/vosk/
 [claude-stt]: https://github.com/jarrodwatts/claude-stt
 [wake-word]: https://github.com/Traves-Theberge/Wake-Word

--- a/docs/cc-community/CC-community-reimplementations-landscape.md
+++ b/docs/cc-community/CC-community-reimplementations-landscape.md
@@ -156,8 +156,8 @@ Cross-ref: [CC-reverse-engineering-landscape.md](CC-reverse-engineering-landscap
 | [leaked-claude-code/leaked-claude-code][leaked] | Alleged proprietary source (excluded from analysis) |
 | [zackautocracy/claude-code][zack] | Source snapshot powering ccunpacked.dev (leak-derived) |
 
-[claw]: https://github.com/instructkr/claw-code
-[claurst]: https://github.com/Kuberwastaken/claude-code
+[claw]: https://github.com/ultraworkers/claw-code
+[claurst]: https://github.com/Kuberwastaken/claurst
 [learn]: https://github.com/shareAI-lab/learn-claude-code
 [openclaude]: https://github.com/Gitlawb/openclaude
 [nvim]: https://github.com/coder/claudecode.nvim

--- a/docs/cc-community/CC-community-tooling-landscape.md
+++ b/docs/cc-community/CC-community-tooling-landscape.md
@@ -548,7 +548,7 @@ Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-exte
 
 [awesome-design-md]: https://github.com/VoltAgent/awesome-design-md
 [graphify]: https://github.com/safishamsi/graphify
-[mempalace]: https://github.com/milla-jovovich/mempalace
+[mempalace]: https://github.com/MemPalace/mempalace
 [longmemeval]: https://github.com/xiaowu0162/LongMemEval
 [code-review-graph]: https://github.com/tirth8205/code-review-graph
 [rtk-repo]: https://github.com/rtk-ai/rtk

--- a/docs/cc-community/CC-office-worker-workflows.md
+++ b/docs/cc-community/CC-office-worker-workflows.md
@@ -25,7 +25,7 @@ Receipt images/PDFs → Claude OCR → Excel spreadsheet → Accounting API (Xer
 - **Validation**: Flags duplicate invoice numbers, inconsistent payment terms, budget overruns
 - **Output**: Tax-ready organized records pushed to accounting system
 - **Tools**: Built-in `xlsx`/`pdf` skills + [Xero MCP](../cc-native/plugins-ecosystem/CC-business-api-integrations.md#xero-official-xeroapi) or [QuickBooks MCP](../cc-native/plugins-ecosystem/CC-business-api-integrations.md#quickbooks)
-- **Reference**: [Cowork invoice processing](https://support.claude.com/en/articles/13345190-get-started-with-cowork)
+- **Reference**: [Cowork invoice processing](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork)
 
 ### Document Renaming & Organization
 
@@ -36,7 +36,7 @@ Chaotic folder → Content-aware analysis → YYYY-MM-DD taxonomy → Organized 
 - **Pattern**: Claude reads document content (not just filenames), classifies by type, applies consistent naming
 - **Example**: 247 chaotic invoice files → tax-ready order with date-based naming
 - **Tools**: CC CLI file operations or Cowork drag-and-drop
-- **Scheduling**: [Cowork scheduled tasks](https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-cowork) — set weekly/monthly cleanup cadence
+- **Scheduling**: [Cowork scheduled tasks](https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-claude-cowork) — set weekly/monthly cleanup cadence
 
 ### Email Triage
 
@@ -155,5 +155,5 @@ CC-first for high ROI MVP, but these extend the pattern:
 [orch]: https://github.com/Jedward23/Tmux-Orchestrator
 [cc-conductor]: https://github.com/lancejames221b/claude-conductor
 [teams]: https://code.claude.com/docs/en/agent-teams
-[cowork]: https://support.claude.com/en/articles/13345190-get-started-with-cowork
-[cowork-sched]: https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-cowork
+[cowork]: https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork
+[cowork-sched]: https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-claude-cowork

--- a/docs/cc-community/CC-reverse-engineering-landscape.md
+++ b/docs/cc-community/CC-reverse-engineering-landscape.md
@@ -191,7 +191,7 @@ Tracking issue: [qte77/ai-agents-research#70][tracking-issue]
 [hn-thread]: https://news.ycombinator.com/item?id=43217357
 [turboai]: https://www.turboai.dev/blog/claude-code-versions
 [unkn0wncode]: https://gist.github.com/unkn0wncode/f87295d055dd0f0e8082358a0b5cc467
-[schema-store]: https://json.schemastore.org/claude-code-settings.json
+[schema-store]: https://www.schemastore.org/claude-code-settings.json
 [gh-11795]: https://github.com/anthropics/claude-code/issues/11795
 [xdanny-gist]: https://gist.github.com/xdannyrobertsx/0a395c59b1ef09508e52522289bd5bf6
 [yoffe]: https://medium.com/@liranyoffe/reverse-engineering-claude-code-web-tools-1409249316c3

--- a/docs/cc-native/CC-first-party-docs-index.md
+++ b/docs/cc-native/CC-first-party-docs-index.md
@@ -50,7 +50,7 @@ validated_links: 2026-04-13
 
 | Topic | URL |
 |-------|-----|
-| Client SDKs (Python + TypeScript) | <https://docs.anthropic.com/en/api/client-sdks> |
+| Client SDKs (Python + TypeScript) | <https://platform.claude.com/docs/en/api/client-sdks> |
 | GitHub (Python) | <https://github.com/anthropics/anthropic-sdk-python> |
 | GitHub (TypeScript) | <https://github.com/anthropics/anthropic-sdk-typescript> |
 
@@ -58,9 +58,9 @@ validated_links: 2026-04-13
 
 | Topic | URL |
 |-------|-----|
-| Tool use overview | <https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview> |
-| Text editor tool | <https://docs.anthropic.com/en/docs/build-with-claude/tool-use/text-editor-tool> |
-| Building effective agents | <https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/building-effective-agents> |
+| Tool use overview | <https://platform.claude.com/docs/en/docs/agents-and-tools/tool-use/overview> |
+| Text editor tool | <https://platform.claude.com/docs/en/docs/build-with-claude/tool-use/text-editor-tool> |
+| Building effective agents | <https://platform.claude.com/docs/en/docs/build-with-claude/prompt-engineering/building-effective-agents> |
 
 ## GitHub Resources
 

--- a/docs/cc-native/agents-skills/CC-agent-teams-orchestration.md
+++ b/docs/cc-native/agents-skills/CC-agent-teams-orchestration.md
@@ -451,6 +451,6 @@ Cross-ref: [CC-community-reimplementations-landscape.md](../../cc-community/CC-c
 [dev-opencode]: https://dev.to/uenyioha/porting-claude-codes-agent-teams-to-opencode-4hol
 [compiler-case]: https://www.theregister.com/2026/02/09/claude_opus_46_compiler/
 [register-leak]: https://www.theregister.com/2026/03/31/anthropic_claude_code_source_code/
-[techsy-leaked]: https://techsy.io/blog/claude-code-leaked-features-2026
+[techsy-leaked]: https://techsy.io/en/blog/claude-code-leaked-features-2026
 [minbook-hidden]: https://minbook.dev/en/blog/claude-code-anatomy-hidden-features/
 [zread-coordinator]: https://zread.ai/instructkr/claude-code/19-coordinator-mode

--- a/docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md
+++ b/docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md
@@ -94,7 +94,7 @@ Shell commands fire automatically at specific agent lifecycle points, outside th
 
 ## Author
 
-[Bilgin Ibryam](https://www.linkedin.com/in/bibryam/) -- Principal PM at Diagrid (Dapr). Apache Software Foundation Member. Previously 9 years at Red Hat, before that BBC News. Author of *Kubernetes Patterns* (O'Reilly, 2nd ed. 2023), *Camel Design Patterns*, and the new [Prompt Patterns](https://promptpatterns.dev/) catalog.
+[Bilgin Ibryam](https://www.linkedin.com/in/bibryam/) -- Principal PM at Diagrid (Dapr). Apache Software Foundation Member. Previously 9 years at Red Hat, before that BBC News. Author of *Kubernetes Patterns* (O'Reilly, 2nd ed. 2023), *Camel Design Patterns*, and the new [Prompt Patterns](https://www.promptpatterns.dev/) catalog.
 
 Pattern taxonomist by trade: Kubernetes patterns -> Camel patterns -> Prompt patterns -> Agentic harness patterns.
 
@@ -103,7 +103,7 @@ Pattern taxonomist by trade: Kubernetes patterns -> Camel patterns -> Prompt pat
 - [12 Agentic Harness Patterns from Claude Code](https://generativeprogrammer.com/p/12-agentic-harness-patterns-from) (2026-04-05)
 - [Practical Lessons From the Claude Code Leak](https://generativeprogrammer.com/p/practical-lessons-from-the-claude) (2026-04-03)
 - [Kubernetes Patterns (O'Reilly)](https://k8spatterns.com/)
-- [Prompt Patterns catalog](https://promptpatterns.dev/)
+- [Prompt Patterns catalog](https://www.promptpatterns.dev/)
 - [The Generative Programmer Substack](https://generativeprogrammer.com/)
 
 ## Action Items

--- a/docs/cc-native/agents-skills/CC-ralph-enhancement-research.md
+++ b/docs/cc-native/agents-skills/CC-ralph-enhancement-research.md
@@ -136,7 +136,7 @@ Community-published Ralph loop as a CC Skill. Uses `.claude/ralph-loop.local.md`
 [ghuntley-loop]: https://ghuntley.com/loop/
 [ralph-playbook]: https://github.com/ClaytonFarr/ralph-playbook
 [ralphinho]: https://github.com/affaan-m/everything-claude-code
-[trellis]: https://docs.trytrellis.app/guide/ch05-commands
+[trellis]: https://docs.trytrellis.app/start/everyday-use
 [lobehub-ralph]: https://lobehub.com/skills/101mare-skill-library-ralph-loop
 [ralph-official]: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/ralph-loop
 [linearb]: https://linearb.io/dev-interrupted/podcast/inventing-the-ralph-wiggum-loop

--- a/docs/cc-native/agents-skills/CC-recursive-spawning-patterns.md
+++ b/docs/cc-native/agents-skills/CC-recursive-spawning-patterns.md
@@ -1,6 +1,6 @@
 ---
 title: CC Recursive Spawning Patterns
-source: https://code.claude.com/docs/en/sub-agents, https://github.com/anthropics/claude-agent-sdk-python/issues/573, https://forem.com/jungjaehoon/why-claude-code-subagents-waste-50k-tokens-per-turn-and-how-to-fix-it-41ma
+source: https://code.claude.com/docs/en/sub-agents, https://github.com/anthropics/claude-agent-sdk-python/issues/573, https://dev.to/jungjaehoon/why-claude-code-subagents-waste-50k-tokens-per-turn-and-how-to-fix-it-41ma
 purpose: Analysis of recursive claude -p invocation patterns, the CLAUDECODE=1 session guard, and spawning method trade-offs for autonomous agent orchestration.
 created: 2026-03-17
 updated: 2026-03-17
@@ -71,7 +71,7 @@ any work.
 - Set `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1` to skip git context
 - Set `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` to prevent extended context
 
-**Source**: [DEV Community -- "Why Each Subprocess Burns 50K Tokens"](https://forem.com/jungjaehoon/why-claude-code-subagents-waste-50k-tokens-per-turn-and-how-to-fix-it-41ma)
+**Source**: [DEV Community -- "Why Each Subprocess Burns 50K Tokens"](https://dev.to/jungjaehoon/why-claude-code-subagents-waste-50k-tokens-per-turn-and-how-to-fix-it-41ma)
 
 ## Key Environment Variables
 
@@ -127,7 +127,7 @@ teams are independent.
 |---|---|
 | [Official sub-agents docs](https://code.claude.com/docs/en/sub-agents) | Subagent architecture |
 | [claude-agent-sdk-python#573](https://github.com/anthropics/claude-agent-sdk-python/issues/573) | `CLAUDECODE=1` guard bug in SDK |
-| [DEV Community](https://forem.com/jungjaehoon/why-claude-code-subagents-waste-50k-tokens-per-turn-and-how-to-fix-it-41ma) | 50K token cost per subprocess |
+| [DEV Community](https://dev.to/jungjaehoon/why-claude-code-subagents-waste-50k-tokens-per-turn-and-how-to-fix-it-41ma) | 50K token cost per subprocess |
 | [haasonsaas/claude-recursive-spawn](https://github.com/haasonsaas/claude-recursive-spawn) | Bash script with depth control, JSON parsing |
 | [#31977](https://github.com/anthropics/claude-code/issues/31977) | No Agent tool in in-process teammates |
 | [#30008](https://github.com/anthropics/claude-code/issues/30008) | Teams + print mode hang |

--- a/docs/cc-native/ci-remote/CC-github-actions-analysis.md
+++ b/docs/cc-native/ci-remote/CC-github-actions-analysis.md
@@ -287,9 +287,9 @@ A Python composite GHA addressing all four gaps is planned at [qte77/gha-issue-t
 [dev-to-pr]: https://dev.to/myougatheaxo/automate-your-entire-pr-workflow-with-claude-code-description-review-tests-1i41
 [gh-larger-runners]: https://docs.github.com/en/actions/concepts/runners/larger-runners
 [gh-runner-pricing]: https://docs.github.com/en/billing/reference/actions-runner-pricing
-[gh-larger-runner-jobs]: https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/running-jobs-on-larger-runners
+[gh-larger-runner-jobs]: https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners/use-larger-runners
 [cc-action-repo]: https://github.com/anthropics/claude-code-action
-[copilot-agent]: https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-coding-agent
+[copilot-agent]: https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent
 [codex-action]: https://github.com/openai/codex-action
 [sweep-repo]: https://github.com/sweepai/sweep
 [swe-agent-repo]: https://github.com/SWE-agent/SWE-agent

--- a/docs/cc-native/ci-remote/CC-remote-access-landscape.md
+++ b/docs/cc-native/ci-remote/CC-remote-access-landscape.md
@@ -1,6 +1,6 @@
 ---
 title: CC Remote Access Landscape
-source: https://omnara.com, https://cloudcli.ai, https://happy.engineering, https://code.claude.com/docs/en/remote-control, https://zilliz.com/blog/3-easiest-ways-to-use-claude-code-on-your-mobile-phone
+source: https://www.omnara.com, https://cloudcli.ai, https://happy.engineering, https://code.claude.com/docs/en/remote-control, https://zilliz.com/blog/3-easiest-ways-to-use-claude-code-on-your-mobile-phone
 purpose: Comparison of remote access options for monitoring and steering Claude Code sessions (autonomous loops, teams, baselines) from mobile/web.
 created: 2026-03-07
 updated: 2026-03-12
@@ -192,13 +192,13 @@ Tools that complement any remote access method ([source][zilliz]):
 [happy]: https://happy.engineering
 [happy-gh]: https://github.com/slopus/happy
 [happy-hn]: https://news.ycombinator.com/item?id=44904039
-[omnara]: https://omnara.com
+[omnara]: https://www.omnara.com
 [omnara-yc]: https://www.ycombinator.com/companies/omnara
 [omnara-gh]: https://github.com/omnara-ai/omnara
 [omnara-hn]: https://news.ycombinator.com/item?id=44878650
 [omnara-techmonk]: https://techmonk.economictimes.indiatimes.com/news/ai/omnara-wants-to-put-your-coding-agent-on-your-phone/128286862
 [omnara-hiretop]: https://hiretop.com/blog5/omnara-mobile-voice-interface-for-claude-code/
-[omnara-appstore]: https://apps.apple.com/us/app/omnara-ai-command-center/id6748426727
+[omnara-appstore]: https://apps.apple.com/us/app/omnara-claude-codex-mobile/id6748426727
 [emdash]: https://emdash.dev
 [cloudcli]: https://cloudcli.ai
 [cc-cloud]: https://code.claude.com/docs/en/claude-code-on-the-web

--- a/docs/cc-native/ci-remote/CC-status-monitoring-analysis.md
+++ b/docs/cc-native/ci-remote/CC-status-monitoring-analysis.md
@@ -166,4 +166,4 @@ Changes are submitted via PR (branch protection requires PRs on `main`). Unlike 
 
 - [Statuspage API docs](https://developer.statuspage.io/)
 - [GitHub repository_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch)
-- [Claude API errors](https://docs.anthropic.com/en/api/errors)
+- [Claude API errors](https://platform.claude.com/docs/en/api/errors)

--- a/docs/cc-native/ci-remote/CC-version-pinning-resilience.md
+++ b/docs/cc-native/ci-remote/CC-version-pinning-resilience.md
@@ -1,6 +1,6 @@
 ---
 title: CC Version Pinning & Provider Resilience
-source: https://code.claude.com/docs/en/setup, https://www.npmjs.com/package/@anthropic-ai/claude-code, https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners, https://www.vcluster.com/blog/comparing-coder-vs-codespaces-vs-gitpod-vs-devpod
+source: https://code.claude.com/docs/en/setup, https://www.npmjs.com/package/@anthropic-ai/claude-code, https://docs.github.com/en/actions/concepts/runners/self-hosted-runners, https://www.vcluster.com/blog/comparing-coder-vs-codespaces-vs-gitpod-vs-devpod
 purpose: Document how to pin Claude Code versions for reproducible CI/CD and container environments, self-hosted runners, cloud dev environments, and resilience against Anthropic API outages or discontinuation.
 created: 2026-03-12
 updated: 2026-03-12
@@ -388,6 +388,6 @@ For scenarios where Anthropic may be entirely unavailable (business discontinuat
 [npm-cc]: https://www.npmjs.com/package/@anthropic-ai/claude-code
 [datacamp-docker]: https://www.datacamp.com/tutorial/claude-code-docker
 [local-setup]: https://medium.com/@luongnv89/run-claude-code-on-local-cloud-models-in-5-minutes-ollama-openrouter-llama-cpp-6dfeaee03cda
-[gh-runners]: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners
-[gh-runners-req]: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#requirements-for-self-hosted-runner-machines
-[gh-runners-net]: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#communication-requirements
+[gh-runners]: https://docs.github.com/en/actions/concepts/runners/self-hosted-runners
+[gh-runners-req]: https://docs.github.com/en/actions/concepts/runners/self-hosted-runners#requirements-for-self-hosted-runner-machines
+[gh-runners-net]: https://docs.github.com/en/actions/concepts/runners/self-hosted-runners#communication-requirements

--- a/docs/cc-native/configuration/CC-binary-architecture.md
+++ b/docs/cc-native/configuration/CC-binary-architecture.md
@@ -283,7 +283,7 @@ Settings key: `voiceEnabled:y.boolean().optional()` — toggled via `/voice` com
 [monitoring]: https://code.claude.com/docs/en/monitoring-usage
 [api-ref]: https://platform.claude.com/docs/en/api
 [remote-control]: https://code.claude.com/docs/en/remote-control
-[schema-store]: https://json.schemastore.org/claude-code-settings.json
+[schema-store]: https://www.schemastore.org/claude-code-settings.json
 [gh-11795]: https://github.com/anthropics/claude-code/issues/11795
 [re-landscape]: ../../cc-community/CC-reverse-engineering-landscape.md
 [cc-changelog]: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

--- a/docs/cc-native/configuration/CC-inline-visuals-analysis.md
+++ b/docs/cc-native/configuration/CC-inline-visuals-analysis.md
@@ -81,7 +81,7 @@ Evolution of "Imagine with Claude" — a temporary experience previewed in Fall 
 ## References
 
 [blog]: https://claude.com/blog/claude-builds-visuals "Claude builds interactive visuals right in your conversation"
-[helpcenter]: https://support.claude.com/en/articles/13979539-custom-visuals-in-chat "Custom visuals in chat — Claude Help Center"
+[helpcenter]: https://support.claude.com/en/articles/13979539-custom-visuals-in-chat-and-cowork "Custom visuals in chat — Claude Help Center"
 [engadget]: https://www.engadget.com/ai/claude-can-now-generate-charts-and-diagrams-160000369.html "Claude can now generate charts and diagrams — Engadget"
 [thenewstack]: https://thenewstack.io/anthropics-claude-interactive-visualizations/ "Anthropic's Claude interactive visualizations — The New Stack"
 [opentools]: https://opentools.ai/news/anthropics-claude-ai-unleashes-exciting-inline-visualization-capabilities "Anthropic's Claude AI inline visualization capabilities — OpenTools"

--- a/docs/cc-native/configuration/CC-model-provider-configuration.md
+++ b/docs/cc-native/configuration/CC-model-provider-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: CC Model & Provider Configuration
-source: https://code.claude.com/docs/en/settings#environment-variables, https://openrouter.ai/docs/guides/guides/coding-agents/claude-code-integration, https://ollama.com/blog/claude, https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models
+source: https://code.claude.com/docs/en/settings#environment-variables, https://openrouter.ai/docs/guides/coding-agents/claude-code-integration, https://ollama.com/blog/claude, https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models
 purpose: Reference for configuring CC with alternative models, endpoints, API keys, third-party providers (OpenRouter, Bedrock, Vertex, Foundry), local models (Ollama, llama.cpp, LM Studio), and LLM gateway proxies.
 created: 2026-03-07
 updated: 2026-03-12
@@ -269,7 +269,7 @@ When routing through gateways, additionally set ([source][cc-settings]):
 - [Local setup guide][local-setup]
 
 [cc-settings]: https://code.claude.com/docs/en/settings#environment-variables
-[openrouter]: https://openrouter.ai/docs/guides/guides/coding-agents/claude-code-integration
+[openrouter]: https://openrouter.ai/docs/guides/coding-agents/claude-code-integration
 [ollama-claude]: https://ollama.com/blog/claude
 [llamacpp-anthropic]: https://huggingface.co/blog/ggml-org/anthropic-messages-api-in-llamacpp
 [litellm]: https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models

--- a/docs/cc-native/configuration/CC-tools-inventory.md
+++ b/docs/cc-native/configuration/CC-tools-inventory.md
@@ -280,4 +280,4 @@ Cross-ref: [CC-agent-teams-orchestration.md](../agents-skills/CC-agent-teams-orc
 [model-config]: https://code.claude.com/docs/en/model-config
 [remote-control]: https://code.claude.com/docs/en/remote-control
 [btw-gist]: https://gist.github.com/ZhangHanDong
-[claurst]: https://github.com/Kuberwastaken/claude-code
+[claurst]: https://github.com/Kuberwastaken/claurst

--- a/docs/cc-native/context-memory/CC-extended-context-analysis.md
+++ b/docs/cc-native/context-memory/CC-extended-context-analysis.md
@@ -20,7 +20,7 @@ hitting context limits or triggering auto-compaction.
 | Account Type | 1M Access | Billing |
 | ------------ | --------- | ------- |
 | API / pay-as-you-go | Full access | Long-context pricing above 200K |
-| Pro, Max, Teams, Enterprise | Requires [extra usage](https://support.claude.com/en/articles/12429409-extra-usage-for-paid-claude-plans) enabled | Tokens above 200K billed as extra usage |
+| Pro, Max, Teams, Enterprise | Requires [extra usage](https://support.claude.com/en/articles/12429409-manage-extra-usage-for-paid-claude-plans) enabled | Tokens above 200K billed as extra usage |
 
 ## Pricing Model
 

--- a/docs/cc-native/plugins-ecosystem/CC-chrome-extension-analysis.md
+++ b/docs/cc-native/plugins-ecosystem/CC-chrome-extension-analysis.md
@@ -1,6 +1,6 @@
 ---
 title: Claude Chrome Extension Analysis
-source: https://claude.com/chrome
+source: https://claude.com/claude-for-chrome
 purpose: Evaluate the Claude Chrome extension for potential relevance to CC-based workflows.
 created: 2026-03-07
 updated: 2026-03-12
@@ -37,4 +37,4 @@ A Chrome browser extension that allows Claude to navigate, click, and fill forms
 
 - [Claude Chrome extension][chrome-product]
 
-[chrome-product]: https://claude.com/chrome
+[chrome-product]: https://claude.com/claude-for-chrome

--- a/docs/non-cc/goose-analysis.md
+++ b/docs/non-cc/goose-analysis.md
@@ -1,6 +1,6 @@
 ---
 title: Block Goose Analysis
-source: https://github.com/block/goose
+source: https://github.com/aaif-goose/goose
 purpose: Analysis of Goose as MCP co-creator, reference implementation, and AAIF founding project — architectural comparison with CC's MCP integration.
 created: 2026-04-05
 updated: 2026-04-05
@@ -80,7 +80,7 @@ This is comparable to CC's WebSocket IDE protocol but uses a different standard 
 | [AAIF announcement][aaif] | Linux Foundation founding with MCP + Goose + AGENTS.md |
 | [MCP Apps blog][mcp-apps] | Goose as reference MCP Apps client |
 
-[repo]: https://github.com/block/goose
+[repo]: https://github.com/aaif-goose/goose
 [arch]: https://block.github.io/goose/
 [arcade-origin]: https://www.arcade.dev/blog/goose-the-open-source-agent-that-shaped-mcp
 [aaif]: https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation


### PR DESCRIPTION
## Summary

Closes #106. Applied 41 URL updates across 22 files for all lychee-detected 301/308 permanent redirects. Per issue spec, 307 (temporary) redirects left untouched — those are active Anthropic docs migration paths that may change.

## Before / After

| Metric | Before | After |
|---|---|---|
| Redirects | 53 | 24 |
| 301 hops | 43 | 0 |
| 308 hops | 4 | 0 |
| 307 hops (untouched) | 25 | 23 |

Remaining 24 redirects are all 307 (temporary) or self-redirects like GitHub auth-gated pages.

## Key change categories

- `docs.anthropic.com/en/api/*` → `platform.claude.com/docs/en/api/*`
- `docs.github.com/en/actions/hosting-your-own-runners/...` → `concepts/runners/...`
- `docs.github.com/en/copilot/.../coding-agent` → `cloud-agent` (Copilot rename)
- `github.com/block/goose` → `github.com/aaif-goose/goose` (org transfer)
- `github.com/ggerganov/whisper.cpp` → `github.com/ggml-org/whisper.cpp`
- `github.com/Kuberwastaken/claude-code` → `claurst`
- `claude.com/chrome` → `claude.com/claude-for-chrome`
- Multiple `support.claude.com/...articles/...-cowork` → `...claude-cowork` slug updates
- `www.` canonicalization: omnara, schemastore, promptpatterns

## Test plan

- [x] `lychee --config lychee.toml --verbose .` confirms 0 permanent redirects remaining
- [x] 22 files modified, 41 replacements — no content changes beyond URL strings
- [ ] CI link check passes

Generated with Claude <noreply@anthropic.com>