### PR TITLE
fix(docs): repair lychee link-check failures (dead + bot-blocked URLs)

### DIFF
--- a/docs/cc-community/CC-agent-observability-methods-analysis.md
+++ b/docs/cc-community/CC-agent-observability-methods-analysis.md
@@ -409,7 +409,7 @@ This pattern provides deep integration with specific frameworks or ecosystems.
 
 **2025-2026 Updates**:
 
-- **Performance**: Virtually no measurable overhead making it ideal for performance-critical production environments (0% overhead compared to 12% for AgentOps, 15% for Langfuse)
+- **Performance**: Virtually no measurable overhead making it ideal for performance-critical production environments
 - **OpenTelemetry Support**: Supports OpenTelemetry (OTel) to unify observability stacks across services
 - **Production Grade**: Complete visibility into agent behavior with tracing, real-time monitoring, alerting, and high-level usage insights
 - **Enterprise Adoption**: Proven enterprise deployment with production-grade reliability
@@ -418,7 +418,6 @@ This pattern provides deep integration with specific frameworks or ecosystems.
 
 - [LangSmith Observability](https://www.langchain.com/langsmith/observability)
 - [LangSmith Data Export Documentation](https://docs.smith.langchain.com/observability/how_to_guides/data_export)
-- [LangSmith Performance Comparison](https://www.akira.ai/blog/langsmith-and-agentops-with-ai-agents)
 
 #### Pydantic Logfire
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -41,6 +41,7 @@ exclude = [
     "openai.com",  # 403 to HEAD on /index/* article URLs
     "code2tutorial.com",  # 404 to HEAD; root may anti-bot — referenced in cc-community landscape
     "techcommunity.microsoft.com",  # 403 to HEAD on /blog/* URLs (anti-bot)
+    "zread.ai",  # 403 to all automated requests (Cloudflare); AI doc-reader of GitHub repos — referenced in CC-agent-teams-orchestration.md
     # Auth-gated (requires login) — both `/code` and `/code/scheduled` and `/settings/*` return 403 to anonymous requests
     "claude.ai/code",
     "claude.ai/settings",
@@ -55,4 +56,5 @@ exclude = [
     "deepwiki.com",
     "minbook.dev",
     "emdash.dev",
+    "apmdigest.com",  # valid (200) but slow — times out lychee even with retries
 ]


### PR DESCRIPTION
## Summary

The repo-wide `Link check (lychee)` was red on `main` (and therefore blocked
every PR, including #196). Three links failed; fixed by failure type, verified
locally with `lychee --config lychee.toml` (0 errors):

- **`akira.ai` LangSmith comparison** — DNS no longer resolves (confirmed from
  both CI and a separate network). Removed the dead link **and** the specific
  overhead figures ("0% vs 12% AgentOps, 15% Langfuse") it was the sole source
  for. Kept the qualitative statement, still backed by the two LangSmith sources.
- **`zread.ai`** — Cloudflare 403 to all automated requests (valid page, just
  bot-blocked). Added to `lychee.toml` exclude, alongside peers like
  `deepwiki.com` / `code2tutorial.com`.
- **`apmdigest.com`** — returns 200 but is slow enough to time out the checker
  even with retries (the transient CI failure). Added to the timeout-prone
  exclude group.

## Related issues

Unblocks the `lychee` check for #196 (changelog-monitor fix) and all other PRs.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore

## Checklist

- [ ] Tests added or updated — N/A
- [x] Docs updated where applicable
- [x] CI passes locally — `lychee` on the two affected files: 0 errors
- [x] Self-reviewed the diff

---

Note: two `lychee.toml` exclude additions (per your conservative-config-edits
preference, flagging for review). `akira.ai` removed the figures rather than
re-sourcing them — restore with a live citation if you have one.