### PR TITLE
chore: gitignore bwrap sandbox phantom files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ Thumbs.db
 # bwrap sandbox phantom files
 # Bug: $HOME-dotfile deny list resolved against process.cwd() leaks 0-byte
 # char-special /dev/null bind-mount targets into the project root. See
-# docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md.
+# https://github.com/qte77/ai-agents-research/blob/main/docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md
 # Tracked: anthropics/claude-code#17727, sandbox-runtime#139
 /.bash_profile
 /.bashrc

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,33 @@ Thumbs.db
 .claude/scripts/
 .claude/skills/
 
+# bwrap sandbox phantom files
+# Bug: $HOME-dotfile deny list resolved against process.cwd() leaks 0-byte
+# char-special /dev/null bind-mount targets into the project root. See
+# docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md.
+# Tracked: anthropics/claude-code#17727, sandbox-runtime#139
+/.bash_profile
+/.bashrc
+/.claude/agents
+/.claude/commands
+/.claude/skills
+/.gitconfig
+/.gitmodules
+/.idea
+/.mcp.json
+/.profile
+/.ripgreprc
+/.vscode
+/.zprofile
+/.zshrc
+# Git internals leaked by denyWithinAllow auto-generation dropping the
+# .git/ prefix — same root cause class
+/HEAD
+/config
+/hooks
+/objects
+/refs
+
 # Python artifacts
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Summary

Follow-up to #144 — adds rooted-pattern `.gitignore` entries for the bwrap sandbox phantom files documented in `docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md`.

## What's added

A new `.gitignore` section between "Plugin-deployed files" and "Python artifacts":

- **14 `$HOME`-dotfile phantoms** (poltimmer's `oiH` list on anthropics/claude-code#17727): `.bash_profile`, `.bashrc`, `.claude/agents`, `.claude/commands`, `.claude/skills`, `.gitconfig`, `.gitmodules`, `.idea`, `.mcp.json`, `.profile`, `.ripgreprc`, `.vscode`, `.zprofile`, `.zshrc`
- **5 git-internals leaks** from `denyWithinAllow` auto-generation dropping the `.git/` prefix: `HEAD`, `config`, `hooks`, `objects`, `refs`

All entries use rooted patterns (`/<path>`) because the existing trailing-slash directory patterns (`.vscode/`, `.idea/`, `.claude/skills/`) do not match the phantoms — bwrap creates them as 0-byte char-special device nodes, not directories.

## Verification

| Before patch | After patch |
|---|---|
| 17+ untracked phantom files in `git status` | only `.env` (real user file) + `MEMORY.md` (auto-memory) untracked |

The `git fetch` warning `unable to access '.../.gitmodules': Permission denied` is unaffected (it's git probing the file at fetch time, not honoring `.gitignore`), but the `git status` noise is fully resolved.

## Tracked upstream

- [anthropics/claude-code#17727](https://github.com/anthropics/claude-code/issues/17727) — canonical active discussion
- [`sandbox-runtime#139`](https://github.com/anthropic-experimental/sandbox-runtime/issues/139) — upstream fix tracker

## Test plan

- [x] `git status` shows phantoms ignored
- [x] No real files inadvertently ignored (rooted patterns scope to repo root only)
- [x] Section placement consistent with existing comment-block convention

Generated with Claude <noreply@anthropic.com>