### PR TITLE
docs(readme): drop overview tagline, broaden Why and What

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # ai-agents-research
 
-> Project overview — start here. Audience: any contributor or AI agent.
->
-> Field research and feature analysis for AI coding agents — from sandboxing internals to agent orchestration.
+> Field research and feature analysis for AI coding agents — sandboxing, orchestration, plugins, community tooling, SDLC patterns.
 
 ## Why
 
-Understand how Claude Code works under the hood so you can make informed adopt/defer/skip decisions before building production systems with it.
+Make informed adopt / defer / skip decisions about coding agents and their ecosystems before building production systems on them. Tracks Claude Code, JetBrains Air, DeerFlow, Goose, Codex, Devin and others — plus the surrounding plugins, observability, SDLC patterns, and cross-repo learnings.
 
 ## What
 
-Standalone deep-dive analyses of CC features, each following a consistent format:
+A continuously-updated research catalog spanning Anthropic-native CC features, non-CC coding agents, the community ecosystem (skills, plugins, tooling), SDLC + lifecycle patterns, and cross-repo learnings distilled from live development across the qte77 ecosystem.
+
+Each analysis follows the same four-section structure:
 **What it is** → **How it works** → **Adoption decision** → **Action items**
+
+Currency is maintained by four cron-driven monitors — see [How it stays current](#how-it-stays-current) below.
 
 ## Contents
 


### PR DESCRIPTION
## Summary

Per direct user feedback that the prior README opening had three problems:

1. Hero line "Project overview — start here. Audience: any contributor or AI agent." restated the H1 with no extra value
2. "Why" section was CC-only — didn't reflect the repo's actual coverage of non-CC agents, community tooling, SDLC patterns
3. "What" section was similarly CC-narrow

## Diff shape

| Section | Before | After |
|---|---|---|
| Hero | 2 lines (overview tagline + scope sentence) | 1 line (scope only) |
| Why | "Understand how Claude Code works..." | Adopt/defer/skip across coding agents AND their ecosystems; names Claude Code, JetBrains Air, DeerFlow, Goose, Codex, Devin |
| What | "Standalone deep-dive analyses of CC features..." | 5-axis catalog (CC, non-CC, community, SDLC, learnings) maintained by 4 monitors |

No structural changes to the Contents table, How-it-stays-current section, Local development, Related Repos, Origin, or License sections.

Generated with Claude <noreply@anthropic.com>