### PR TITLE
chore: post-#105 cleanup — lychee comment + broken xref

### DIFF
--- a/docs/non-cc/autoagent-analysis.md
+++ b/docs/non-cc/autoagent-analysis.md
@@ -27,7 +27,7 @@ AutoAgent is a **fully-automated, zero-code LLM agent framework** from the Unive
 | HKUDS OpenHarness | Community tooling landscape | `docs/cc-community/CC-community-tooling-landscape.md:147-179` |
 | HKUDS CLI-Anything | CLI analysis | `docs/cc-native/agents-skills/CC-cli-anything-analysis.md` |
 | HKUDS AI-Researcher | Further reading (NeurIPS 2025 Spotlight) | `docs/todo/research/further_reading.md:732` |
-| Agent frameworks | 30+ frameworks landscape | `docs/todo/landscape/agent_frameworks.md` |
+| Agent frameworks | 30+ frameworks landscape | `docs/todo/landscape/landscape-agent-frameworks-infrastructure.md` |
 | Zero-code agents | Convergence research | `docs/todo/research/research_integration_analysis.md` |
 
 ## Three Operational Modes

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,9 +1,9 @@
 # Lychee link checker config
 # https://lychee.cli.rs/configuration/
 
-# Exclude auto-generated and pre-standardized content
+# Exclude auto-generated and archived content
 # triage/ — auto-generated monitor outputs (see CONTRIBUTING.md)
-# docs/todo/ — Agents-eval era docs pending content review and reorganization
+# docs/todo/ — archived Agents-eval era docs (status: archived frontmatter); see #105
 exclude_path = ["triage/", "docs/todo/"]
 
 # Accept common bot-blocked status codes


### PR DESCRIPTION
## Summary

Cleanup after #105 triage (PRs #120 + #121 merged).

- `lychee.toml`: update `docs/todo/` exclusion comment to reflect current state (archived, not "pending review")
- `docs/non-cc/autoagent-analysis.md`: fix broken xref from non-existent `docs/todo/landscape/agent_frameworks.md` → actual archived file `landscape-agent-frameworks-infrastructure.md`

Closes #105.

## Test plan

- [x] 2 files changed, 3 line edits
- [ ] CodeFactor check

Generated with Claude <noreply@anthropic.com>