### PR TITLE
fix(ci): harden monitor error handling, community path, and triage PR body cap

### DIFF
--- a/.github/actions/create-triage-pr/action.yaml
+++ b/.github/actions/create-triage-pr/action.yaml
@@ -86,6 +86,15 @@ runs:
           echo "_${{ inputs.pr-body-note }}_" > /tmp/pr-body.md
         fi
 
+        # GitHub caps PR bodies at 65536 chars. The full report is committed as
+        # the triage file in this branch, so truncate an oversized body and
+        # point to that file rather than failing the run on a large catch-up.
+        if [ "$(wc -c < /tmp/pr-body.md)" -gt 60000 ]; then
+          head -c 60000 /tmp/pr-body.md > /tmp/pr-body.trunc
+          printf '\n\n_…truncated (GitHub PR-body limit). Full report: `%s` in this branch._\n' "${REPORT_PATH:-the committed triage file}" >> /tmp/pr-body.trunc
+          mv /tmp/pr-body.trunc /tmp/pr-body.md
+        fi
+
         gh pr create \
           --base main \
           --head "$BRANCH" \

--- a/.github/scripts/changelog-compare.py
+++ b/.github/scripts/changelog-compare.py
@@ -14,6 +14,8 @@ Usage:
 Exit codes:
     0 = no new uncovered features
     1 = new features found (workflow should open a PR)
+    2 = fatal error (bad input / parse failure) — distinct from 1 so the
+        workflow fails loudly instead of treating an error as "new features"
 """
 
 import argparse
@@ -23,6 +25,16 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from lib.monitor_utils import extract_keywords
+
+
+def _fatal(message: str) -> None:
+    """Print an error to stderr and exit 2.
+
+    Exit 2 is distinct from the exit-1 "new features found" signal, so the
+    workflow can fail loudly on a real error instead of mistaking it for a PR-worthy result.
+    """
+    print(message, file=sys.stderr)
+    sys.exit(2)
 
 
 # ---------------------------------------------------------------------------
@@ -42,7 +54,7 @@ def parse_scanned_version(scan_doc_path: Path) -> str:
     # Match frontmatter block between --- markers
     fm_match = re.search(r"^---\s*\n(.*?)\n---", text, re.DOTALL | re.MULTILINE)
     if not fm_match:
-        sys.exit(f"ERROR: No frontmatter found in {scan_doc_path}")
+        _fatal(f"ERROR: No frontmatter found in {scan_doc_path}")
 
     frontmatter = fm_match.group(1)
     # purpose: ... (v2.1.0–2.1.71) ...
@@ -51,7 +63,7 @@ def parse_scanned_version(scan_doc_path: Path) -> str:
         r"purpose:.*?v(\d+\.\d+\.\d+)[–\-](\d+\.\d+\.\d+)", frontmatter
     )
     if not purpose_match:
-        sys.exit(
+        _fatal(
             f"ERROR: Could not find version range in purpose field of {scan_doc_path}"
         )
 
@@ -99,7 +111,7 @@ def parse_changelog_versions(changelog_path: Path) -> list[tuple[str, list[str]]
     )
     matches = list(section_pattern.finditer(text))
     if not matches:
-        sys.exit(f"ERROR: No version sections found in {changelog_path}")
+        _fatal(f"ERROR: No version sections found in {changelog_path}")
 
     versions: list[tuple[str, list[str]]] = []
     for i, match in enumerate(matches):
@@ -280,7 +292,7 @@ def main() -> None:
     # Validate inputs
     for p in (args.changelog, args.scan_doc, args.docs_dir):
         if not p.exists():
-            sys.exit(f"ERROR: Path does not exist: {p}")
+            _fatal(f"ERROR: Path does not exist: {p}")
 
     last_scanned = parse_scanned_version(args.scan_doc)
     print(f"Last scanned version: {last_scanned}", file=sys.stderr)

--- a/.github/scripts/community-monitor.py
+++ b/.github/scripts/community-monitor.py
@@ -13,6 +13,8 @@ Usage:
 Exit codes:
     0 = no new uncovered content
     1 = new content found (workflow should open a PR)
+    2 = fatal error (bad input) — distinct from 1 so the workflow fails loudly
+        instead of treating an error as "new content"
 """
 
 import argparse
@@ -30,6 +32,16 @@ from lib.monitor_utils import (
     fetch_text,
     run_monitor,
 )
+
+
+def _fatal(message: str) -> None:
+    """Print an error to stderr and exit 2.
+
+    Exit 2 is distinct from the exit-1 "new content found" signal, so the
+    workflow can fail loudly on a real error instead of opening an empty triage PR.
+    """
+    print(message, file=sys.stderr)
+    sys.exit(2)
 
 # ---------------------------------------------------------------------------
 # Source definitions
@@ -303,7 +315,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--community-docs-dir", required=True, type=Path,
-        help="Path to docs/community/ directory",
+        help="Path to docs/cc-community/ directory",
     )
     parser.add_argument(
         "--state-file", type=Path,
@@ -313,7 +325,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if not args.community_docs_dir.exists():
-        sys.exit(
+        _fatal(
             f"ERROR: Community docs dir does not exist: {args.community_docs_dir}"
         )
 

--- a/.github/workflows/cc-changelog-community-monitor.yaml
+++ b/.github/workflows/cc-changelog-community-monitor.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           set +e
           python .github/scripts/community-monitor.py \
-            --community-docs-dir docs/community/ \
+            --community-docs-dir docs/cc-community/ \
             --state-file .github/state/community-monitor-state.json \
             > /tmp/report.md 2>/tmp/monitor-stderr.txt
           EXIT_CODE=$?
@@ -45,8 +45,11 @@ jobs:
 
           if [ $EXIT_CODE -eq 1 ]; then
             echo "new_content=true" >> "$GITHUB_OUTPUT"
-          else
+          elif [ $EXIT_CODE -eq 0 ]; then
             echo "new_content=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::community-monitor.py failed (exit $EXIT_CODE)"
+            exit "$EXIT_CODE"
           fi
 
       - name: Create triage PR

--- a/.github/workflows/cc-changelog-monitor.yaml
+++ b/.github/workflows/cc-changelog-monitor.yaml
@@ -51,8 +51,11 @@ jobs:
 
           if [ $EXIT_CODE -eq 1 ]; then
             echo "new_features=true" >> "$GITHUB_OUTPUT"
-          else
+          elif [ $EXIT_CODE -eq 0 ]; then
             echo "new_features=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::changelog-compare.py failed (exit $EXIT_CODE)"
+            exit "$EXIT_CODE"
           fi
 
       - name: Run native sources monitor


### PR DESCRIPTION
## Summary

Robustness fixes for the monitor pipeline, surfaced while fixing the
changelog-monitor outage (#196) and running the catch-up (#199).

1. **Exit-code conflation** — `changelog-compare.py` and `community-monitor.py`
   used `sys.exit("ERROR…")` (exit **1**) for fatal errors, the same code as the
   "new features/content found" signal, so errors masqueraded as PR-worthy
   results. Both now exit **2** (via a `_fatal` helper); the workflows treat any
   non-0/1 exit as a **loud job failure**.

2. **Live sibling bug** — `cc-changelog-community-monitor.yaml` passed
   `--community-docs-dir docs/community/`, which doesn't exist (repo has
   `docs/cc-community/`) → script error → exit 1 → empty triage PRs (the
   zero-byte `triage/community/2026-05-*.md`). Path corrected.

3. **Triage PR body cap** — the catch-up run (#199) pushed its branch then failed
   at `gh pr create` with `Body is too long (max 65536)` because
   `create-triage-pr` passes the full report as the PR body. Bodies over 60000
   chars are now truncated with a pointer to the committed triage file (which
   already holds the complete report).

## Verification (no test harness exists for these scripts)

- `py_compile` both scripts: OK
- Error paths now exit **2**; happy path still exits 0/1
- Body cap is a bounded `wc -c`/`head -c` guard in the composite action

## Type of change

- [x] Bug fix

## Checklist

- [ ] Tests added or updated — N/A (no harness for `.github/`; verified manually)
- [x] Docs updated where applicable — script docstrings + argparse help corrected
- [x] CI passes locally — py_compile + manual exit-code checks; actionlint in CI
- [x] Self-reviewed the diff

---

Out of scope (flagged): empty `triage/community/2026-05-*.md` artifacts could be
deleted; `native-sources-monitor.py` shares the exit-1 pattern; the two `_fatal`
helpers could later hoist into `lib/monitor_utils.py`.