### PR TITLE
docs: disambiguate Anthropic design offerings + extend first-party repo index

### DIFF
--- a/docs/cc-native/CC-first-party-docs-index.md
+++ b/docs/cc-native/CC-first-party-docs-index.md
@@ -2,8 +2,8 @@
 title: CC First-Party Documentation Index
 purpose: Canonical Anthropic URLs for CC, Agent SDK, Anthropic SDK, API, and best practices.
 created: 2026-03-28
-updated: 2026-04-13
-validated_links: 2026-04-13
+updated: 2026-06-11
+validated_links: 2026-06-11
 ---
 
 ## CC First-Party Documentation Index
@@ -67,5 +67,7 @@ validated_links: 2026-04-13
 | Topic | URL |
 |-------|-----|
 | Claude Code repo | <https://github.com/anthropics/claude-code> |
-| Official plugins | <https://github.com/anthropics/claude-code/tree/main/plugins> |
+| Official plugins marketplace | <https://github.com/anthropics/claude-plugins-official> |
+| Knowledge-work plugins | <https://github.com/anthropics/knowledge-work-plugins> |
+| Financial services agents | <https://github.com/anthropics/financial-services> |
 | Model Context Protocol | <https://modelcontextprotocol.io/> |

--- a/docs/cc-native/plugins-ecosystem/CC-official-plugins-landscape.md
+++ b/docs/cc-native/plugins-ecosystem/CC-official-plugins-landscape.md
@@ -3,8 +3,8 @@ title: CC Official Plugins Landscape
 source: https://www.firecrawl.dev/blog/best-claude-code-plugins, https://code.claude.com/docs/en/plugins
 purpose: Catalog the official CC plugin ecosystem, assess coverage gaps in this research repo, and provide adoption guidance per plugin.
 created: 2026-03-12
-updated: 2026-03-12
-validated_links: 2026-03-12
+updated: 2026-06-11
+validated_links: 2026-06-11
 ---
 
 **Status**: Reference (living catalog — update as ecosystem evolves)
@@ -121,6 +121,8 @@ mcp__context7__get-library-docs \
 
 **Fit assessment**: **Skip unless frontend project.** A skills-based plugin that adjusts Claude's design sensibility. No backend or API relevance. Adopt if building user-facing web interfaces where visual quality matters.
 
+**Disambiguation — three Anthropic "design" offerings.** Don't conflate: **`frontend-design`** (the CC plugin above — adjusts UI-generation sensibility); the **`design`** plugin ([claude.com/plugins/design][design-cowork]), a **Claude Cowork** plugin for design critique, UX microcopy, WCAG 2.1 AA accessibility audits, research synthesis, and dev handoff; and **Claude Design** (`claude.ai/design`), an Anthropic Labs research-preview *product* (Opus 4.7 vision; designs, prototypes, slides) that packages a build bundle for handoff to Claude Code ([announced 2026-04-17][labs-design]). The first two are plugins; the third is a standalone product, not a plugin.
+
 ### Linear
 
 **What it does**: Connects Claude to Linear issue tracker — pull issues, summarize tickets, mark in-progress, break into subtasks ([source][firecrawl-blog]).
@@ -226,3 +228,5 @@ These plugins have full analysis elsewhere in this repo:
 [cc-best-practice-gh]: https://github.com/shanraisshan/claude-code-best-practice
 [everything-cc]: https://github.com/affaan-m/everything-claude-code
 [cuttlesoft]: https://cuttlesoft.com/blog/2026/02/03/claude-code-for-advanced-users/
+[design-cowork]: https://claude.com/plugins/design
+[labs-design]: https://www.anthropic.com/news/claude-design-anthropic-labs


### PR DESCRIPTION
## Summary

Coverage follow-up: address the absent Anthropic resources surfaced in the last review.

- **Design disambiguation** (`CC-official-plugins-landscape.md`) — a note in the Frontend Design section separating the three easily-conflated Anthropic "design" offerings:
  - `frontend-design` — the CC plugin (UI-generation sensibility).
  - `design` — a Claude **Cowork** plugin ([claude.com/plugins/design](https://claude.com/plugins/design)): design critique, UX microcopy, WCAG 2.1 AA audits, research synthesis, dev handoff.
  - **Claude Design** (`claude.ai/design`) — an Anthropic **Labs** research-preview *product* (Opus 4.7 vision; designs/prototypes/slides) that hands a build bundle to Claude Code ([announced 2026-04-17](https://www.anthropic.com/news/claude-design-anthropic-labs)). Not a plugin.
- **First-party docs index** (`CC-first-party-docs-index.md`, light) — refresh the GitHub Resources table: replace the stale official-plugins path with `anthropics/claude-plugins-official`, and add the `knowledge-work-plugins` and `financial-services` repos already cited piecemeal.

## Commits (by topic)

1. `docs(plugins-ecosystem)` — design disambiguation.
2. `docs(cc-native)` — first-party repo index extension.

## Validation

- `markdownlint-cli2` — 0 errors.
- `lychee` — 0 errors (`claude.ai/design` rendered as a code span, not a checked link, since it bot-blocks with 403; the canonical Labs announcement URL is the cited source).

Generated with Claude <noreply@anthropic.com>