### PR TITLE
fix(rxiv): lint assembled triage report; strip eval's leading H1

### DIFF
--- a/.github/workflows/rxiv-paper-eval.yaml
+++ b/.github/workflows/rxiv-paper-eval.yaml
@@ -75,6 +75,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
       - name: Download eval artifact
         uses: actions/download-artifact@v8
         with:
@@ -84,8 +89,12 @@ jobs:
       - name: Assemble triage report
         run: |
           set -euo pipefail
+          # Strip eval's own leading H1 — create-triage-pr prepends its own
+          # `# <pr-body-header>` so keeping the inner H1 would violate MD025
+          # (multiple top-level headings). Demote any other H1s in the body
+          # to H2 as a belt-and-suspenders guard.
           {
-            cat eval-output/summary.md
+            sed -E '1{/^# /d;}; s/^# (.*)$/## \1/' eval-output/summary.md
             echo ""
             echo "## Extracts"
             echo ""
@@ -109,6 +118,23 @@ jobs:
               print()
           PY
           } > /tmp/report.md
+
+      - name: Lint assembled report
+        # Simulate create-triage-pr's H1 prepend then lint with the repo's
+        # .markdownlint.json. Fails the job (and prevents an opening PR) if
+        # the assembled output would land md-lint-dirty.
+        env:
+          PR_BODY_HEADER: 'ArXiv AI Agents: Relevant Papers'
+        run: |
+          set -euo pipefail
+          {
+            echo "# ${PR_BODY_HEADER}"
+            echo ""
+            cat /tmp/report.md
+          } > /tmp/final.md
+          make setup_mdlint
+          export PATH="$HOME/.local/share/node/bin:$PATH"
+          markdownlint-cli2 --config .markdownlint.json /tmp/final.md
 
       - name: Create triage PR
         uses: ./.github/actions/create-triage-pr

--- a/.github/workflows/rxiv-paper-eval.yaml
+++ b/.github/workflows/rxiv-paper-eval.yaml
@@ -89,12 +89,13 @@ jobs:
       - name: Assemble triage report
         run: |
           set -euo pipefail
-          # Strip eval's own leading H1 — create-triage-pr prepends its own
-          # `# <pr-body-header>` so keeping the inner H1 would violate MD025
-          # (multiple top-level headings). Demote any other H1s in the body
-          # to H2 as a belt-and-suspenders guard.
+          # Strip eval's own leading H1 (create-triage-pr prepends its own,
+          # would violate MD025) and any leading blank lines that would
+          # collide with the action's prepend (MD012 — double blank).
+          # Demote in-body H1s to H2 as a belt-and-suspenders guard.
           {
-            sed -E '1{/^# /d;}; s/^# (.*)$/## \1/' eval-output/summary.md
+            sed -E '1{/^# /d;}; s/^# (.*)$/## \1/' eval-output/summary.md \
+              | sed '/./,$!d'
             echo ""
             echo "## Extracts"
             echo ""
@@ -105,7 +106,10 @@ jobs:
                   continue
               d = json.loads(line)
               ex = d.get("extracted", {})
+              # Blank line below heading and around lists is required
+              # (MD022 / MD032).
               print(f"### {d.get('title', '(no title)')}")
+              print()
               doi = d.get("doi", "")
               if doi:
                   print(f"- arxiv: <https://arxiv.org/abs/{doi}>")
@@ -118,6 +122,10 @@ jobs:
               print()
           PY
           } > /tmp/report.md
+          # Collapse runs of blank lines to one (MD012) and trim leading/
+          # trailing blanks so the action's prepend produces clean output.
+          awk 'BEGIN{blank=0;started=0} /^$/{blank=1;next} {if(started&&blank)print ""; started=1; blank=0; print}' /tmp/report.md > /tmp/report.md.clean
+          mv /tmp/report.md.clean /tmp/report.md
 
       - name: Lint assembled report
         # Simulate create-triage-pr's H1 prepend then lint with the repo's


### PR DESCRIPTION
## Summary
- Test-run triage output ([#178 closed](https://github.com/qte77/ai-agents-research/pull/178)) had two H1s — `# ArXiv AI Agents: Relevant Papers` (action prepend) **plus** `# rxiv eval — arxiv 2026-W21` (eval's own summary.md). Violates MD025.
- Adds active md-lint validation of the assembled report so any future drift fails the workflow instead of opening dirty triage PRs.

## Changes

**`Assemble triage report` step**: pipe `summary.md` through `sed` to strip the leading H1 and demote any other in-body H1s to H2. Belt-and-suspenders for whatever the eval action ships.

**New `Lint assembled report` step**: simulate `create-triage-pr`'s `# <pr-body-header>` prepend, then `markdownlint-cli2 --config .markdownlint.json /tmp/final.md`. Fails the job (skips PR creation) on any rule violation.

**New `Set up Node` step**: required by `make setup_mdlint` (markdownlint-cli2 installs via npm into `~/.local/share/node/bin`).

## Test plan
- [ ] Dispatch against week 21 — eval succeeds, lint step runs against the assembled report, all green
- [ ] Triage PR opens with single H1 (`# ArXiv AI Agents: Relevant Papers`) and no other lint errors
- [ ] No regression in non-rxiv triage flows (this PR only touches `rxiv-paper-eval.yaml`)

Generated with Claude <noreply@anthropic.com>