### PR TITLE
ci(changelog-monitor): fix stale scan-doc path breaking weekly runs

### DIFF
--- a/.github/workflows/cc-changelog-monitor.yaml
+++ b/.github/workflows/cc-changelog-monitor.yaml
@@ -40,7 +40,7 @@ jobs:
           set +e
           python .github/scripts/changelog-compare.py \
             --changelog /tmp/CC-CHANGELOG.md \
-            --scan-doc docs/cc-native/CC-changelog-feature-scan.md \
+            --scan-doc docs/cc-native/configuration/CC-changelog-feature-scan.md \
             --docs-dir docs/cc-native/ \
             --update-scan-doc \
             > /tmp/report.md 2>/tmp/compare-stderr.txt
@@ -83,7 +83,7 @@ jobs:
           branch-prefix: chore/changelog-triage
           report-dest: triage/cc-changelog/changelog-triage
           extra-files: >-
-            docs/cc-native/CC-changelog-feature-scan.md
+            docs/cc-native/configuration/CC-changelog-feature-scan.md
             .github/state/native-monitor-state.json
           pr-title-prefix: 'chore: changelog triage'
           pr-body-header: 'CC Changelog & Native Sources: New Uncovered Features Detected'


### PR DESCRIPTION
## Summary

The weekly Changelog Monitor has failed on every scheduled run since
2026-03-30 (10 consecutive failures; last success 2026-03-23).

Root cause: `CC-changelog-feature-scan.md` was relocated to
`docs/cc-native/configuration/` on 2026-03-27, but the workflow's
`--scan-doc` argument and the `create-triage-pr` `extra-files` input still
referenced the old `docs/cc-native/` path. The compare step errored
(`Path does not exist`) and `create-triage-pr` died at `git add`
(`fatal: pathspec ... did not match`, exit 128).

Fix points both references at the current path. No other behavior change.

## Related issues

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [ ] Tests added or updated — N/A (path-only workflow fix; no test harness)
- [ ] Docs updated where applicable — N/A
- [x] CI passes locally — YAML validated via IDE diagnostics (no local GHA runner); full run verifies post-merge
- [x] Self-reviewed the diff

---

Follow-ups (not in this PR): harden `changelog-compare.py` exit codes (it returns `1` for both "new features" and fatal errors, masking failures); check sibling `cc-changelog-community-monitor.yaml` for the same pattern.