### PR TITLE
docs(cc-native): engine-layer cross-links to doc-pipeline-engine (#131, #132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/cc-native/plugins-ecosystem/CC-office-document-skills.md`: engine-layer cross-link (dated 2026-04-26) to `qte77/doc-pipeline-engine/docs/landscape-output.md` per #131
+- `docs/cc-native/plugins-ecosystem/CC-web-scraping-plugins-analysis.md`: engine-layer cross-link (dated 2026-04-26) to `qte77/doc-pipeline-engine/docs/landscape-ingest.md` per #132
+
 - `docs/cc-community/CC-community-tooling-landscape.md`: ccusage (13.4K stars, MIT, ryoppippi, v18.0.11) — CC/Codex JSONL usage analyzer with daily/monthly/session/blocks reports, cache-token split, offline mode (`--offline`), built-in MCP server, statusline hook (Beta); reads `~/.claude/projects/`
 - `docs/cc-community/CC-community-tooling-landscape.md`: Claude-Code-Usage-Monitor (7.8K stars, MIT, Maciek-roboblog, v3.1.0) — predictive real-time TUI with P90-based custom plan auto-detection, burn-rate analytics, Pro/Max5/Max20 plan-aware limits; Python 3.9+ via `uv tool install` or `pip`
 - `docs/cc-community/CC-community-tooling-landscape.md`: CodeBurn (4K stars, MIT, AgentSeal) — cross-agent token-usage TUI dashboard reading on-disk session data from Claude Code, Codex, Cursor, OpenCode, Copilot and others; 13 task categories, `optimize`/`compare`/`export` subcommands, LiteLLM-sourced pricing, native macOS menubar app

--- a/docs/cc-native/plugins-ecosystem/CC-office-document-skills.md
+++ b/docs/cc-native/plugins-ecosystem/CC-office-document-skills.md
@@ -100,6 +100,10 @@ Standalone MCP servers enabling Claude Code (or any MCP client) to manipulate do
 - [CC-business-api-integrations.md](CC-business-api-integrations.md) — Business APIs (accounting, CRM, payments) that feed into document workflows
 - [CC-office-worker-workflows.md](../../cc-community/CC-office-worker-workflows.md) — End-to-end workflow patterns combining these capabilities
 
+### Engine-layer view (added 2026-04-26 per #131)
+
+For the Python-library landscape behind office-document generation (python-docx, python-pptx, openpyxl, docxtpl, WeasyPrint, ReportLab, Pandoc, Typst — including license/runtime trade-offs), see [doc-pipeline-engine / landscape-output.md](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape-output.md). This file covers the CC orchestration layer above those libraries.
+
 ## Sources
 
 | Source | Content |

--- a/docs/cc-native/plugins-ecosystem/CC-web-scraping-plugins-analysis.md
+++ b/docs/cc-native/plugins-ecosystem/CC-web-scraping-plugins-analysis.md
@@ -422,6 +422,10 @@ Community testing ([source][devto-browser-tools]) identified additional options 
 - **Self-host Firecrawl** if scraping volume exceeds free tier or privacy requirements mandate it
 - **Evaluate PinchTab** as a lighter-weight Playwright alternative for token-constrained contexts
 
+## Engine-layer view (added 2026-04-26 per #132)
+
+For the Python-library landscape behind web crawling and source connectors (polyfetch-scrape, trafilatura, scrapy, httpx, watchdog, plus SharePoint/Confluence/Drive/S3/IMAP connectors), see [doc-pipeline-engine / landscape-ingest.md](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape-ingest.md). This file covers the CC orchestration layer above those tools.
+
 ## References
 
 ### First-Party


### PR DESCRIPTION
## Summary

Adds the reverse-direction cross-links requested in #131 and #132. The doc-pipeline-engine landscape files already link here; these one-way refs become bidirectional.

Cross-links are **dated in-line** (`added 2026-04-26 per #131` / `#132`) so future audits can spot stale engine-layer pointers without git archaeology — the dates travel with the content.

## Changes

- **`CC-office-document-skills.md`** → `doc-pipeline-engine / landscape-output.md` (Python writers: python-docx, python-pptx, openpyxl, docxtpl, WeasyPrint, ReportLab, Pandoc, Typst)
- **`CC-web-scraping-plugins-analysis.md`** → `doc-pipeline-engine / landscape-ingest.md` (crawlers + connectors: polyfetch-scrape, trafilatura, scrapy, httpx, watchdog, SharePoint/Confluence/Drive/S3/IMAP)

## Closes

- #131
- #132

## Test plan

- [x] `make check_docs` — 0 errors
- [x] `make check_links` — 0 errors (1361 links, both new external links resolved OK)
- [x] CHANGELOG entries added under `[Unreleased] / Added`

🤖 Generated with [Claude Code](https://claude.com/claude-code)