### PR TITLE
docs: AGENT_LEARNINGS bwrap phantom-files entry

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -15,7 +15,7 @@ description: Non-obvious patterns that prevent repeated mistakes across sprints
 
 ### Phantom files in repo root from bwrap sandbox
 
-- **Context**: Linux/WSL2/Codespace with Claude Code's bubblewrap sandbox enabled (default). Reproduces on Fedora 43, Arch, Ubuntu 24.04, WSL2.
-- **Problem**: Project root accumulates 0-byte char-special files (`.bashrc`, `.gitconfig`, `.gitmodules`, `.mcp.json`, `HEAD`, `config`, etc.) that poison `git status`, break `git log HEAD`, block `EnterWorktree`, and surface as `Permission denied` warnings during `git fetch`.
-- **Solution**: Recognize the symptom early via the file morphology table in the friction doc. Apply the rooted-pattern `.gitignore` block (already in this repo). Do NOT try to fix via `permissions.deny` (the deny list is hardcoded in runtime function `Rx4`, not user-configurable). Do NOT pre-create the file with `touch` (bwrap mounts `/dev/null` over real content; cleanup is best-effort and skipped when concurrent sandboxes are active).
-- **References**: [docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md](docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md) — canonical analysis with full issue map, version timeline, and dead-end mitigations. Upstream: [anthropics/claude-code#17727](https://github.com/anthropics/claude-code/issues/17727), [sandbox-runtime#139](https://github.com/anthropic-experimental/sandbox-runtime/issues/139).
+- **Context**: Claude Code with bubblewrap sandbox on Linux/WSL2/Codespaces.
+- **Problem**: 0-byte char-special files leak into project root (`.bashrc`, `.mcp.json`, `HEAD`, `config`, etc.) — poison `git status`, break `git log HEAD`, block `EnterWorktree`.
+- **Solution**: Use the rooted-pattern `.gitignore` block (already in repo). See friction doc for dead-ends to avoid.
+- **References**: [docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md](docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md) (canonical), [anthropics/claude-code#17727](https://github.com/anthropics/claude-code/issues/17727).

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -12,3 +12,10 @@ description: Non-obvious patterns that prevent repeated mistakes across sprints
 - **References**: Related files
 
 ## Learned Patterns
+
+### Phantom files in repo root from bwrap sandbox
+
+- **Context**: Linux/WSL2/Codespace with Claude Code's bubblewrap sandbox enabled (default). Reproduces on Fedora 43, Arch, Ubuntu 24.04, WSL2.
+- **Problem**: Project root accumulates 0-byte char-special files (`.bashrc`, `.gitconfig`, `.gitmodules`, `.mcp.json`, `HEAD`, `config`, etc.) that poison `git status`, break `git log HEAD`, block `EnterWorktree`, and surface as `Permission denied` warnings during `git fetch`.
+- **Solution**: Recognize the symptom early via the file morphology table in the friction doc. Apply the rooted-pattern `.gitignore` block (already in this repo). Do NOT try to fix via `permissions.deny` (the deny list is hardcoded in runtime function `Rx4`, not user-configurable). Do NOT pre-create the file with `touch` (bwrap mounts `/dev/null` over real content; cleanup is best-effort and skipped when concurrent sandboxes are active).
+- **References**: [docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md](docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md) — canonical analysis with full issue map, version timeline, and dead-end mitigations. Upstream: [anthropics/claude-code#17727](https://github.com/anthropics/claude-code/issues/17727), [sandbox-runtime#139](https://github.com/anthropic-experimental/sandbox-runtime/issues/139).


### PR DESCRIPTION
## Summary

Adds the first entry to `AGENT_LEARNINGS.md` — a brief pointer to the bwrap phantom-files friction doc.

Per the compound-learning rule, this pattern surfaced 3+ times in recent work (`.mcp.json` char-dev phantom, `.gitmodules` permission-denied during `git fetch`, `.bashrc`/`.zshrc` shell-rc leakage) across [4 GitHub issues](https://github.com/anthropics/claude-code/issues/17727).

Establishes the pattern for future learnings: brief pointer to a canonical doc, no duplication. Two commits squash to one — the second tightens the first to be a pointer rather than a re-explanation.

## Test plan

- [x] markdownlint-cli2 — 0 errors
- [x] lychee — 2/2 URLs OK
- [x] Single-source principle: entry references `docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md` rather than restating its content

Generated with Claude <noreply@anthropic.com>