### PR TITLE
docs(bwrap): Friction 3 — bind-mount-held files block git unlink + workaround

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -19,3 +19,10 @@ description: Non-obvious patterns that prevent repeated mistakes across sprints
 - **Problem**: 0-byte char-special files leak into project root (`.bashrc`, `.mcp.json`, `HEAD`, `config`, etc.) — poison `git status`, break `git log HEAD`, block `EnterWorktree`.
 - **Solution**: Use the rooted-pattern `.gitignore` block (already in repo). See friction doc for dead-ends to avoid.
 - **References**: [docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md](docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md) (canonical), [anthropics/claude-code#17727](https://github.com/anthropics/claude-code/issues/17727).
+
+### bwrap bind-mount blocks `git unlink` on project-root config files
+
+- **Context**: Claude Code with bubblewrap sandbox on Linux/WSL2/Codespaces, running `git switch` / `git restore` / `gh pr merge`.
+- **Problem**: Git operations fail with `error: unable to unlink old '<file>': Device or resource busy` on project-root config files (varies by project: `CHANGELOG.md`, `README.md`, `pyproject.toml`, `Makefile`, `.claude/settings.json`). Server-side merges succeed but local FF fails; working tree desyncs from HEAD.
+- **Solution**: `git update-ref` + `git reset HEAD` to move branch pointer without checkout; `git restore` for unlocked files; Claude Code Edit/Write tool for busy ones (overwrites via `O_TRUNC`, bypasses `unlink(2)`).
+- **References**: [docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md](docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md) (canonical, Friction 3), [anthropics/claude-code#17727](https://github.com/anthropics/claude-code/issues/17727).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md`: Friction 3 — bwrap bind-mount holds project-root config files (`CHANGELOG.md`, `README.md`, `pyproject.toml`, `Makefile`, `.claude/settings.json` — set varies by project) open via fd, blocking `git unlink(2)` on `git switch` / `git restore` / `git pull` / `gh pr merge`; recovery workaround via `git update-ref` + `git reset HEAD` + Claude Code Edit/Write tool (which uses `O_TRUNC` instead of `unlink`). Tracks anthropics/claude-code#17727
+- `AGENT_LEARNINGS.md`: second learned pattern — bwrap bind-mount blocks `git unlink` on project-root config files; pointer to Friction 3
 - `docs/cc-native/plugins-ecosystem/CC-office-document-skills.md`: engine-layer cross-link (dated 2026-04-26) to `qte77/doc-pipeline-engine/docs/landscape-output.md` per #131
 - `docs/cc-native/plugins-ecosystem/CC-web-scraping-plugins-analysis.md`: engine-layer cross-link (dated 2026-04-26) to `qte77/doc-pipeline-engine/docs/landscape-ingest.md` per #132
 

--- a/docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md
+++ b/docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md
@@ -4,8 +4,8 @@ description: bwrap-on-Linux friction independent of execution context (local, WS
 source: https://github.com/anthropics/claude-code/issues/17727, https://github.com/anthropics/claude-code/issues/17087, https://github.com/anthropic-experimental/sandbox-runtime/issues/139
 category: analysis
 created: 2026-05-02
-updated: 2026-05-02
-validated_links: 2026-05-02
+updated: 2026-05-17
+validated_links: 2026-05-17
 ---
 
 **Status**: Active upstream bug — `claude-code#17727` open; `claude-code#17087` closed-as-completed but recurring; `sandbox-runtime#139` is the upstream fix tracker.
@@ -193,6 +193,108 @@ and Claude Code starts cleanly.
 
 Hard startup-blocker as of v2.1.120 — first-time Ubuntu 24.04 users hit a
 wall with no actionable error message. Tracking: [#17727][gh-17727].
+
+## Friction 3 — Bind-Mount-Held Files Block `git unlink`
+
+### Symptom
+
+`git switch`, `git restore`, `git pull --ff-only`, and `gh pr merge` (which
+runs `git pull` internally) fail with:
+
+```text
+error: unable to unlink old 'CHANGELOG.md': Device or resource busy
+error: unable to unlink old 'README.md': Device or resource busy
+error: unable to unlink old 'Makefile': Device or resource busy
+```
+
+Server-side `gh pr merge` succeeds (`origin/main` advances), but the
+local-side `git pull` aborts mid-flight — leaving the local branch behind
+origin and the working tree partially stale.
+
+### Affected files (project-dependent)
+
+The set is stable per project but varies across projects. Observed:
+
+- **`qte77/analyze-stock-kpi`**: `CHANGELOG.md`, `README.md`, `pyproject.toml`, `Makefile`
+- **`qte77/ai-agents-research`**: `.claude/settings.json`, `Makefile`, `README.md`
+
+Pattern: project-root config/context files CC reads at session start.
+Distinct symptom class from Friction 1 — that one *creates* extra files;
+this one makes *existing* files temporarily un-`unlink(2)`-able.
+
+### Root cause
+
+Related bug class to Friction 1 ([`claude-code#17727`][gh-17727]). Open file
+descriptors against the sandbox's bind-mount targets block `unlink(2)`,
+which is what git calls on every checkout/restore to swap file content.
+Cleanup is best-effort and skipped while other sandboxes are active.
+Distinct from Friction 1's `--ro-bind /dev/null` phantom-creation: here the
+bind-mount holds real files open via fd.
+
+### Side effects
+
+- After `git switch <branch>`: HEAD ref moves but busy files stay at the
+  prior branch's content. `git status` reports them "Modified" on a
+  freshly-switched branch — confusing.
+- After `gh pr merge --delete-branch`: server-side merge completes,
+  `origin/<branch>` advances, but the local `git pull` step inside `gh`
+  aborts. Local main desyncs from origin.
+- Subagents launched mid-session inherit the sandbox state — they see the
+  same busy-lock.
+
+### Recovery workaround
+
+```bash
+# 1. Ensure remote ref is current
+git fetch origin
+
+# 2. Move local branch pointer to remote without touching working tree
+git update-ref refs/heads/main refs/remotes/origin/main
+
+# 3. Refresh the index from new HEAD (working tree untouched)
+git reset HEAD -- .
+
+# 4. Restore files NOT on the busy list (normal git path)
+git restore <unlocked-files>
+
+# 5. For files ON the busy list: overwrite in place via Claude Code's
+#    Edit/Write tool. open(O_WRONLY|O_TRUNC) bypasses unlink(2), so the
+#    bind-mount lock doesn't block it. Source the desired content via:
+git show HEAD:<file> > "$TMPDIR/<file>.head"
+#    Then Edit the working-tree file to match.
+```
+
+### Data-safety guards
+
+- **Pre-flight**: `git rev-parse HEAD origin/main` — confirm the SHA you're
+  about to `update-ref` to is what you want. The SHA the server reported on
+  the merge is the truth source.
+- **WIP detection**: `git diff HEAD -- <busy-files>` before any step. If the
+  diff is only stale-branch leftovers, proceed. If it shows pending edits
+  you care about, stage them first via `git add` (index updates bypass the
+  unlink lock).
+- **Source from HEAD, not working tree**: when overwriting via Edit/Write,
+  dump `git show HEAD:<file> > $TMPDIR/<file>.head` and eyeball before
+  applying. The stuck working-tree copy is, by definition, stale.
+- **Recovery net**: `git reflog` records every `update-ref` for 90 days;
+  objects persist until `gc`. Mistakes are reversible.
+
+### What does NOT work
+
+- `git restore <busy-file>` — hits the same `unlink(2)` path.
+- `git checkout -- <busy-file>` — same.
+- `git reset --hard` — same, with worse failure mode: partial reset state
+  plus the unlink error.
+- `git update-index --skip-worktree <busy-file> && git restore` — `restore`
+  still tries to `unlink` before `skip-worktree` takes effect.
+- `rm -f <busy-file>` from inside the sandbox — same unlink failure. Only
+  `rm` from a non-sandboxed shell works.
+
+### Version timeline
+
+| Version | Observation |
+| ------- | ----------- |
+| 2.1.123 — 2.1.127 (2026-05) | Reproduces on Fedora 43 across multiple PR-merge cycles in `qte77/analyze-stock-kpi` and `qte77/ai-agents-research` |
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Promotes the bwrap busy-lock workaround from chat-knowledge-only into versioned documentation. The existing `CC-sandbox-bwrap-host-quirks.md` covers Friction 1 (phantom dotfiles) and Friction 2 (AppArmor `userns` prerequisite) for [`claude-code#17727`](https://github.com/anthropics/claude-code/issues/17727), but stops short of the related `git unlink: Device or resource busy` failure mode.

## Changes

- `docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md` — new `## Friction 3 — Bind-Mount-Held Files Block git unlink` section. Mirrors Friction 1's structure (Symptom / Affected files / Root cause / Side effects / Recovery workaround / Data-safety guards / What does NOT work / Version timeline). Hedged the root-cause claim — same bwrap-bind-mount class, but distinct mechanism (open fd holding real files, not `--ro-bind /dev/null` phantom creation).
- `AGENT_LEARNINGS.md` — second learned pattern below the existing "Phantom files" entry. Brief Context/Problem/Solution/References pointer to Friction 3.
- `CHANGELOG.md` — Unreleased/Added entries for both above.

## File-set caveat

The affected file set is project-dependent (stable per project, varies across):

- `qte77/analyze-stock-kpi`: `CHANGELOG.md`, `README.md`, `pyproject.toml`, `Makefile`
- `qte77/ai-agents-research` (this repo): `.claude/settings.json`, `Makefile`, `README.md`

Pattern: project-root config/context files CC reads at session start.

## Why now

Discovered across multiple PR-merge cycles in `qte77/analyze-stock-kpi`. Every `gh pr merge --delete-branch` triggered the same recovery loop on the project's specific busy-list. The workaround pattern (`update-ref` + `reset HEAD` + `git restore` for unlocked files + Edit/Write tool for busy ones) consistently recovers without the heavyweight "run from non-sandboxed shell" escape hatch. Cross-repo audit confirmed the pattern was not previously documented in the qte77 ecosystem.

## Test plan

- [x] `markdownlint-cli2` clean on the 3 edited files
- [x] In-scope `make check_docs` clean (130 files, 0 errors)
- [ ] CI: markdownlint + lychee workflows pass

## Refs

- Upstream root cause: [anthropics/claude-code#17727](https://github.com/anthropics/claude-code/issues/17727)
- Companion friction class: `CC-sandbox-bwrap-host-quirks.md` Friction 1 (phantom dotfiles)

Generated with Claude <noreply@anthropic.com>