### PR TITLE
chore: untrack-ignore .claude/rules/ to allow project-local rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 Thumbs.db
 
 # Plugin-deployed files (source of truth: claude-code-plugins)
-.claude/rules/
 .claude/scripts/
 .claude/skills/
 


### PR DESCRIPTION
## Summary

Removes `.claude/rules/` from `.gitignore` so the project can track local rule files.

## Rationale

The plugin deployment (`Makefile :: setup_skills`) only symlinks into `.claude/skills/` — `.claude/rules/` was a preemptive entry never used. Removing it lets project-local rules be tracked alongside plugin-deployed skills, no conflict.

`.claude/scripts/` and `.claude/skills/` remain ignored (unchanged).

## Test plan

- [x] Single-line deletion, minimal scope
- [x] Verified Makefile has zero `rules` references — no plugin/local conflict
- [x] `.claude/rules/` is not in poltimmer's bwrap phantom-leak list (#17727), so no phantom-file conflict either

Generated with Claude <noreply@anthropic.com>