### PR TITLE
docs: add GitHub Copilot CLI analysis + catalog graphify coding agents

### DIFF
--- a/docs/cc-native/ci-remote/CC-github-actions-analysis.md
+++ b/docs/cc-native/ci-remote/CC-github-actions-analysis.md
@@ -296,6 +296,8 @@ The CC GHA interactive mode supports `@claude` in issue comments, but the broade
 | [Devin][devin] | Yes (full autonomous) | No | Basic | Full agent | No | $20/mo + ACUs |
 | [AI Issue Resolver][axiotree] | Yes (label-triggered) | No | Label-triggered | Generates PRs | MIT | Free (BYOK) |
 
+**CLI vs cloud-agent surfaces.** The *GitHub Copilot Coding Agent* and *Devin* rows above are the autonomous **cloud** products (assign work, it opens a PR). They are distinct from the same brands' interactive **terminal/IDE** agents — [GitHub Copilot CLI][copilot-cli] (same agentic harness, run locally), VS Code Copilot Chat, and Devin CLI — which are tracked in the [non-CC coding-agent landscape](../../non-cc/README.md#planned), not as CI-native issue→PR automations.
+
 ### Gap Analysis
 
 Four capabilities most solutions miss when applied to issue lifecycle:
@@ -334,6 +336,7 @@ A Python composite GHA addressing all four gaps is planned at [qte77/gha-issue-t
 [gh-larger-runner-jobs]: https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners/use-larger-runners
 [cc-action-repo]: https://github.com/anthropics/claude-code-action
 [copilot-agent]: https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent
+[copilot-cli]: https://github.com/github/copilot-cli
 [codex-action]: https://github.com/openai/codex-action
 [sweep-repo]: https://github.com/sweepai/sweep
 [swe-agent-repo]: https://github.com/SWE-agent/SWE-agent

--- a/docs/non-cc/README.md
+++ b/docs/non-cc/README.md
@@ -18,6 +18,7 @@ Standalone analyses of coding agents and orchestration tools beyond Claude Code.
 | [feynman-analysis.md](feynman-analysis.md) | Companion AI Feynman (research agent, multi-agent investigation) | Yes | Yes (MIT) |
 | [hermes-agent-analysis.md](hermes-agent-analysis.md) | Nous Research Hermes (self-improving, multi-platform, 43K stars) | Yes | Yes (MIT) |
 | [rowboat-analysis.md](rowboat-analysis.md) | Rowboat (AI coworker, knowledge graph from comms) | No | Yes (Apache-2.0) |
+| [github-copilot-cli-analysis.md](github-copilot-cli-analysis.md) | GitHub Copilot CLI (terminal agent, same harness as Copilot coding agent) | Yes | No (proprietary) |
 
 ## Knowledge Management
 
@@ -54,6 +55,14 @@ Standalone analyses of coding agents and orchestration tools beyond Claude Code.
 ## Planned
 
 Cline, opencode, Codebuff, Gemini CLI, Cursor, Antigravity, Kiro, Codex CLI,
-Copilot, Windsurf, Aider, Amazon Q -- see
+VS Code Copilot Chat, Devin CLI, Windsurf, Aider, Amazon Q,
+CodeBuddy, Kilo Code, Trae, Kimi Code, Amp, Pi -- see
 [coding-agent-eval plan](https://github.com/qte77/coding-agent-eval) for the
 full landscape.
+
+**Disambiguation.** [GitHub Copilot CLI](github-copilot-cli-analysis.md)
+(analyzed above) and *Devin CLI* are interactive terminal agents. They share
+branding — but not surface — with the *GitHub Copilot Coding Agent* (cloud;
+assign an issue, it opens a PR) and *autonomous Devin*, which are covered
+separately under CI automation in
+[CC-github-actions-analysis.md](../cc-native/ci-remote/CC-github-actions-analysis.md#issue-lifecycle-automation-landscape).

--- a/docs/non-cc/github-copilot-cli-analysis.md
+++ b/docs/non-cc/github-copilot-cli-analysis.md
@@ -1,0 +1,135 @@
+---
+title: GitHub Copilot CLI Analysis
+source: https://github.com/github/copilot-cli
+purpose: Analysis of GitHub Copilot CLI as a terminal coding agent sharing the agentic harness of the Copilot coding agent, distinct from its cloud surface.
+platform_scope: [cli, cloud]
+created: 2026-06-11
+updated: 2026-06-11
+validated_links: 2026-06-11
+---
+
+**Status**: Proprietary ([custom license][copilot-cli-license], no derivatives) | **GA**: 2026-02-25 | **Version**: v1.0.61 (2026-06-09) | requires active Copilot subscription
+
+## What It Is
+
+GitHub Copilot CLI is a **terminal-native coding agent** — "the power of GitHub
+Copilot, in your terminal." Run `copilot` in a repo and it plans, edits files,
+runs commands, reviews changes, and remembers across sessions. It is "powered by
+the **same agentic harness** as GitHub's Copilot coding agent," so the two share
+behavior but are **different surfaces**: this is the interactive local terminal
+agent; the [Copilot coding agent][copilot-agent] is the autonomous cloud product
+that opens PRs from assigned issues (covered separately under
+[CI automation](../cc-native/ci-remote/CC-github-actions-analysis.md#issue-lifecycle-automation-landscape)).
+
+**Key distinction vs OSS peers** (Aider, Kilo Code, OpenCode): Copilot CLI is
+**proprietary** and gated on a Copilot subscription, but reuses an org's existing
+GitHub identity, billing, and the GitHub MCP server out of the box — the adoption
+cost is access control, not a new vendor.
+
+## How It Works
+
+### Agentic harness and models
+
+Default model is **Claude Sonnet 4.5**; `/model` switches across providers
+(Anthropic, OpenAI, Google) — e.g. Claude Sonnet 4, GPT-5. The harness plans,
+executes multi-step workflows, and can **delegate to subagent processes**.
+
+### Built-in agents
+
+Six specialized agents cover distinct workflows: **Explore** (codebase analysis
+without growing primary context), **Task** (run tests/builds), **General
+purpose** (full toolset), **Code review** (low-false-positive change assessment),
+**Research** (deep cross-source investigation), **Rubber duck** (feedback).
+Select via `/agent` or `--agent=<name>`.
+
+### Extensibility (MCP, custom agents, instructions)
+
+| Surface | Location |
+|---|---|
+| MCP servers | GitHub MCP server preconfigured; add via `/mcp add` → `mcp-config.json` |
+| Custom agents | Markdown profiles at `~/.copilot/agents`, `.github/agents`, `.github-private/agents` |
+| Instructions | `.github/copilot-instructions.md`, `.github/instructions/**/*.instructions.md` |
+| Settings | `settings.json` in `~/.copilot` (override path via `COPILOT_HOME`) |
+| LSP | `~/.copilot/lsp-config.json` (user) or `.github/lsp.json` (repo) |
+
+Note the instruction file is `copilot-instructions.md`, **not `AGENTS.md`** — a
+portability gap vs the AGENTS.md convergence ([CC-skills-adoption-analysis.md](../cc-native/agents-skills/CC-skills-adoption-analysis.md)).
+
+### Permissions, sandboxing, autonomy
+
+Default model is **preview-every-action**: approve once, approve session-wide, or
+reject with alternate instructions. Escalating autonomy via plan mode and
+autopilot mode (cycle with Shift+Tab), `--allow-all` / `--yolo` to bypass
+prompts, and `/sandbox enable` for local or cloud sandboxing. `--cloud` delegates
+the run to the cloud coding-agent backend.
+
+### Sessions, memory, auth
+
+`/resume` (or `--resume` / `--continue`) restores sessions with automatic context
+compression and **cross-session repository memory**; `/usage`, `/context`,
+`/compact` manage the window. Auth via `/login` or a fine-grained PAT with the
+**Copilot Requests** permission set through `GH_TOKEN` / `GITHUB_TOKEN`. Each
+prompt consumes one premium request against the monthly quota.
+
+### Install and invoke
+
+`curl -fsSL https://gh.io/copilot-install | bash` · `brew install copilot-cli` ·
+`winget install GitHub.Copilot` · `npm install -g @github/copilot`. Then run
+`copilot` (Linux/macOS/Windows).
+
+## Adoption Decision
+
+| Dimension | Assessment |
+|---|---|
+| **Use case** | Terminal coding agent; peer to Codex CLI / Gemini CLI / Claude Code |
+| **Model flexibility** | Multi-provider via `/model` (default Claude Sonnet 4.5) |
+| **Extensibility** | MCP (GitHub server default), custom agents, plugins, LSP |
+| **Permission model** | Preview-every-action → plan/autopilot → `--yolo`; local/cloud sandbox |
+| **Maturity** | GA 2026-02-25, actively released (v1.0.61) |
+| **License** | **Proprietary** — no modification, no standalone redistribution |
+| **Cost** | Copilot Pro / Pro+ / Business / Enterprise; 1 premium request per prompt |
+
+**Strengths**: Same agentic harness as the Copilot coding agent — consistent
+behavior across CLI and cloud. Reuses existing GitHub auth, billing, and MCP
+server (lowest onboarding friction for orgs already on Copilot). Strong
+permission/sandbox model. Multi-provider model choice.
+
+**Risks**: **Proprietary license** — cannot fork, embed, or self-host (unlike
+Aider/Kilo/OpenCode). Subscription + per-prompt premium-request quota.
+Business/Enterprise use requires admin enablement. `copilot-instructions.md`
+instead of `AGENTS.md` adds a config surface in multi-agent shops. PAT auth keys
+off `GH_TOKEN`/`GITHUB_TOKEN` — watch for env-var shadowing in CI.
+
+## Action Items
+
+- **Evaluate** as the terminal agent for teams already holding Copilot
+  Business/Enterprise — no new vendor, reuses GitHub identity and billing.
+- **Disambiguate** in any agent comparison: CLI (local, interactive) vs coding
+  agent (cloud, issue→PR) — same harness, different surface.
+- **Factor the config gap** (`copilot-instructions.md` ≠ `AGENTS.md`) into
+  multi-agent onboarding ([multi-agent-onboarding-outlook.md](../sdlc-lcm/multi-agent-onboarding-outlook.md)).
+- **Flag the license** when comparing against OSS peers — adoption is reversible
+  only at the subscription level, not the code level.
+
+## Cross-References
+
+- [CC-github-actions-analysis.md](../cc-native/ci-remote/CC-github-actions-analysis.md#issue-lifecycle-automation-landscape) — the Copilot **coding agent** (cloud) it shares a harness with
+- [CC-skills-adoption-analysis.md](../cc-native/agents-skills/CC-skills-adoption-analysis.md) — AGENTS.md convergence vs `copilot-instructions.md`
+- [multi-agent-onboarding-outlook.md](../sdlc-lcm/multi-agent-onboarding-outlook.md) — per-agent config-file comparison
+- [CC-community-tooling-landscape.md](../cc-community/CC-community-tooling-landscape.md) — multi-agent tooling (CC Switch, CodeBurn) that targets Copilot; `~/.copilot` session data
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [github/copilot-cli repo][copilot-cli-repo] | Install, models, MCP, permission model, license |
+| [Copilot CLI docs][copilot-cli-docs] | Agents, slash commands, config files, sandboxing, auth |
+| [Copilot CLI overview][copilot-cli-overview] | Capabilities, autopilot, LSP, quota |
+| [GA changelog 2026-02-25][copilot-cli-ga] | GA date, eligible plans, headline features |
+
+[copilot-cli-repo]: https://github.com/github/copilot-cli
+[copilot-cli-license]: https://github.com/github/copilot-cli/blob/main/LICENSE.md
+[copilot-cli-docs]: https://docs.github.com/en/copilot/how-tos/copilot-cli
+[copilot-cli-overview]: https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli/overview
+[copilot-cli-ga]: https://github.blog/changelog/2026-02-25-github-copilot-cli-is-now-generally-available/
+[copilot-agent]: https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent


### PR DESCRIPTION
## Summary

Research follow-up from analyzing the coding agents in graphify's [\"Pick your platform\"](https://github.com/safishamsi/graphify#pick-your-platform) section against this repo's coverage.

- **New analysis** — `docs/non-cc/github-copilot-cli-analysis.md`: standalone 4-section analysis of **GitHub Copilot CLI** (GA 2026-02-25, proprietary license, default Claude Sonnet 4.5, shares the agentic harness of the Copilot coding agent). Indexed under non-cc Agents.
- **Catalog** — extend the non-cc *Planned* list with the untracked graphify entrants: CodeBuddy, Kilo Code, Trae, Kimi Code, Amp, Pi, VS Code Copilot Chat, Devin CLI.
- **Disambiguation** — in both the non-cc index and the CI issue-lifecycle landscape, separate the *CLI/terminal* surfaces (Copilot CLI, Copilot Chat, Devin CLI) from the *autonomous cloud* products (Copilot Coding Agent, Devin) they share branding with.

## Commits (by topic)

1. `docs(cc-native)` — disambiguate Copilot/Devin CLI vs cloud agent in the CI landscape table.
2. `docs(non-cc)` — add the GitHub Copilot CLI analysis and catalog the graphify agents.

## Validation

- `markdownlint-cli2` — 0 errors on changed files.
- `lychee` — 0 errors (65 OK, 2 redirect warnings).
- All claims cited to first-party sources (github/copilot-cli repo, GitHub Docs, GA changelog).

Generated with Claude <noreply@anthropic.com>