### PR TITLE
ci(issues): add AI issue-triage via qte77/gha-issue-triage@v0.2.4

### DIFF
--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -1,0 +1,34 @@
+# AI-powered issue triage via qte77/gha-issue-triage. Fires on every new,
+# edited, or reopened issue. Detects duplicates, scores relevance against
+# the repo's scope (README/AGENTS), analyzes feasibility + complexity,
+# auto-labels, and posts a single sticky summary comment that is edited
+# in place on re-runs.
+#
+# Backend defaults to GitHub Models via the workflow's GITHUB_TOKEN —
+# `permissions: models: read` is the load-bearing line. No external API
+# key required.
+name: issue-triage
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  models: read
+
+concurrency:
+  # One in-flight triage per issue so a quick edit doesn't race with the
+  # initial open and stack two summary comments before the sticky-edit
+  # logic kicks in. ISSUE_NUMBER is numeric — safe to interpolate.
+  group: issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: qte77/gha-issue-triage@cc8f0cf99014af906ea3ad1ee977d92852069579  # v0.2.4
+        with:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/issue-triage.yaml` — a composite GitHub Action
that fires on issue `opened` / `edited` / `reopened`. Per run it:

- Fuzzy-matches new/edited issue against existing open issues (duplicate detection)
- Scores relevance (0-10) vs. repo scope read from `README.md` + `AGENTS.md` / `CLAUDE.md`
- Judges feasibility (yes/no) + complexity (low/medium/high)
- Auto-labels: `duplicate`, `bug`, `feature`, `enhancement`, `good-first-issue`, `needs-discussion`, `invalid`
- Posts a single sticky summary comment, edited in place on re-runs

Backend defaults to GitHub Models via the workflow's `GITHUB_TOKEN` —
`permissions: models: read` is the load-bearing line. No external API key required.

SHA-pinned to `cc8f0cf99014af906ea3ad1ee977d92852069579` (v0.2.4, lightweight tag, commit-typed — verified via `gh api`).

## Validated state

- Action `v0.2.4` previously triaged 8 issues on `qte77/analyze-stock-kpi` (#4, #8, #9, #10, #21, #22, #23, #97)
- No timeouts, no rate-limit hits, every run completed in <10 s
- Sticky-comment edit-in-place confirmed on re-edited issue

## Gotchas / follow-ups

- **Label collision risk**: this repo already has `good first issue` (with spaces); the bot will auto-create `good-first-issue` (with hyphens) on first fire — both will coexist. Decide post-merge whether to delete the spaces version.
- **Missing labels the bot will auto-create**: `feature`, `good-first-issue`, `needs-discussion`. Pre-create them with `gh label create` if you want to avoid the bot inventing colors/descriptions.
- **Duplicate detection is open-only** — won't catch "already done by merged PR #N".
- **Relevance scorer reads `README.md` + `AGENTS.md`** — stale scope docs → stale scores.

## Test plan

- [ ] CI green on this PR (no workflow lint failures from `.github/workflows/lint.yaml`)
- [ ] Post-merge: edit an existing open issue with an invisible marker to fire the `edited` event
- [ ] Confirm `gh run list --workflow=issue-triage.yaml` shows `success` in <10 s
- [ ] Confirm new labels added (additive — existing labels preserved)
- [ ] Confirm sticky comment by `github-actions[bot]` containing `### AI triage summary` with relevance / feasibility / complexity lines

Generated with Claude <noreply@anthropic.com>