### PR TITLE
fix(setup): align setup_lychee with lycheeverse/lychee-action install pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,18 @@ setup_lychee: ## Install lychee link checker user-locally to ~/.local/bin (no su
 	else
 		echo "Installing lychee ($(LYCHEE_ARCH)) to $(LOCAL_BIN) ..."
 		mkdir -p $(LOCAL_BIN)
-		curl -sSfL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-$(LYCHEE_ARCH).tar.gz \
-			| tar xz --strip-components=1 -C $(LOCAL_BIN) --wildcards '*/lychee' \
-			&& chmod +x $(LOCAL_BIN)/lychee \
+		# Tarball contains a wrapper dir (lychee-<target>/lychee).
+		# Mirror lycheeverse/lychee-action's pattern: extract to tmpdir, find
+		# binary via glob, install with explicit mode. Avoids GNU-tar-only
+		# flags (--wildcards, --strip-components with member matching) so the
+		# recipe is portable to BSD tar.
+		tmp=$$(mktemp -d) \
+			&& curl -sSfL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-$(LYCHEE_ARCH).tar.gz \
+				| tar xz -C "$$tmp" \
+			&& install -m 755 "$$tmp"/lychee-*/lychee $(LOCAL_BIN)/lychee \
+			&& rm -rf "$$tmp" \
 			&& echo "lychee installed to $(LOCAL_BIN)/lychee — ensure $(LOCAL_BIN) is on PATH" \
-			|| echo "Install failed — download manually from https://github.com/lycheeverse/lychee/releases"
+			|| { rm -rf "$$tmp"; echo "Install failed — download manually from https://github.com/lycheeverse/lychee/releases"; exit 1; }
 	fi
 
 setup_mdlint: setup_node ## Install markdownlint-cli2 via user-local npm (no sudo)


### PR DESCRIPTION
## Summary
- Switch `setup_lychee` from a GNU-tar-specific recipe to the extract-to-tmpdir + `install` pattern used by upstream `lycheeverse/lychee-action` itself.
- Behavior unchanged on GHA Linux runners; gains portability to BSD tar (macOS without brew, some alpine CI images).

## Old recipe (Linux branch)
```makefile
| tar xz --strip-components=1 -C $(LOCAL_BIN) --wildcards '*/lychee' \
&& chmod +x $(LOCAL_BIN)/lychee
```
- `--wildcards` is GNU tar only. BSD tar errors.
- `--strip-components` + `--wildcards` interaction is GNU-specific.

## New recipe
```makefile
tmp=$(mktemp -d) \
    && curl ... | tar xz -C "$tmp" \
    && install -m 755 "$tmp"/lychee-*/lychee $(LOCAL_BIN)/lychee \
    && rm -rf "$tmp"
```
- Plain `tar xz -C dir` works on every tar implementation.
- `install -m 755` does atomic copy + explicit exec bit (replaces separate `chmod +x`).
- Glob `lychee-*/` accommodates future target-triple changes without recipe edits.
- Matches what `lycheeverse/lychee-action` does internally (see [action.yml](https://github.com/lycheeverse/lychee-action/blob/master/action.yml)).

## Test plan
- [ ] CI lint job runs `make setup_lychee` → lychee installed at `~/.local/bin/lychee`
- [ ] `make check_links` succeeds (no "lychee not installed")
- [ ] Re-run with cache present still passes

## Context
Follow-up to #170 which fixed the bug but used GNU-only flags. Research traced upstream's canonical pattern; switching to it for durability.

Generated with Claude <noreply@anthropic.com>