### PR TITLE
chore(ci): SHA-pin GitHub Actions for supply-chain hardening

### DIFF
--- a/.github/workflows/cc-changelog-community-monitor.yaml
+++ b/.github/workflows/cc-changelog-community-monitor.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/cc-changelog-monitor.yaml
+++ b/.github/workflows/cc-changelog-monitor.yaml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/cc-status-monitor.yaml
+++ b/.github/workflows/cc-status-monitor.yaml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/learnings-aggregator.yaml
+++ b/.github/workflows/learnings-aggregator.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,10 +31,10 @@ jobs:
     name: Markdown lint (markdownlint-cli2)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '20'
 
@@ -48,10 +48,10 @@ jobs:
     name: Link check (lychee)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Cache lychee binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.local/bin/lychee
           # Bump suffix (v1 -> v2) to force a fresh lychee download
@@ -67,7 +67,7 @@ jobs:
     name: Action lint (actionlint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Install actionlint
         run: make setup_actionlint

--- a/.github/workflows/rxiv-paper-eval.yaml
+++ b/.github/workflows/rxiv-paper-eval.yaml
@@ -121,15 +121,15 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '20'
 
       - name: Download eval artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ${{ needs.eval.outputs.artifact_name }}
           path: eval-output


### PR DESCRIPTION
## Summary

- Pins all mutable `actions/*` tag refs to immutable 40-char commit SHAs across 6 workflow files
- Keeps the tag as a trailing `# vX.Y.Z` comment for readability, matching the style in `issue-triage.yaml` and the centralised `qte77/.github` lint workflow
- `actionlint` passes after changes; CI behaviour is unchanged (SHAs match each tag's current target)

Closes #186

## Actions pinned

| Action | Tag | SHA |
|---|---|---|
| `actions/checkout` | `v6` | `df4cb1c069e1874edd31b4311f1884172cec0e10` (v6.0.3) |
| `actions/setup-node` | `v6` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0) |
| `actions/cache` | `v5` | `27d5ce7f107fe9357f9df03efb73ab90386fccae` (v5.0.5) |
| `actions/download-artifact` | `v8` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8.0.1) |
| `actions/setup-python` | `v6` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` (v6.2.0) |

## Files changed

- `.github/workflows/lint.yaml` (3 jobs: markdown, links, actions)
- `.github/workflows/rxiv-paper-eval.yaml` (triage job)
- `.github/workflows/cc-changelog-monitor.yaml`
- `.github/workflows/cc-status-monitor.yaml`
- `.github/workflows/cc-changelog-community-monitor.yaml`
- `.github/workflows/learnings-aggregator.yaml`

## Test plan

- [ ] Verify `actionlint` passes in CI (lint workflow `actions` job)
- [ ] Confirm all 6 workflows run correctly on next scheduled trigger or manual dispatch
- [ ] Check that no other `actions/*@<mutable-tag>` refs remain in `.github/`

Generated with Claude <noreply@anthropic.com>