### PR TITLE
chore: gitignore .env phantom + .gh-cache + add MEMORY.md scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ Thumbs.db
 .claude/scripts/
 .claude/skills/
 
+# Tooling caches (per-session artifacts, never tracked)
+.gh-cache/
+
 # bwrap sandbox phantom files
 # Bug: $HOME-dotfile deny list resolved against process.cwd() leaks 0-byte
 # char-special /dev/null bind-mount targets into the project root. See
@@ -16,6 +19,7 @@ Thumbs.db
 /.claude/agents
 /.claude/commands
 /.claude/skills
+/.env
 /.gitconfig
 /.gitmodules
 /.idea

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,31 @@
+# Claude Code Memory
+
+Cross-repo working patterns for AI coding agent workflows.
+
+## Git Conventions
+
+- **Protected mains** — always feature branches + PRs
+- **Squash merge**: `PR <conventional-commit-title> (#NUM)`, branch commits in body
+- **Push**: `git push origin <branch-name>` (never `HEAD` or bare)
+
+## Auth & Credentials
+
+<!-- Project-specific auth patterns (PATs, tokens, SSO) -->
+
+## Sandbox & Settings
+
+- Network sandbox ON, filesystem relaxed (container isolation)
+- SOT: `~/.claude/settings.json`
+- Settings require session restart (no hot-reload)
+
+## Project Patterns
+
+<!-- Project-specific conventions, architecture notes -->
+
+## Learned Preferences
+
+<!-- Agent behavior corrections, confirmed approaches -->
+
+## Known Issues
+
+<!-- Active workarounds, known bugs, environment quirks -->


### PR DESCRIPTION
## Summary

Two small chores split into one commit each.

### 1. `chore: gitignore .env phantom file and .gh-cache tooling dir`

- `/.env` joins the bwrap phantom-file section. The host's bwrap sandbox emits a 0-byte char-special `/dev/null` bind-mount target named `.env` in the project root — same root cause class as the other entries already documented there (see `docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md`). Confirmed via `stat .env` showing `character special file`, `Uid: nobody`.
- `.gh-cache/` joins a new tooling-cache section. `gh run view --log-failed` needs a writable `XDG_CACHE_HOME`; in this sandbox the only writable path is the project root, so a per-session `.gh-cache/` is created. Should never be tracked.

### 2. `docs: add MEMORY.md scaffold for cross-repo working patterns`

Top-level scratchpad alongside `AGENTS.md` / `CLAUDE.md` / `AGENT_LEARNINGS.md`. Sections: Git Conventions, Auth & Credentials, Sandbox & Settings, Project Patterns, Learned Preferences, Known Issues. Most are placeholders — entries get added as patterns emerge.

## Test plan

- [x] `git status` clean after commits (no `.env`, no `.gh-cache/`, no `MEMORY.md` left untracked)
- [ ] CI lint passes (markdownlint + lychee)

🤖 Generated with [Claude Code](https://claude.com/claude-code)