### PR TITLE
docs: add Claude Fable 5 + 5 codebase-analysis tools

### DIFF
--- a/docs/cc-community/CC-community-tooling-landscape.md
+++ b/docs/cc-community/CC-community-tooling-landscape.md
@@ -5,8 +5,8 @@ category: landscape
 status: research
 platform_scope: [claude-code, cursor, codex, gemini-cli, opencode, windsurf, zed, antigravity]
 created: 2026-03-13
-updated: 2026-04-26
-validated_links: 2026-04-26
+updated: 2026-06-10
+validated_links: 2026-06-10
 ---
 
 **Status**: Research (informational)
@@ -506,6 +506,117 @@ Cross-ref: [CC-repo-to-docs-tools-landscape.md](CC-repo-to-docs-tools-landscape.
 
 ---
 
+## codebase-memory-mcp (DeusData)
+
+**Repo**: [DeusData/codebase-memory-mcp][codebase-memory-mcp] | **Stars**: 3.2K | **License**: MIT | **Version**: v0.7.0 (2026-05-30)
+
+Single static binary that builds a persistent code knowledge graph for agents — no runtime dependencies, no external API. Combines 159 vendored tree-sitter grammars (syntactic parse), a clean-room hybrid-LSP type-resolution layer (Python, TS/JS, PHP, C#, Go, C/C++), and bundled `nomic-embed-code` embeddings (semantic search) into a SQLite-backed graph of typed nodes (Function, Class, Route) and edges (CALLS, IMPORTS, HTTP_CALLS).
+
+### CC Integration
+
+| Surface | Mechanism |
+|---------|-----------|
+| **MCP server** | 14 tools — `index_repository`, `search_graph`, `trace_path`, `query_graph` (Cypher-like read-only), `get_architecture`, `detect_changes`, `manage_adr`, `ingest_traces` |
+| **PreToolUse hook** | Augments Grep/Glob with graph results before keyword search |
+| **Auto-config** | `install` wires up Claude Code, Codex, Gemini CLI, Zed, OpenCode, Aider + others (PreToolUse hook for CC; SessionStart reminders for the rest) |
+
+### Key Features
+
+- **99.2% token reduction** claim: ~3,400 tokens for 5 structural queries vs ~412,000 via file-by-file grep
+- **159 languages** (88 full AST, 71 additional); Linux kernel (~28M LOC) indexed in ~3 min, sub-ms queries
+- **Install**: one-line `curl … | bash`, plus AUR / Homebrew / PyPI / npm; macOS / Linux / Windows
+
+### Adoption Considerations
+
+**Strengths**: Zero-dependency single binary (vs graphify's PyPI + LLM calls). Bundled local embeddings — semantic search with no API cost or data egress. Broadest language coverage in this category.
+
+**Risks**: 99.2% reduction is self-reported (no independent benchmark). Hybrid-LSP type resolution is a clean-room reimplementation (only 7 languages fully resolved). Overlaps graphify and Code-Review-Graph on the AST/graph layer. Early stage (v0.x).
+
+Cross-ref: Graphify and Code-Review-Graph above — same code→graph category; Serena below — live-LSP alternative
+
+---
+
+## Serena (oraios)
+
+**Repo**: [oraios/serena][serena] | **Stars**: 25.2K | **License**: MIT | **Version**: v1.5.3 (2026-05-26)
+
+LSP-based semantic coding toolkit — "an IDE for your agent." Unlike the AST/graph tools above (which precompute a graph), Serena drives live language servers via the Language Server Protocol, giving agents symbol-level operations: find symbol, find references, type hierarchy, rename/move refactor, safe delete, and diagnostics — atomic cross-file edits instead of text-replace guesswork.
+
+### CC Integration
+
+| Surface | Mechanism |
+|---------|-----------|
+| **MCP server** | 20+ symbol-level tools, configured as a launch command in CC. In a harness like CC the overlapping file/search/shell tools are often disabled, leaving Serena's semantic tools |
+| **Memory** | Project memory files for long-lived workflows |
+| **Install** | `uv tool install -p 3.13 serena-agent` then `serena init` |
+
+### Key Features
+
+- **40+ languages** via open-source language servers (Python, TS/JS, Go, Rust, C/C++, C#, Java, Kotlin, Scala, …); optional paid JetBrains backend
+- Symbol-level retrieval/edit "especially in larger and more complex codebases"
+- Free and OSS; reuses LLMs you already have
+
+### Adoption Considerations
+
+**Strengths**: Live LSP semantics (always current, no index to rebuild) vs the precomputed-graph approach of graphify / Code-Review-Graph / codebase-memory-mcp. Most-starred tool in this category. Symbol-aware refactors agents can't safely do via text edits.
+
+**Risks**: Per-language LSP setup adds moving parts. Overlap with CC's built-in tools means the payoff is mainly in larger codebases. No headline token-reduction metric — efficiency comes from precise symbol queries, not corpus compression.
+
+Cross-ref: [CC-official-plugins-landscape.md](../cc-native/plugins-ecosystem/CC-official-plugins-landscape.md) — previously only named there (partner marketplace); analyzed here
+
+---
+
+## ast-grep MCP (ast-grep)
+
+**Repo**: [ast-grep/ast-grep-mcp][ast-grep-mcp] | **Stars**: 419 | **License**: MIT | **Version**: unreleased (main branch)
+
+Experimental MCP wrapper around the [ast-grep][ast-grep] Rust structural search/rewrite CLI. Exposes tree-sitter AST pattern matching to agents so they search by *syntax structure* (functions, classes, imports, call shapes) instead of text — fewer false positives than Grep, and structure-preserving rewrites.
+
+### CC Integration
+
+| Surface | Mechanism |
+|---------|-----------|
+| **MCP server** | 4 tools — `dump_syntax_tree`, `test_match_code_rule`, `find_code`, `find_code_by_rule` (YAML rules) |
+| **Runtime** | Python + FastMCP; `uvx --from git+https://github.com/ast-grep/ast-grep-mcp`; JSON client config (CC / Cursor / Claude Desktop) |
+
+### Key Features
+
+- Structural patterns across JS/TS, Python, Rust, Go, Java, C/C++, C# and more (custom languages supported)
+- **~75% fewer tokens** with the text output format vs JSON metadata
+- `dump_syntax_tree` lets the agent learn a language's node types before writing a pattern
+
+### Adoption Considerations
+
+**Strengths**: Lightweight and on-demand — no index to build (vs the persistent-graph tools above). Precise structural search/rewrite; pairs well with a graph tool for navigation plus a pattern tool for edits.
+
+**Risks**: Experimental, no tagged releases, low star count (the parent ast-grep CLI is mature; the MCP wrapper is early). Requires writing ast-grep patterns / YAML rules to get full value.
+
+Cross-ref: complements the persistent-graph tools above (search/rewrite vs navigation)
+
+---
+
+## Repomix & code2prompt (repository packers)
+
+A distinct sub-category: one-shot **context export** rather than a live MCP graph. Both flatten a repo into a single LLM-ready artifact with token counting, for pasting into a chat or seeding an agent's first turn.
+
+### Repomix (yamadashy)
+
+**Repo**: [yamadashy/repomix][repomix] | **Stars**: 26.2K | **License**: MIT | **Version**: v1.14.1 (2026-05-27)
+
+Packs a repository into one AI-friendly file (XML / Markdown / JSON / plain text), respecting `.gitignore` and scanning for secrets via Secretlint. `--compress` uses tree-sitter to keep classes/functions/interfaces and drop bodies — **~70% token reduction** while preserving structure. Reports per-file and repo-wide token counts (`o200k_base` / `cl100k_base`). **CC integration**: MCP server (`pack_codebase`, `pack_remote_repository`, `read_repomix_output`, `grep_repomix_output`, …) plus official CC plugins — `repomix-mcp`, `repomix-commands`, `repomix-explorer` via `/plugin marketplace add yamadashy/repomix`. Run with `npx repomix@latest`.
+
+### code2prompt (mufeedvh)
+
+**Repo**: [mufeedvh/code2prompt][code2prompt] | **Stars**: 7.4K | **License**: MIT | **Version**: v4.2.0 (2025-12-11)
+
+Rust CLI that renders a codebase into a single prompt with a source tree, Handlebars templating, git integration, and token counting. Ships an MCP server and a Python SDK (`pip install code2prompt-rs`); also `cargo install` / Homebrew.
+
+### Adoption Considerations
+
+**Use when**: you want a deterministic, whole-repo snapshot for a one-off question, an agent's first turn, or a non-CC LLM — no server to run. **Prefer the graph/LSP tools above** (codebase-memory-mcp, graphify, Serena) for repeated, large-codebase work, where re-sending a packed corpus every turn would blow the context budget. Repomix's `--compress` and these packers are complementary to RTK (output-side) and Boucle (read dedup), both above.
+
+---
+
 ## CodeBurn (AgentSeal)
 
 **Repo**: [getagentseal/codeburn][codeburn] | **Stars**: 4K | **License**: MIT | **Latest**: Menubar v0.9.0 (2026-04-25) | **Stack**: TypeScript, Node.js 20+
@@ -662,11 +773,16 @@ Cross-ref: [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-a
 | **Graphify** | Code→knowledge graph | Hooks + slash commands + MCP + CLAUDE.md | Semantic knowledge graphs from repos | Active (16.5K stars) |
 | **MemPalace** | Persistent memory | MCP server + plugin marketplace | Verbatim palace-metaphor memory | Active (33.6K stars, v3.0.0) |
 | **Code-Review-Graph** | Structural code analysis | MCP server (22 tools, auto-config) | AST-based blast radius for reviews | Active (7.1K stars) |
+| **codebase-memory-mcp** | Code→graph + LSP + embeddings | MCP (14 tools) + PreToolUse hook + auto-config | Single-binary knowledge graph | Active (3.2K stars, v0.7.0) |
+| **Serena** | Semantic code (live LSP) | MCP server (20+ tools) | Symbol-level retrieve/edit/refactor | Active (25.2K stars, v1.5.3) |
+| **ast-grep MCP** | Structural search/rewrite | MCP server (4 tools) | tree-sitter AST patterns | Experimental (419 stars, no release) |
+| **Repomix** | Repo→single-file context export | MCP server + official CC plugins | tree-sitter compression + token counts | Stable (26.2K stars, v1.14.1) |
+| **code2prompt** | Repo→single-prompt context export | MCP server + CLI | Templated export + token counts | Stable (7.4K stars, v4.2.0) |
 | **CodeBurn** | Token-usage observability (cross-agent) | CLI (reads on-disk session data) | Cross-agent dashboard, 13 task categories, optimize/compare | Active (4K stars) |
 | **ccusage** | Token-usage observability (CC/Codex) | CLI + MCP server + statusline | JSONL analyzer, cache-token split, offline mode | Stable (13.4K stars, v18.0.11) |
 | **Claude-Code-Usage-Monitor** | Predictive usage monitoring | Real-time TUI | P90-based limit prediction, burn-rate analytics, plan-aware | Active (7.8K stars, v3.1.0) |
 
-All sixteen address different layers of the agent stack — complementary, not competing.
+All twenty-one address different layers of the agent stack — complementary, not competing. The five code-analysis tools (graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP) split along precompute-a-graph vs. live-LSP vs. on-demand-structural-search; the two repo packers (Repomix, code2prompt) are one-shot context export rather than a live server.
 
 Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-extended-context-analysis.md) — CC's built-in context compaction
 
@@ -689,6 +805,11 @@ Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-exte
 | [Graphify][graphify] | Code→knowledge graph via slash commands, hooks, MCP (16.5K stars) |
 | [MemPalace][mempalace] | Local-first AI memory with palace metaphor, 96.6% LongMemEval (33.6K stars) |
 | [Code-Review-Graph][code-review-graph] | AST-based blast radius analysis, 22 MCP tools (7.1K stars) |
+| [codebase-memory-mcp][codebase-memory-mcp] | Single-binary code knowledge graph: 159 tree-sitter grammars + hybrid LSP + embeddings, 14 MCP tools (3.2K stars, MIT) |
+| [Serena][serena] | LSP-based semantic coding MCP toolkit, 20+ symbol-level tools, 40+ languages (25.2K stars, MIT) |
+| [ast-grep MCP][ast-grep-mcp] | MCP wrapper for ast-grep structural AST search/rewrite, 4 tools (419 stars, MIT) |
+| [Repomix][repomix] | Repo→single-file packer, tree-sitter `--compress`, MCP server + CC plugins (26.2K stars, MIT) |
+| [code2prompt][code2prompt] | Repo→single-prompt CLI with token counting, MCP server + Python SDK (7.4K stars, MIT) |
 | [CodeBurn][codeburn] | Cross-agent token-usage TUI dashboard (4K stars, MIT) |
 | [ccusage][ccusage] | CC/Codex JSONL usage analyzer, MCP-integrated (13.4K stars, MIT) |
 | [Claude-Code-Usage-Monitor][claude-monitor] | Predictive real-time usage monitor with P90-based limits (7.8K stars, MIT) |
@@ -698,6 +819,12 @@ Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-exte
 [mempalace]: https://github.com/MemPalace/mempalace
 [longmemeval]: https://github.com/xiaowu0162/LongMemEval
 [code-review-graph]: https://github.com/tirth8205/code-review-graph
+[codebase-memory-mcp]: https://github.com/DeusData/codebase-memory-mcp
+[serena]: https://github.com/oraios/serena
+[ast-grep-mcp]: https://github.com/ast-grep/ast-grep-mcp
+[ast-grep]: https://github.com/ast-grep/ast-grep
+[repomix]: https://github.com/yamadashy/repomix
+[code2prompt]: https://github.com/mufeedvh/code2prompt
 [rtk-repo]: https://github.com/rtk-ai/rtk
 [rtk-839]: https://github.com/rtk-ai/rtk/issues/839
 [gsd-repo]: https://github.com/gsd-build/get-shit-done

--- a/docs/cc-native/configuration/CC-model-provider-configuration.md
+++ b/docs/cc-native/configuration/CC-model-provider-configuration.md
@@ -31,7 +31,7 @@ Claude Fable 5 (`claude-fable-5`) — Anthropic's most capable widely released m
 | -------- | ----- |
 | Model ID | `claude-fable-5` |
 | Context / max output | 1M tokens (default) / 128K tokens ([source][models-overview]) |
-| Pricing | $10 / $50 per MTok (input / output) — above Opus-tier's $5 / $25 ([source][models-overview]) |
+| Pricing | $10 / $50 per MTok (input / output) — above Opus-tier's $5 / $25 ([source][models-pricing]) |
 | Thinking | Adaptive only, always on (`thinking: disabled` unsupported); tune depth with `CLAUDE_CODE_EFFORT_LEVEL` / effort `low`–`xhigh`/`max` ([source][fable5-intro]) |
 
 CC-relevant caveats ([source][fable5-intro]):
@@ -189,7 +189,7 @@ claude
 | **KV cache invalidation** | CC prepends an attribution header that invalidates KV cache. Set `CLAUDE_CODE_ATTRIBUTION_HEADER=0` to prevent this ([source][local-setup]) |
 | **Login bypass** | If CC prompts for login, add `"hasCompletedOnboarding": true` and `"primaryApiKey": "sk-dummy-key"` to `~/.claude.json` ([source][local-setup]) |
 | **Non-essential traffic** | Set `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` to reduce calls to Anthropic servers ([source][cc-settings]) |
-| **Cost savings** | Local models are free; third-party cloud options like DeepSeek V3.2 are ~$0.28/$0.42 per million tokens vs Opus 4.8 $5/$25 (Fable 5 $10/$50) ([source][models-overview]) |
+| **Cost savings** | Local models are free; third-party cloud options like DeepSeek V3.2 are ~$0.28/$0.42 per million tokens vs Opus 4.8 $5/$25 (Fable 5 $10/$50) ([source][models-pricing]) |
 
 ### LLM Gateway / Proxy Configuration
 
@@ -285,6 +285,7 @@ When routing through gateways, additionally set ([source][cc-settings]):
 - [CC Settings — Environment Variables][cc-settings]
 - [Anthropic — Introducing Claude Fable 5 & Mythos 5][fable5-intro]
 - [Anthropic — Models Overview][models-overview]
+- [Anthropic — Pricing][models-pricing]
 - [OpenRouter — Claude Code Integration][openrouter]
 - [Ollama — Claude Code with Anthropic API Compatibility][ollama-claude]
 - [llama.cpp — Anthropic Messages API][llamacpp-anthropic]
@@ -303,6 +304,6 @@ When routing through gateways, additionally set ([source][cc-settings]):
 [olla]: https://thushan.github.io/olla/integrations/frontend/claude-code/
 [bifrost]: https://www.getmaxim.ai/articles/running-non-anthropic-models-in-claude-code-via-an-enterprise-ai-gateway/
 [local-setup]: https://medium.com/@luongnv89/run-claude-code-on-local-cloud-models-in-5-minutes-ollama-openrouter-llama-cpp-6dfeaee03cda
-[models-pricing]: https://platform.claude.com/docs/en/docs/about-claude/models
 [fable5-intro]: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
 [models-overview]: https://platform.claude.com/docs/en/about-claude/models/overview
+[models-pricing]: https://platform.claude.com/docs/en/about-claude/pricing

--- a/docs/cc-native/configuration/CC-model-provider-configuration.md
+++ b/docs/cc-native/configuration/CC-model-provider-configuration.md
@@ -3,8 +3,8 @@ title: CC Model & Provider Configuration
 source: https://code.claude.com/docs/en/settings#environment-variables, https://openrouter.ai/docs/guides/coding-agents/claude-code-integration, https://ollama.com/blog/claude, https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models
 purpose: Reference for configuring CC with alternative models, endpoints, API keys, third-party providers (OpenRouter, Bedrock, Vertex, Foundry), local models (Ollama, llama.cpp, LM Studio), and LLM gateway proxies.
 created: 2026-03-07
-updated: 2026-04-23
-validated_links: 2026-04-23
+updated: 2026-06-10
+validated_links: 2026-06-10
 ---
 
 **Status**: Reference (actionable configuration guide)
@@ -18,10 +18,28 @@ validated_links: 2026-04-23
 | `ANTHROPIC_DEFAULT_SONNET_MODEL` | Override Sonnet-class model | Custom model ID |
 | `ANTHROPIC_DEFAULT_OPUS_MODEL` | Override Opus-class model | Custom model ID |
 | `CLAUDE_CODE_SUBAGENT_MODEL` | Model for subagents/teammates | Custom model ID |
-| `CLAUDE_CODE_EFFORT_LEVEL` | Reasoning effort (Opus 4.6, Sonnet 4.6) | `low`, `medium`, `high` |
+| `CLAUDE_CODE_EFFORT_LEVEL` | Reasoning effort (Fable 5, Opus 4.8/4.7/4.6, Sonnet 4.6) | `low`, `medium`, `high`, `xhigh`, `max` |
 | `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` | Disable adaptive reasoning | `1` |
 
 All variables can also be set in `settings.json` under the `env` key. ([source][cc-settings])
+
+### Claude Fable 5 (newest model)
+
+Claude Fable 5 (`claude-fable-5`) — Anthropic's most capable widely released model, built for complex, long-running agentic work — is selectable in CC via `/model` or `ANTHROPIC_MODEL=claude-fable-5`. Generally available on the Claude API and major clouds since 2026-06-09 ([source][fable5-intro]).
+
+| Property | Value |
+| -------- | ----- |
+| Model ID | `claude-fable-5` |
+| Context / max output | 1M tokens (default) / 128K tokens ([source][models-overview]) |
+| Pricing | $10 / $50 per MTok (input / output) — above Opus-tier's $5 / $25 ([source][models-overview]) |
+| Thinking | Adaptive only, always on (`thinking: disabled` unsupported); tune depth with `CLAUDE_CODE_EFFORT_LEVEL` / effort `low`–`xhigh`/`max` ([source][fable5-intro]) |
+
+CC-relevant caveats ([source][fable5-intro]):
+
+- **New tokenizer** (the one introduced with Opus 4.7): the same text is ~30% more tokens than on pre-4.7 models — re-baseline cost and `CLAUDE_CODE_MAX_OUTPUT_TOKENS` expectations.
+- **`refusal` stop reason**: safety classifiers may decline a request as a successful HTTP 200 (not an error); plan for refusal handling and fallback to another model.
+- **30-day data retention required** — not available to zero-data-retention orgs.
+- **CC plan access** (per the in-product `/model` notice, 2026-06): included in Claude plan limits until 2026-06-22, after which it continues via usage credits.
 
 ## API Key & Endpoint
 
@@ -171,7 +189,7 @@ claude
 | **KV cache invalidation** | CC prepends an attribution header that invalidates KV cache. Set `CLAUDE_CODE_ATTRIBUTION_HEADER=0` to prevent this ([source][local-setup]) |
 | **Login bypass** | If CC prompts for login, add `"hasCompletedOnboarding": true` and `"primaryApiKey": "sk-dummy-key"` to `~/.claude.json` ([source][local-setup]) |
 | **Non-essential traffic** | Set `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` to reduce calls to Anthropic servers ([source][cc-settings]) |
-| **Cost savings** | Local models are free; third-party cloud options like DeepSeek V3.2 are ~$0.28/$0.42 per million tokens vs Opus 4.6 $5/$25 ([source][models-pricing]) |
+| **Cost savings** | Local models are free; third-party cloud options like DeepSeek V3.2 are ~$0.28/$0.42 per million tokens vs Opus 4.8 $5/$25 (Fable 5 $10/$50) ([source][models-overview]) |
 
 ### LLM Gateway / Proxy Configuration
 
@@ -265,6 +283,8 @@ When routing through gateways, additionally set ([source][cc-settings]):
 ## References
 
 - [CC Settings — Environment Variables][cc-settings]
+- [Anthropic — Introducing Claude Fable 5 & Mythos 5][fable5-intro]
+- [Anthropic — Models Overview][models-overview]
 - [OpenRouter — Claude Code Integration][openrouter]
 - [Ollama — Claude Code with Anthropic API Compatibility][ollama-claude]
 - [llama.cpp — Anthropic Messages API][llamacpp-anthropic]
@@ -284,3 +304,5 @@ When routing through gateways, additionally set ([source][cc-settings]):
 [bifrost]: https://www.getmaxim.ai/articles/running-non-anthropic-models-in-claude-code-via-an-enterprise-ai-gateway/
 [local-setup]: https://medium.com/@luongnv89/run-claude-code-on-local-cloud-models-in-5-minutes-ollama-openrouter-llama-cpp-6dfeaee03cda
 [models-pricing]: https://platform.claude.com/docs/en/docs/about-claude/models
+[fable5-intro]: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
+[models-overview]: https://platform.claude.com/docs/en/about-claude/models/overview

--- a/lychee.toml
+++ b/lychee.toml
@@ -42,6 +42,7 @@ exclude = [
     "openai.com",  # 403 to HEAD on /index/* article URLs
     "code2tutorial.com",  # 404 to HEAD; root may anti-bot — referenced in cc-community landscape
     "techcommunity.microsoft.com",  # 403 to HEAD on /blog/* URLs (anti-bot)
+    "datacamp.com",  # 403 to HEAD (anti-bot) on /tutorial/* URLs — referenced in CC-version-pinning-resilience.md
     "zread.ai",  # 403 to all automated requests (Cloudflare); AI doc-reader of GitHub repos — referenced in CC-agent-teams-orchestration.md
     # Auth-gated (requires login) — both `/code` and `/code/scheduled` and `/settings/*` return 403 to anonymous requests
     "claude.ai/code",


### PR DESCRIPTION
## Summary

Two topics, one branch (commit-by-topic):

1. **`docs(cc-native)`** — Add **Claude Fable 5** (`claude-fable-5`) to the CC model/provider configuration doc, and refresh stale Opus references to **Opus 4.8**.
2. **`docs(cc-community)`** — Add **5 codebase-analysis / token-saving tools** to the community tooling landscape (16 → 21).

## Topic 1 — Claude Fable 5 + Opus 4.8

`docs/cc-native/configuration/CC-model-provider-configuration.md`

- New **Claude Fable 5** subsection under Model Selection: 1M context / 128K output, `$10/$50` pricing, always-on adaptive thinking (no `budget_tokens`; effort `low`–`xhigh`/`max`), ~30% more tokens (new tokenizer) cost note, `refusal` stop reason, 30-day data-retention requirement, and the CC plan-limits-until-2026-06-22-then-credits note.
- Refreshed stale refs: `CLAUDE_CODE_EFFORT_LEVEL` row now lists Fable 5 / Opus 4.8 / 4.7 / 4.6; cost-savings row compares vs Opus 4.8 (`$5/$25`; Fable 5 `$10/$50`).
- First-party sources: Anthropic "Introducing Claude Fable 5 & Mythos 5" and "Models Overview".

## Topic 2 — codebase-analysis / token-saving tools

`docs/cc-community/CC-community-tooling-landscape.md`

| Tool | Approach | Stars |
|---|---|---|
| **codebase-memory-mcp** (DeusData) | single-binary tree-sitter (159 grammars) + hybrid LSP + bundled embeddings → SQLite graph; 14 MCP tools, PreToolUse hook | 3.2K |
| **Serena** (oraios) | live-LSP semantic MCP toolkit, 20+ symbol-level tools, 40+ languages | 25.2K |
| **ast-grep MCP** | tree-sitter structural search/rewrite, 4 MCP tools | 419 |
| **Repomix** (yamadashy) | repo → single AI file, `--compress` (tree-sitter), token counts; MCP + CC plugins | 26.2K |
| **code2prompt** (mufeedvh) | repo → single prompt, templating + token counts; MCP + Python SDK | 7.4K |

- `graphify` was already documented and is left as-is; these fill the gaps in the AST/graph/LSP and repo-packer sub-categories.
- Updated the comparison table, the "twenty-one tools" count, the Sources table, and link defs. All entries cite their first-party GitHub repos.

## Notes

- All new links use first-party sources (Anthropic docs / tool repos); `platform.claude.com` is not lychee-excluded, so the links are checked in CI.
- Out of scope / open question: `mammouth.ai` (not in the repo; would fit "Direct CC-Compatible Endpoints" if it exposes an Anthropic-compatible endpoint — needs verification before adding).

Generated with Claude <noreply@anthropic.com>
