### PR TITLE
chore(ci): bump JS actions to Node 24-supporting versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Cache lychee binary
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/bin/lychee
           # Bump suffix (v1 -> v2) to force a fresh lychee download

--- a/.github/workflows/rxiv-paper-eval.yaml
+++ b/.github/workflows/rxiv-paper-eval.yaml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download eval artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ needs.eval.outputs.artifact_name }}
           path: eval-output


### PR DESCRIPTION
## Summary
- GitHub deprecated Node 20 for JavaScript actions ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Forced default flips 2026-06-02; Node 20 removed 2026-09-16.
- Bump the three JS-action pins still on Node 20 to their current latest Node-24-supporting majors.

## Diffs

| File | Action | From | To |
|---|---|---|---|
| `lint.yaml` | `actions/setup-node` | `@v4` | `@v6` |
| `lint.yaml` | `actions/cache` | `@v4` | `@v5` |
| `rxiv-paper-eval.yaml` | `actions/download-artifact` | `@v4` | `@v8` |

`actions/checkout@v6` and `actions/setup-python@v6` are already on Node-24-supporting majors — unchanged.

## Test plan
- [ ] Lint workflow runs against this PR (markdown + lychee both green)
- [ ] No `actions are deprecated. The following actions are running on Node.js 20` warning in the run log
- [ ] Cache hit/miss behavior unchanged on `actions/cache@v5`
- [ ] Next rxiv cron uses `download-artifact@v8` successfully (or validate via manual dispatch)

## Notes
Both `actions/cache@v5` and `actions/download-artifact@v8` are major-version bumps but the inputs we use (`path`, `key` for cache; `name`, `path` for download-artifact) are stable across these versions — no input shape changes expected.

Generated with Claude <noreply@anthropic.com>