### PR TITLE
fix(ci): resolve 6 pre-existing lychee link errors (closes #143)

### DIFF
--- a/docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md
+++ b/docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md
@@ -94,7 +94,7 @@ Shell commands fire automatically at specific agent lifecycle points, outside th
 
 ## Author
 
-[Bilgin Ibryam](https://www.linkedin.com/in/bibryam/) -- Principal PM at Diagrid (Dapr). Apache Software Foundation Member. Previously 9 years at Red Hat, before that BBC News. Author of *Kubernetes Patterns* (O'Reilly, 2nd ed. 2023), *Camel Design Patterns*, and the new [Prompt Patterns](https://www.promptpatterns.dev/) catalog.
+[Bilgin Ibryam](https://github.com/bibryam) -- Principal PM at Diagrid (Dapr). Apache Software Foundation Member. Previously 9 years at Red Hat, before that BBC News. Author of *Kubernetes Patterns* (O'Reilly, 2nd ed. 2023), *Camel Design Patterns*, and the new [Prompt Patterns](https://www.promptpatterns.dev/) catalog.
 
 Pattern taxonomist by trade: Kubernetes patterns -> Camel patterns -> Prompt patterns -> Agentic harness patterns.
 

--- a/docs/cc-native/plugins-ecosystem/CC-office-document-skills.md
+++ b/docs/cc-native/plugins-ecosystem/CC-office-document-skills.md
@@ -102,7 +102,7 @@ Standalone MCP servers enabling Claude Code (or any MCP client) to manipulate do
 
 ### Engine-layer view (added 2026-04-26 per #131)
 
-For the Python-library landscape behind office-document generation (python-docx, python-pptx, openpyxl, docxtpl, WeasyPrint, ReportLab, Pandoc, Typst — including license/runtime trade-offs), see [doc-pipeline-engine / landscape-output.md](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape-output.md). This file covers the CC orchestration layer above those libraries.
+For the Python-library landscape behind office-document generation (python-docx, python-pptx, openpyxl, docxtpl, WeasyPrint, ReportLab, Pandoc, Typst — including license/runtime trade-offs), see [doc-pipeline-engine / landscape/output.md](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/output.md). This file covers the CC orchestration layer above those libraries.
 
 ## Sources
 

--- a/docs/cc-native/plugins-ecosystem/CC-web-scraping-plugins-analysis.md
+++ b/docs/cc-native/plugins-ecosystem/CC-web-scraping-plugins-analysis.md
@@ -424,7 +424,7 @@ Community testing ([source][devto-browser-tools]) identified additional options 
 
 ## Engine-layer view (added 2026-04-26 per #132)
 
-For the Python-library landscape behind web crawling and source connectors (polyfetch-scrape, trafilatura, scrapy, httpx, watchdog, plus SharePoint/Confluence/Drive/S3/IMAP connectors), see [doc-pipeline-engine / landscape-ingest.md](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape-ingest.md). This file covers the CC orchestration layer above those tools.
+For the Python-library landscape behind web crawling and source connectors (polyfetch-scrape, trafilatura, scrapy, httpx, watchdog, plus SharePoint/Confluence/Drive/S3/IMAP connectors), see [doc-pipeline-engine / landscape/ingest.md](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/ingest.md). This file covers the CC orchestration layer above those tools.
 
 ## References
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -38,8 +38,11 @@ exclude = [
     "substack.com",
     "blog.jetbrains.com",
     "neptune.ai",
-    # Auth-gated (requires login)
-    "claude.ai/code/scheduled",
+    # Auth-gated (requires login) — both `/code` and `/code/scheduled` and `/settings/*` return 403 to anonymous requests
+    "claude.ai/code",
+    "claude.ai/settings",
+    # HF Space outage 2026-04 — re-check periodically; underlying paper is still cited in autoagent-analysis.md
+    "gaia-benchmark-leaderboard.hf.space",
     # Timeout-prone marketing sites (heavy JS homepages or JS-rendered)
     "agentskills.io",
     "e2b.dev",


### PR DESCRIPTION
## Summary

Fixes the 6 pre-existing lychee errors documented in #143 that block green CI on every docs PR (currently blocking #142).

| URL (was) | Status | Fix |
|---|---|---|
| `linkedin.com/in/bibryam/` | 404 | Replaced with `github.com/bibryam` (verified live via gh api) |
| `claude.ai/code` | 403 | Added to `lychee.toml` exclude (auth-gated). Now also covers `claude.ai/code/scheduled` as substring match — old narrower entry removed. |
| `claude.ai/settings/connectors` | 403 | Added `claude.ai/settings` exclude (covers all settings subpaths, all auth-gated) |
| `doc-pipeline-engine/.../docs/landscape-output.md` | 404 | Repointed to `docs/landscape/output.md` (sibling repo restructured `docs/landscape/` into a directory; verified via gh api) |
| `doc-pipeline-engine/.../docs/landscape-ingest.md` | 404 | Repointed to `docs/landscape/ingest.md` (same restructure) |
| `gaia-benchmark-leaderboard.hf.space` | 503 | Added URL to `lychee.toml` exclude (HF Space outage). Underlying GAIA paper citation preserved in `autoagent-analysis.md`. |

## Test plan

- [x] `make check_docs` — 0 markdownlint errors across 130 files
- [x] `make check_links` — 0 errors (one transient GitHub 502 on first run; passed cleanly on retry — already covered by existing `max_retries = 3` in lychee.toml)
- [x] All replacement URLs verified resolvable via `gh api` (network-gated to github.com in this env)

## Notes

- 4 files changed, 8 insertions(+), 5 deletions(-)
- No autofix was run — all edits are targeted (memory: markdownlint --fix can corrupt ref-style link defs)
- Once merged, this should unblock #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)