### PR TITLE
docs: clarify doc hierarchy + add fresh-agent onboarding block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,13 @@ Gather more context or escalate to AGENT_REQUESTS.md
 
 ## Agent Quick Reference
 
+**Onboarding (fresh AI agent):**
+
+1. Read README.md (project overview) → AGENTS.md (this file) → CONTRIBUTING.md (workflow)
+2. Read AGENT_LEARNINGS.md and AGENT_REQUESTS.md for tracked patterns and open asks. If your harness exposes a per-project auto-memory store, read it too (host-local, optional, not git-tracked)
+3. Use one Explore-style subagent for "survey docs/ for existing coverage of X" — return summary, not raw dumps. Default to single-agent execution; switch to team mode only if work parallelizes across independent files
+4. Then follow CONTRIBUTING.md (Research Workflow → Maintenance → Commit & PR)
+
 **Pre-Task:**
 
 - Read AGENTS.md > CONTRIBUTING.md for technical details

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ai-agents-research
 
-Documentation standards and conventions for research analysis documents.
+Documentation standards and conventions for research analysis documents — for any contributor, human or AI agent.
 
 ## Document Structure
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ai-agents-research
 
+> Project overview — start here. Audience: any contributor or AI agent.
+>
 > Field research and feature analysis for AI coding agents — from sandboxing internals to agent orchestration.
 
 ## Why


### PR DESCRIPTION
## Summary

Codifies the doc-hierarchy convention (audience split) that was implicit but undocumented, and adds a concrete onboarding sequence for fresh AI agents.

## Changes

| File | Change |
|---|---|
| README.md | Audience tag: \"Project overview — start here. Audience: any contributor or AI agent.\" |
| CONTRIBUTING.md | Tagline appended: \"— for any contributor, human or AI agent.\" |
| AGENTS.md | New \"Onboarding (fresh AI agent)\" subsection at top of Agent Quick Reference |

The onboarding block defines: read order (README → AGENTS → CONTRIBUTING), tracked-context files (AGENT_LEARNINGS.md, AGENT_REQUESTS.md, optional host-local auto-memory), Explore-subagent default vs team-mode threshold, and pointer back to CONTRIBUTING for workflow.

10 lines added total. No content duplicated.

## Test plan

- [x] make check_docs → 0 errors
- [x] make check_links → 0 errors
- [ ] CI Lint workflow run on this PR

Generated with Claude <noreply@anthropic.com>