### PR TITLE
docs: list bwrap dead-end mitigations in friction doc

### DIFF
--- a/docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md
+++ b/docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md
@@ -123,6 +123,24 @@ Upstream fix tracker: [`anthropic-experimental/sandbox-runtime#139`][sr-139].
 - Avoid project-scoped `.mcp.json` while bug is live — the phantom shadows
   any real config placed there.
 
+### What does NOT work (don't waste time on these)
+
+- **Editing `permissions.deny` or `sandbox.filesystem.denyRead`** — the
+  `$HOME`-dotfile deny list is built by an internal runtime function
+  (`Rx4`'s hardcoded `oiH` array per [poltimmer on #17727][gh-17727]),
+  not from user settings. There is nothing to remove.
+- **`submodule.recurse=false`** or other submodule git config — git probes
+  `.gitmodules` to discover submodules regardless of recurse settings, so
+  the `unable to access ... .gitmodules: Permission denied` warning during
+  `git fetch` persists.
+- **`touch .gitmodules`** (or any other affected file) to pre-create a real
+  file — bwrap mounts `/dev/null` over it during the session, and
+  cleanup-on-exit is best-effort and skipped when concurrent sandboxes are
+  active. Real content can be lost.
+
+The only working mitigations are gitignore (cosmetic), full sandbox disable,
+or waiting for [`sandbox-runtime#139`][sr-139].
+
 ### Version timeline
 
 | Version | Observation |


### PR DESCRIPTION
## Summary

Follow-up to #144 (and complementing #145) — adds a `### What does NOT work` subsection to `docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md` listing three plausible-looking mitigations that don't work, with the reason each fails.

## What's added

A new subsection between "Mitigations" and "Version timeline" covering:

1. **Editing `permissions.deny` / `sandbox.filesystem.denyRead`** — the `\$HOME`-dotfile deny list is hardcoded in runtime function `Rx4` (poltimmer's `oiH` analysis on [#17727](https://github.com/anthropics/claude-code/issues/17727)), not user-configurable.
2. **`submodule.recurse=false`** — git probes `.gitmodules` to discover submodules regardless of recurse setting, so the `Permission denied` fetch warning persists.
3. **`touch .gitmodules`** to pre-create a real file — bwrap mounts `/dev/null` over it during the session and cleanup-on-exit is best-effort, so real content can be lost.

Closes the gap by pointing readers back to the only working mitigations (gitignore via #145, full sandbox disable, or [`sandbox-runtime#139`](https://github.com/anthropic-experimental/sandbox-runtime/issues/139)).

## Test plan

- [x] markdownlint-cli2 — 0 errors
- [x] lychee — 16/16 URLs OK
- [x] Cross-references (`[gh-17727]`, `[sr-139]`) reuse existing footnote definitions in the doc

Generated with Claude <noreply@anthropic.com>