### PR TITLE
chore(ci): add Dependabot github-actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` configuring weekly grouped Dependabot version updates for the `github-actions` ecosystem
- All actions updates are grouped under a single `actions` group (pattern `*`) to reduce PR noise
- Commit messages are prefixed with `chore` to match repo conventions
- Complements #186 (SHA-pinned actions): keeps those pins current and patched without manual intervention

## Test plan

- [ ] Confirm `.github/dependabot.yml` is valid and Dependabot picks it up in the repository's Security > Dependabot tab
- [ ] Verify the first weekly run groups all actions updates into a single PR

Generated with Claude <noreply@anthropic.com>