### PR TITLE
docs: OTel + Claude Code reference, AG-UI/A2UI landscape

### DIFF
--- a/docs/cc-community/CC-agent-observability-methods-analysis.md
+++ b/docs/cc-community/CC-agent-observability-methods-analysis.md
@@ -2,8 +2,8 @@
 title: "Agent Observability Methods Analysis"
 purpose: Technical analysis of 17 observability platforms and five primary tracing patterns for AI agent behavior.
 created: 2025-08-24
-updated: 2026-04-23
-validated_links: 2026-04-23
+updated: 2026-04-24
+validated_links: 2026-04-24
 ---
 
 **Status**: Assess
@@ -36,6 +36,59 @@ This analysis examines the specific technical mechanisms used by 17 observabilit
 - **Integration complexity** assessment for each approach
 - **OpenTelemetry adoption** rates and semantic convention compliance
 - **Multi-agent observability** patterns for distributed agent coordination
+
+## Claude Code (First-Party OTel Integration)
+
+Source: [Claude Code — Monitoring usage][cc-monitoring] (first-party).
+
+Claude Code is itself an OTel-instrumented client — enabling `CLAUDE_CODE_ENABLE_TELEMETRY=1` emits metrics (time series) and logs/events via standard OTLP. Distributed tracing is available in beta via `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` + `OTEL_TRACES_EXPORTER`. This makes every OTel-native backend in the sections below a candidate CC observability backend out of the box.
+
+### Span Hierarchy (Beta Traces)
+
+```text
+claude_code.interaction                        # root span: one per user prompt
+├── claude_code.llm_request                    # API call to Anthropic Messages
+├── claude_code.hook                           # requires detailed beta tracing
+└── claude_code.tool
+    ├── claude_code.tool.blocked_on_user       # permission-wait time
+    ├── claude_code.tool.execution             # actual tool run
+    └── (Task tool) subagent claude_code.llm_request / claude_code.tool spans
+```
+
+- Task-spawned subagents nest their own `llm_request` and `tool` spans under the parent's `claude_code.tool` span
+- Retries on `claude_code.llm_request` are recorded as `gen_ai.request.attempt` span events with `attempt` and `client_request_id` attributes
+- Tool span attributes include `file_path` (Read/Edit/Write), `full_command` (Bash), `skill_name` (Skill tool), `subagent_type` (Task tool) — all gated behind `OTEL_LOG_TOOL_DETAILS`
+
+### Privacy-First Defaults
+
+All sensitive attributes are **redacted unless explicitly unlocked**:
+
+| Gate | What it reveals |
+|---|---|
+| `OTEL_LOG_USER_PROMPTS` | Prompt text on `user_prompt` events / interaction span |
+| `OTEL_LOG_TOOL_DETAILS` | Bash command, MCP tool name, Skill name, file path, subagent type |
+| `OTEL_LOG_TOOL_CONTENT` | Tool input/output content in span events (60 KB truncation) |
+| `OTEL_LOG_RAW_API_BODIES` | Full Anthropic API request/response JSON (`1` inline / `file:<dir>` to disk with `body_ref`) |
+
+This is notably stricter than most third-party LLM observability platforms, which default to capturing prompts and tool I/O.
+
+### Distributed Trace Propagation
+
+`TRACEPARENT` is auto-injected into Bash and PowerShell subprocesses so any W3C-compliant child can parent its spans under the active tool execution span. In Agent SDK and headless (`claude -p`) sessions, CC **reads** `TRACEPARENT` + `TRACESTATE` from its own environment so an embedding process can pass in its active context. Interactive sessions deliberately ignore inbound `TRACEPARENT` to prevent accidental inheritance from CI/container ambient values.
+
+### Cardinality Controls
+
+Toggle metric attributes to trade granularity for storage cost:
+
+| Variable | Default | Attribute toggled |
+|---|---|---|
+| `OTEL_METRICS_INCLUDE_SESSION_ID` | `true` | `session.id` |
+| `OTEL_METRICS_INCLUDE_VERSION` | `false` | `app.version` |
+| `OTEL_METRICS_INCLUDE_ACCOUNT_UUID` | `true` | `user.account_uuid`, `user.account_id` |
+
+### Cross-Reference
+
+For the complete env var reference, see [CC-env-vars-reference.md § OpenTelemetry Exporter Configuration](../cc-native/configuration/CC-env-vars-reference.md#opentelemetry-exporter-configuration). For SaaS backends that can ingest CC's native OTel output unmodified, see [§ Pydantic Logfire](#pydantic-logfire) below — Logfire explicitly advertises a "zero-config" Claude Code path via its MCP server ([source][logfire]).
 
 ## OpenTelemetry GenAI Semantic Conventions (2025-2026)
 
@@ -588,3 +641,6 @@ The 2026 landscape shows significant maturation with 89% of organizations implem
 ### Future Outlook
 
 The observability landscape continues rapid evolution toward standardization (OpenTelemetry), specialization (multi-agent coordination), and integration (development-to-production workflows). Framework-specific semantic conventions completion expected through 2026 will further unify agent observability across diverse technical stacks, while multi-agent capabilities will become standard rather than specialized features as agentic systems scale in production environments.
+
+[cc-monitoring]: https://code.claude.com/docs/en/monitoring-usage
+[logfire]: https://pydantic.dev/logfire

--- a/docs/cc-native/configuration/CC-env-vars-reference.md
+++ b/docs/cc-native/configuration/CC-env-vars-reference.md
@@ -2,8 +2,8 @@
 title: CC Environment Variables Reference
 purpose: Consolidated reference for CLAUDE_CODE_* and related env vars relevant to autonomous agent workflows, including undocumented vars from binary string extraction.
 created: 2026-03-27
-updated: 2026-04-13
-validated_links: 2026-04-13
+updated: 2026-04-24
+validated_links: 2026-04-24
 ---
 
 **Status**: Adopt
@@ -52,11 +52,53 @@ Cross-ref: [CC-extended-context-analysis.md](../context-memory/CC-extended-conte
 | Variable | Default | Purpose | Source |
 |---|---|---|---|
 | `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `0` | Equivalent of `DISABLE_AUTOUPDATER` + `DISABLE_FEEDBACK_COMMAND` + `DISABLE_ERROR_REPORTING` + `DISABLE_TELEMETRY`. **Blocks Remote Control** — eligibility check uses this path. Use individual flags instead if Remote Control is needed. See [CC-remote-control-analysis.md](../ci-remote/CC-remote-control-analysis.md#environment-variable-blockers) | [env-vars][env-vars] |
-| `CLAUDE_CODE_ENABLE_TELEMETRY` | `0` | Enable OTel metrics/logs export | [env-vars][env-vars], [monitoring][monitoring] |
+| `CLAUDE_CODE_ENABLE_TELEMETRY` | `0` | Enable OTel metrics/logs export (prerequisite for all `OTEL_*` vars below) | [env-vars][env-vars], [monitoring][monitoring] |
+| `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA` | `0` | Enable distributed tracing (beta) in addition to metrics/logs | [monitoring][monitoring] |
+| `CLAUDE_CODE_OTEL_HEADERS_HELPER_DEBOUNCE_MS` | `1740000` (29 min) | Refresh interval for dynamic OTLP headers | [monitoring][monitoring] |
 | `DISABLE_AUTOUPDATER` | `0` | Prevent automatic CC updates | [env-vars][env-vars] |
 | `DISABLE_COST_WARNINGS` | `0` | Suppress cost warning messages | [env-vars][env-vars] |
 
-Cross-ref: [CC-version-pinning-resilience.md](../ci-remote/CC-version-pinning-resilience.md), [monitoring docs][monitoring]
+Cross-ref: [CC-version-pinning-resilience.md](../ci-remote/CC-version-pinning-resilience.md), [monitoring docs][monitoring], [CC-agent-observability-methods-analysis.md](../../cc-community/CC-agent-observability-methods-analysis.md#claude-code-first-party-otel-integration)
+
+### OpenTelemetry Exporter Configuration
+
+Standard `OTEL_*` variables (per the [OpenTelemetry specification][otel-spec]) that Claude Code honours when `CLAUDE_CODE_ENABLE_TELEMETRY=1`. Source for all rows: [monitoring][monitoring].
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OTEL_METRICS_EXPORTER` | — | Comma-separated: `otlp`, `prometheus`, `console`, `none` |
+| `OTEL_LOGS_EXPORTER` | — | Comma-separated: `otlp`, `console`, `none` |
+| `OTEL_TRACES_EXPORTER` | — | Comma-separated: `otlp`, `console`, `none`. Requires `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | — | `grpc`, `http/json`, `http/protobuf` (applies to all signals) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | Collector endpoint for all signals (e.g. `http://localhost:4317`) |
+| `OTEL_EXPORTER_OTLP_{METRICS,LOGS,TRACES}_{PROTOCOL,ENDPOINT}` | — | Per-signal overrides |
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | Auth headers (e.g. `Authorization=Bearer token`) |
+| `OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY` / `_CLIENT_CERTIFICATE` | — | mTLS client key/cert file paths |
+| `OTEL_METRIC_EXPORT_INTERVAL` | `60000` ms | Metrics export interval |
+| `OTEL_LOGS_EXPORT_INTERVAL` | `5000` ms | Logs export interval |
+| `OTEL_TRACES_EXPORT_INTERVAL` | `5000` ms | Span batch export interval |
+| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | `delta` | Set to `cumulative` if backend requires it |
+
+### OpenTelemetry Privacy Gates
+
+All disabled by default. Enabling `OTEL_LOG_RAW_API_BODIES` implies consent to everything the other three would reveal. Source: [monitoring][monitoring].
+
+| Variable | Effect |
+|---|---|
+| `OTEL_LOG_USER_PROMPTS` | Include prompt text in `user_prompt` event and `claude_code.interaction` span attribute (`1` to enable) |
+| `OTEL_LOG_TOOL_DETAILS` | Include tool parameters (Bash command, MCP tool name, Skill name, file path, subagent type) on tool events / span attributes |
+| `OTEL_LOG_TOOL_CONTENT` | Include tool input/output content in span events (truncated at 60 KB; requires tracing) |
+| `OTEL_LOG_RAW_API_BODIES` | Emit full Anthropic Messages API request/response as `api_request_body` / `api_response_body` events. `1` = inline 60 KB truncation; `file:<dir>` = untruncated to disk with `body_ref` pointer |
+
+### OpenTelemetry Cardinality Controls
+
+Toggle metric attributes to trade granularity for storage cost. Source: [monitoring][monitoring].
+
+| Variable | Default | Effect |
+|---|---|---|
+| `OTEL_METRICS_INCLUDE_SESSION_ID` | `true` | Include `session.id` attribute on metrics |
+| `OTEL_METRICS_INCLUDE_VERSION` | `false` | Include `app.version` attribute on metrics |
+| `OTEL_METRICS_INCLUDE_ACCOUNT_UUID` | `true` | Include `user.account_uuid` and `user.account_id` on metrics |
 
 ### Session Guards & Runtime
 
@@ -284,6 +326,7 @@ Cross-ref: [CC-binary-architecture.md](CC-binary-architecture.md), [CC RE landsc
 [settings]: https://code.claude.com/docs/en/settings
 [tools-ref]: https://code.claude.com/docs/en/tools-reference#bash-tool-behavior
 [monitoring]: https://code.claude.com/docs/en/monitoring-usage
+[otel-spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options
 [statusline]: https://code.claude.com/docs/en/statusline
 [gh-9359]: https://github.com/anthropics/claude-code/issues/9359
 [gh-11067]: https://github.com/anthropics/claude-code/issues/11067

--- a/docs/non-cc/README.md
+++ b/docs/non-cc/README.md
@@ -45,6 +45,12 @@ Standalone analyses of coding agents and orchestration tools beyond Claude Code.
 | [simpleagents-analysis.md](simpleagents-analysis.md) | CraftsMan-Labs/SimpleAgents (Rust LLM SDK) | Yes | Yes (Apache-2.0) |
 | [autoagent-analysis.md](autoagent-analysis.md) | HKUDS/AutoAgent (zero-code agent OS) | Yes | Yes (MIT) |
 
+## Protocols & Interfaces
+
+| Document | Scope |
+|---|---|
+| [ag-ui-protocol-landscape.md](ag-ui-protocol-landscape.md) | AG-UI (Agent-User Interaction protocol), A2UI (Google declarative generative-UI spec), OpenGenerativeUI (CopilotKit reference framework); 2026 ecosystem adoption + Salesforce non-adoption note |
+
 ## Planned
 
 Cline, opencode, Codebuff, Gemini CLI, Cursor, Antigravity, Kiro, Codex CLI,

--- a/docs/non-cc/ag-ui-protocol-landscape.md
+++ b/docs/non-cc/ag-ui-protocol-landscape.md
@@ -1,0 +1,140 @@
+---
+title: AG-UI / A2UI / OpenGenerativeUI Landscape
+purpose: Disambiguates the "Protocol Triangle" frontend layer — AG-UI (Agent-User Interaction), A2UI (declarative generative UI spec), OpenGenerativeUI (reference framework). Tracks 2026 ecosystem adoption and clarifies which vendors have and have not joined.
+created: 2026-04-24
+updated: 2026-04-24
+validated_links: 2026-04-24
+---
+
+**Status**: Research (informational)
+
+## Summary
+
+Three frequently-confused names occupy the agent↔user frontend layer in 2026: **AG-UI** is a transport protocol, **A2UI** is a declarative UI-payload spec, and **OpenGenerativeUI** is a CopilotKit reference framework. AG-UI carries A2UI (and other generative-UI specs) as payload. OpenGenerativeUI demonstrates the stack end-to-end but is not itself a protocol. Major framework vendors (Google ADK, Microsoft Agent Framework, AWS AgentCore, Oracle Agent Spec, PydanticAI) have adopted AG-UI; **Salesforce Agentforce 360 has not** — its protocol strategy centers on MCP via MuleSoft.
+
+## The Protocol Triangle (CopilotKit framing)
+
+| Layer | Protocol | Purpose |
+|---|---|---|
+| Model ↔ Tools | **MCP** (Model Context Protocol) | Context and tool exposure |
+| Agent ↔ Agent | **A2A** | Cross-agent coordination |
+| User/App ↔ Agent | **AG-UI** | Bi-directional event stream |
+| UI payload format | **A2UI** (and others) | Declarative widget descriptions carried inside AG-UI events |
+
+Source: [CopilotKit — AG-UI vs A2UI][ag-vs-a2]
+
+## AG-UI (Agent-User Interaction Protocol)
+
+**Repo**: [ag-ui-protocol/ag-ui][ag-ui-repo] | **Docs**: [docs.ag-ui.com][ag-ui-docs] | **Origin**: CopilotKit, incubated via LangGraph + CrewAI partnerships
+
+An open, lightweight, bi-directional protocol between any user-facing application and any agentic backend.
+
+### Wire Format
+
+- Frontend sends **one HTTP POST** carrying the user's prompt or current state
+- Backend replies with a **Server-Sent Events (SSE) stream** of typed JSON events
+- Optional binary channel for high-throughput scenarios
+
+### Core Event Types
+
+| Event | Purpose |
+|---|---|
+| `TEXT_MESSAGE_CONTENT` | Streaming token output |
+| `TOOL_CALL_START` | Agent invoked an external function/API |
+| `STATE_DELTA` | Incremental state diff (table rows, document edits) merged by the UI |
+| *Lifecycle / error events* | Timeouts, failures, done signals |
+
+Each event type has a well-defined JSON schema ([source][ag-ui-docs]).
+
+### Capabilities Out of the Box
+
+- Live token streaming
+- Tool-call progress updates
+- Incremental state diffs (bi-directional read/write or read-only shared state)
+- Explicit error and lifecycle events
+- Multi-agent handoffs on a single channel
+
+### 2026 Ecosystem Adoption
+
+Confirmed integrations per the [ag-ui README][ag-ui-repo] and [CopilotKit AG-UI page][ag-ui-copilotkit]:
+
+| Vendor / Framework | Source | Notes |
+|---|---|---|
+| **Google ADK** | [ag-ui README][ag-ui-repo] | Native integration — ADK agents collaborate via AG-UI |
+| **Microsoft Agent Framework** | [Microsoft Learn — AG-UI Integration][ms-learn-agui] | Official docs page; CopilotKit supplies UI components |
+| **AWS Strands Agents / Bedrock AgentCore** | [ag-ui README][ag-ui-repo] | Dedicated AG-UI endpoint in AgentCore + FAST template pattern (March 2026) |
+| **Oracle Agent Spec** | [Oracle blog — Agent Spec + AG-UI][oracle-agui] (March 2026) | Three-way alignment with Oracle + CopilotKit + Google (AG-UI + A2UI) |
+| **LangGraph**, **CrewAI** | [ag-ui README][ag-ui-repo] | Origin partnerships |
+| **Mastra**, **Pydantic AI**, **Agno**, **LlamaIndex**, **AG2**, **Langroid** | [ag-ui README][ag-ui-repo] | Framework integrations |
+| **Community SDKs** | [ag-ui README][ag-ui-repo] | Kotlin, Go, Dart, Java, Rust, Ruby, .NET, Nim, C++ |
+
+Scale signals (as reported by [CopilotKit][ag-ui-copilotkit]): 9K+ GitHub stars, 120K weekly installs combined with CopilotKit, 2M agent↔user interactions/week.
+
+### Non-Adopters (as of 2026-04-24)
+
+- **Salesforce Agentforce 360** — not listed on the [ag-ui README][ag-ui-repo] integrations. Salesforce's own [Agentforce 360 announcements][sf-agentforce] emphasize **MCP via MuleSoft** and the proprietary **MuleSoft Agent Fabric** for cross-platform agent discovery (spanning Agentforce + Amazon Bedrock + Google Vertex AI + Microsoft Copilot Studio). Frontend strategy is "Headless 360" (API/MCP/CLI exposure), not a frontend interaction protocol. See [Salesforce Ben — ISV expansion (Mar 2026)][sf-ben] and [Agentforce 360 for AWS][sf-aws].
+
+## A2UI (Agent-to-UI — Declarative Generative UI)
+
+**Origin**: Google, launched 2026. CopilotKit is a launch partner.
+
+A2UI is **not a transport** — it is a declarative spec describing UI widgets that an agent returns as part of its response. The transport is typically AG-UI, but A2UI is transport-agnostic.
+
+- A2UI widgets can be carried inside AG-UI events (`TEXT_MESSAGE_CONTENT` or dedicated widget events)
+- AG-UI natively supports all generative-UI specs — developers can also define custom ones
+- CopilotKit claims "full support" for A2UI ([source][ag-vs-a2])
+
+Source: [CopilotKit — Build with Google's new A2UI Spec][a2ui-blog]
+
+## OpenGenerativeUI (CopilotKit Reference Framework)
+
+**Repo**: [CopilotKit/OpenGenerativeUI][ogui-repo] | **Demo**: [opengenerativeui.copilotkit.ai][ogui-site]
+
+Not a protocol — an end-to-end reference implementation:
+
+- **Frontend**: Next.js 16 + React 19 + Tailwind CSS 4; components render as **sandboxed iframes** receiving HTML/SVG from the agent via the `useComponent` hook
+- **Agent**: LangChain Deep Agents with skills-based progressive disclosure
+- **MCP server**: design-system + skill resources + document-assembler exposed over MCP
+
+Supported clients per the repo: Claude Desktop (stdio), Claude Code / HTTP clients, Cursor, Next.js. Uses MCP for tool exposure and HTTP for client communication — **not AG-UI directly**, though the patterns are compatible.
+
+## Decision Matrix
+
+| Your need | Use |
+|---|---|
+| Stream agent events to any frontend | **AG-UI** (protocol) |
+| Agent emits structured UI widgets | **A2UI** spec over AG-UI |
+| End-to-end demo with generative HTML components | **OpenGenerativeUI** (reference) |
+| Claude Code observability over agent-user interactions | Use AG-UI-compatible backend + OTel (see [CC-agent-observability-methods-analysis.md § Claude Code (First-Party OTel Integration)](../cc-community/CC-agent-observability-methods-analysis.md#claude-code-first-party-otel-integration)) |
+
+## Cross-References
+
+- [CC-agent-observability-methods-analysis.md](../cc-community/CC-agent-observability-methods-analysis.md) — OTel observability patterns (AG-UI events can be modeled as OTel spans)
+- [CC-connectors-overview.md](../cc-native/plugins-ecosystem/CC-connectors-overview.md) — MCP connector landscape (the model↔tool leg of the Protocol Triangle)
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [ag-ui-protocol/ag-ui][ag-ui-repo] | Protocol spec, integrations list |
+| [docs.ag-ui.com][ag-ui-docs] | Official AG-UI documentation |
+| [CopilotKit AG-UI page][ag-ui-copilotkit] | Partner list, adoption metrics |
+| [CopilotKit — AG-UI vs A2UI][ag-vs-a2] | Protocol Triangle framing, A2UI relationship |
+| [Google A2UI launch (CopilotKit blog)][a2ui-blog] | A2UI spec origin |
+| [Oracle Agent Spec + AG-UI (Oracle blog)][oracle-agui] | Three-way alignment announcement |
+| [Microsoft Learn — AG-UI Integration][ms-learn-agui] | Microsoft Agent Framework integration |
+| [CopilotKit/OpenGenerativeUI][ogui-repo] | Reference framework |
+| [Salesforce Agentforce 360][sf-agentforce] | Salesforce protocol strategy (MCP, not AG-UI) |
+
+[ag-ui-repo]: https://github.com/ag-ui-protocol/ag-ui
+[ag-ui-docs]: https://docs.ag-ui.com/
+[ag-ui-copilotkit]: https://www.copilotkit.ai/ag-ui
+[ag-vs-a2]: https://www.copilotkit.ai/ag-ui-and-a2ui
+[a2ui-blog]: https://www.copilotkit.ai/blog/build-with-googles-new-a2ui-spec-agent-user-interfaces-with-a2ui-ag-ui
+[oracle-agui]: https://blogs.oracle.com/ai-and-datascience/announcing-agent-spec-for-a2ui-copilotkit-ag-ui
+[ms-learn-agui]: https://learn.microsoft.com/en-us/agent-framework/integrations/ag-ui/
+[ogui-repo]: https://github.com/CopilotKit/OpenGenerativeUI
+[ogui-site]: https://opengenerativeui.copilotkit.ai/
+[sf-agentforce]: https://www.salesforce.com/agentforce/what-is-new/
+[sf-ben]: https://www.salesforceben.com/salesforce-opens-agentforce-360-to-isvs-so-partners-can-build-and-distribute-ai-agents/
+[sf-aws]: https://www.salesforce.com/news/stories/agentforce-360-for-aws-announcement/

--- a/lychee.toml
+++ b/lychee.toml
@@ -8,7 +8,8 @@ exclude_path = ["triage/", "docs/todo/"]
 
 # Accept common bot-blocked status codes
 # 405 = HEAD method not allowed (status pages often reject HEAD)
-accept = [200, 429, 405]
+# 418 = I'm a teapot (freedesktop.org bot-block)
+accept = [200, 429, 405, 418, 202]
 
 # Exclude domains that block automated requests (return 403/401 to HEAD)
 exclude = [


### PR DESCRIPTION
## Summary

Two independent research additions plus a lychee config tweak:

1. **First-party OTel integration for Claude Code** — env var reference and observability analysis extended with the full OTEL_* surface, privacy gates, span hierarchy, TRACEPARENT propagation behavior, and cardinality controls. Sourced entirely from code.claude.com/docs/en/monitoring-usage.
2. **AG-UI / A2UI / OpenGenerativeUI landscape** — new docs/non-cc/ag-ui-protocol-landscape.md disambiguating the Protocol Triangle frontend layer, cataloguing 2026 ecosystem adoption, and explicitly calling out Salesforce Agentforce 360 as a non-adopter (protocol strategy = MCP via MuleSoft, not AG-UI).
3. **chore** — accept 418 (freedesktop.org teapot bot-block) and 202 (marktechpost.com) as success codes in lychee.

## Commits (3, by topic)

1. \`docs:\` — CC OTel integration reference (CC-env-vars-reference.md + CC-agent-observability-methods-analysis.md)
2. \`docs:\` — AG-UI landscape (new file + README index entry)
3. \`chore:\` — lychee accept codes for unrelated hosts

## Test plan

- [x] \`make check_docs\` → 0 errors
- [x] \`make check_links\` → 0 errors (1258 OK / 48 excluded / 43 redirects)
- [x] All new first-party URLs verified (code.claude.com, ag-ui-protocol, docs.ag-ui.com, copilotkit.ai, oracle.com, learn.microsoft.com, salesforce.com)
- [x] No risky \${{ github.event.* }} interpolations (docs only)
- [ ] CI Lint workflow run on this PR

Generated with Claude <noreply@anthropic.com>