### PR TITLE
docs: document dynamic workflows, ultracode & /deep-research in cc-native

### DIFF
--- a/docs/cc-native/README.md
+++ b/docs/cc-native/README.md
@@ -6,7 +6,7 @@ Deep-dive analyses of Anthropic-native Claude Code features and internals.
 
 | Directory | Coverage | Docs |
 |-----------|----------|------|
-| [agents-skills/](agents-skills/) | Agent teams, recursive spawning, skills adoption, Ralph enhancement | 6 |
+| [agents-skills/](agents-skills/) | Agent teams, recursive spawning, skills adoption, Ralph, dynamic workflows | 8 |
 | [sessions/](sessions/) | Session lifecycle, cost analysis, keepalive, headless mode, error messages | 5 |
 | [sandboxing/](sandboxing/) | Filesystem/network sandbox, Codespaces friction, platform comparison, permission bypass | 4 |
 | [ci-remote/](ci-remote/) | GitHub Actions, cloud sessions, remote access/control, web auth, version pinning, monitoring | 8 |

--- a/docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md
+++ b/docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md
@@ -58,7 +58,7 @@ It is **not** part of `effortLevel` in settings.json, the `--effort` flag, or `C
 
 ## Bundled Workflow: /deep-research
 
-The one built-in workflow Claude Code ships ([workflows][cc-workflows]):
+The one built-in workflow Claude Code ships ([bundled workflows][cc-bundled]):
 
 > `/deep-research <question>` — Fans out web searches on a question across several angles, fetches and cross-checks the sources it finds, votes on each claim, and returns a cited report with claims that didn't survive cross-checking filtered out. Requires the [WebSearch tool][cc-tools-ref] to be available.
 
@@ -86,7 +86,8 @@ Workflows run in the CLI, Desktop, IDE extensions, headless (`claude -p`), and t
 
 | Source | Content |
 |---|---|
-| [Dynamic workflows][cc-workflows] | Workflow tool, script API, bundled /deep-research, ultracode triggers, limits, disabling |
+| [Dynamic workflows][cc-workflows] | Workflow tool, script API, ultracode triggers, limits, disabling |
+| [Bundled workflows][cc-bundled] | The `/deep-research` table + walkthrough |
 | [Model configuration — effort][cc-effort] | ultracode effort setting definition and constraints |
 | [Subagents][cc-subagents] | The worker primitive workflows orchestrate |
 | [Run agents in parallel][cc-agents] | Subagents vs skills vs teams vs workflows |
@@ -94,6 +95,7 @@ Workflows run in the CLI, Desktop, IDE extensions, headless (`claude -p`), and t
 | [Tools reference — WebSearch][cc-tools-ref] | `/deep-research` dependency |
 
 [cc-workflows]: https://code.claude.com/docs/en/workflows
+[cc-bundled]: https://code.claude.com/docs/en/workflows#bundled-workflows
 [cc-effort]: https://code.claude.com/docs/en/model-config#adjust-effort-level
 [cc-subagents]: https://code.claude.com/docs/en/sub-agents
 [cc-agents]: https://code.claude.com/docs/en/agents

--- a/docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md
+++ b/docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md
@@ -1,0 +1,101 @@
+---
+title: CC Dynamic Workflows, Ultracode & deep-research
+source: https://code.claude.com/docs/en/workflows
+purpose: Document Claude Code's dynamic workflow orchestration tool, the ultracode effort setting, and the bundled /deep-research workflow, with first-party sourcing.
+created: 2026-06-11
+updated: 2026-06-11
+validated_links: 2026-06-11
+---
+
+**Status**: Trial (GA since CC v2.1.154; paid plans + API/Bedrock/Vertex/Foundry)
+
+## What It Is
+
+A **dynamic workflow** is a JavaScript script that orchestrates [subagents][cc-subagents] at scale — "Claude writes the script for the task you describe, and a runtime executes it in the background while your session stays responsive" ([workflows][cc-workflows]). The loop, branching, and intermediate results live in the script, so only the final answer returns to Claude's context. Built for codebase-wide audits, large (500-file) migrations, and cross-checked research.
+
+Surfaced as the feature-gated `WorkflowTool` (`WORKFLOW_SCRIPTS` flag) in [CC-tools-inventory.md](../configuration/CC-tools-inventory.md); this doc is the first-party-documented analysis of that tool.
+
+**Availability**: CC **v2.1.154+**, all paid plans, plus Anthropic API, Bedrock, Vertex AI, and Foundry. On Pro, enable via the *Dynamic workflows* row in `/config` ([workflows][cc-workflows]).
+
+## When to Use vs Subagents / Skills / Agent Teams
+
+The dividing line is **who holds the plan** ([workflows][cc-workflows]):
+
+| | Subagents | Skills | Agent teams | Workflows |
+|---|---|---|---|---|
+| What it is | A worker Claude spawns | Instructions Claude follows | A lead agent supervising peers | A script the runtime executes |
+| Who decides next | Claude, turn by turn | Claude, per prompt | The lead agent | The script |
+| Intermediate results | Context window | Context window | Shared task list | Script variables |
+| Scale | A few per turn | Same | A handful of peers | Dozens–hundreds per run |
+| Interruption | Restarts turn | Restarts turn | Teammates keep running | Resumable in session |
+
+Moving the plan into code also lets a workflow apply a repeatable **quality pattern** — e.g. independent agents adversarially reviewing each other's findings before they are reported.
+
+## The Workflow Tool & Script API
+
+Invoke a saved workflow as `Workflow({ scriptPath, args })`, or have Claude author one for a task. The runtime provides these script primitives ([workflows][cc-workflows]):
+
+- `agent()` — spawn a subagent (optionally structured-output / model / worktree)
+- `parallel()` — barrier: run thunks concurrently, await all
+- `pipeline()` — run items through stages with no barrier between stages
+- `phase()`, `log()` — progress grouping and narration
+- `budget` — the run's token target
+- `meta` export — name / description / phases (required script header)
+
+**Saving & args**: `/workflows` → `s` saves a run's script to `.claude/workflows/` (project, shared) or `~/.claude/workflows/` (personal); project beats personal on a name clash. Saved workflows run as `/<name>`. Input is passed via the `args` parameter and read inside the script as the `args` global (structured data, not a string).
+
+**Execution model**: the runtime runs the script in an isolated environment; intermediate results stay in script variables; the script is written to a file under `~/.claude/projects/` (readable/editable). Runs are **resumable within the same session** (completed agents return cached results); exiting CC restarts a running workflow fresh next session.
+
+**Limits** ([workflows][cc-workflows]): no mid-run user input (only agent permission prompts pause it); no direct filesystem/shell from the script itself (agents do that); **up to 16 concurrent agents**; **1,000 agents total per run**. Spawned subagents always run in `acceptEdits` and inherit the tool allowlist regardless of session mode.
+
+## Ultracode (effort setting)
+
+`ultracode` is "a Claude Code setting rather than a model effort level: it sends `xhigh` to the model and additionally has Claude orchestrate dynamic workflows for substantive tasks" ([model config — effort][cc-effort]). Set with `/effort ultracode`; **session-only** (resets on a new session — `/effort high` to drop back). With it on, "a single request can turn into several workflows in a row: one to understand the code, one to make the change, and one to verify it" ([workflows][cc-workflows]).
+
+It is **not** part of `effortLevel` in settings.json, the `--effort` flag, or `CLAUDE_CODE_EFFORT_LEVEL`; it can be passed as `"ultracode": true` via `--settings` or an Agent SDK control request ([model config — effort][cc-effort]). Requires a model that supports `xhigh` (Fable 5, Opus 4.8/4.7).
+
+**Keyword trigger** (single task, without changing session effort): include `ultracode` in a prompt — or just ask "use a workflow". Before v2.1.160 the literal keyword was `workflow`. Disable via *Ultracode keyword trigger* in `/config`. Distinct from `ultrathink` (one-off deeper reasoning — no workflow, no effort change).
+
+## Bundled Workflow: /deep-research
+
+The one built-in workflow Claude Code ships ([workflows][cc-workflows]):
+
+> `/deep-research <question>` — Fans out web searches on a question across several angles, fetches and cross-checks the sources it finds, votes on each claim, and returns a cited report with claims that didn't survive cross-checking filtered out. Requires the [WebSearch tool][cc-tools-ref] to be available.
+
+**Workflow vs harness**: `/deep-research` is the **only** bundled workflow Claude Code currently ships, and it is a *workflow* — not a skill. "Harness" describes its *pattern* (fan-out → cross-check → vote → synthesize), not its mechanism; the mechanism is a dynamic workflow. A project may also define a same-named custom `deep-research` **skill** that labels itself a "harness" and mirrors the behavior, but the first-party artifact is the bundled workflow.
+
+## Disabling
+
+Workflows run in the CLI, Desktop, IDE extensions, headless (`claude -p`), and the [Agent SDK][cc-agent-sdk]. Disable via *Dynamic workflows* off in `/config`, `"disableWorkflows": true` in settings, or `CLAUDE_CODE_DISABLE_WORKFLOWS=1`. When disabled, bundled workflow commands are unavailable, the `ultracode` keyword stops triggering, and `ultracode` is removed from the `/effort` menu ([workflows][cc-workflows]).
+
+## Relevance to this repo
+
+- **Doc audits at scale** — a workflow could fan the `enforcing-doc-hierarchy` audit across all of `docs/` in one resumable run instead of turn-by-turn (Fork-Join ≈ `parallel()`, Context-Isolated Subagents ≈ `agent()` — see [CC-agentic-harness-patterns-analysis.md](CC-agentic-harness-patterns-analysis.md)).
+- **Cross-checked research** — `/deep-research` is the canonical fan-out → verify → synthesize pattern this research catalog depends on.
+- **Cost discipline** — a run can spend meaningfully more tokens than a conversation; the docs advise scoping to one directory / narrow question first and watching `/workflows` token totals.
+
+## Cross-References
+
+- [CC-tools-inventory.md](../configuration/CC-tools-inventory.md) — `WorkflowTool` / `WORKFLOW_SCRIPTS` feature gate (leak-derived name)
+- [CC-agentic-harness-patterns-analysis.md](CC-agentic-harness-patterns-analysis.md) — harness patterns that map to `parallel()` / `agent()`
+- [CC-agent-teams-orchestration.md](CC-agent-teams-orchestration.md) — the agent-teams alternative (a lead agent holds the plan)
+- [CC-plans-as-skill-rule-templates.md](CC-plans-as-skill-rule-templates.md) — UltraPlan (cloud planning), a separate "ultra" feature
+- [CC-skills-adoption-analysis.md](CC-skills-adoption-analysis.md) — skills, the lighter alternative
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [Dynamic workflows][cc-workflows] | Workflow tool, script API, bundled /deep-research, ultracode triggers, limits, disabling |
+| [Model configuration — effort][cc-effort] | ultracode effort setting definition and constraints |
+| [Subagents][cc-subagents] | The worker primitive workflows orchestrate |
+| [Run agents in parallel][cc-agents] | Subagents vs skills vs teams vs workflows |
+| [Agent SDK overview][cc-agent-sdk] | Workflows on the SDK surface |
+| [Tools reference — WebSearch][cc-tools-ref] | `/deep-research` dependency |
+
+[cc-workflows]: https://code.claude.com/docs/en/workflows
+[cc-effort]: https://code.claude.com/docs/en/model-config#adjust-effort-level
+[cc-subagents]: https://code.claude.com/docs/en/sub-agents
+[cc-agents]: https://code.claude.com/docs/en/agents
+[cc-agent-sdk]: https://code.claude.com/docs/en/agent-sdk/overview
+[cc-tools-ref]: https://code.claude.com/docs/en/tools-reference#websearch-tool-behavior

--- a/docs/cc-native/agents-skills/README.md
+++ b/docs/cc-native/agents-skills/README.md
@@ -11,3 +11,4 @@ CC agent teams, recursive spawning, skills system, and autonomous loop patterns.
 | [CC-ralph-enhancement-research.md](CC-ralph-enhancement-research.md) | Ralph autonomous loop enhancement research |
 | [CC-cli-anything-analysis.md](CC-cli-anything-analysis.md) | CC CLI invocation patterns and capabilities |
 | [CC-agentic-harness-patterns-analysis.md](CC-agentic-harness-patterns-analysis.md) | 12 agentic harness patterns (Bilgin Ibryam): memory, orchestration, tools, automation |
+| [CC-dynamic-workflows-analysis.md](CC-dynamic-workflows-analysis.md) | Dynamic workflow orchestration tool + script API, ultracode effort, bundled /deep-research |

--- a/docs/cc-native/configuration/CC-tools-inventory.md
+++ b/docs/cc-native/configuration/CC-tools-inventory.md
@@ -219,7 +219,7 @@ The following tools appear in the `@anthropic-ai/claude-code@2.1.88` npm sourcem
 | `TeamCreateTool` | Create agent team | `tengu_amber_flint` |
 | `TeamDeleteTool` | Delete agent team | `tengu_amber_flint` |
 | `MonitorTool` | Monitor MCP servers | — |
-| `WorkflowTool` | Execute workflow scripts | `WORKFLOW_SCRIPTS` |
+| `WorkflowTool` | Execute workflow scripts ([analysis](../agents-skills/CC-dynamic-workflows-analysis.md)) | `WORKFLOW_SCRIPTS` |
 | `SleepTool` | Async delays | — |
 | `SnipTool` | History snippet extraction | `HISTORY_SNIP` |
 | `McpAuthTool` | MCP server authentication | — |


### PR DESCRIPTION
## Summary

Documents three previously-undocumented Claude Code orchestration features in `cc-native/`, all backed by **first-party** `code.claude.com` docs (your 1p requirement). Prior coverage was just the `WorkflowTool` *name* in `CC-tools-inventory.md`, so this is a new dedicated doc per repo policy.

New `docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md`:
- **Dynamic workflows** — the Workflow tool (`Workflow({ scriptPath, args })`), the `agent()`/`parallel()`/`pipeline()`/`phase()`/`log()`/`budget`/`meta` script API, save locations, execution model, and limits (16 concurrent / 1,000 total agents). Requires CC **v2.1.154+**.
- **Ultracode** — `/effort ultracode` = `xhigh` reasoning + automatic workflow orchestration; session-only; not part of `effortLevel`/`--effort`/`CLAUDE_CODE_EFFORT_LEVEL`; the `ultracode` keyword trigger (was `workflow` pre-v2.1.160).
- **/deep-research** — the bundled workflow; clarifies it's the **only** bundled workflow and a **workflow (mechanism)**, not a harness (pattern) or skill.

Indexes: agents-skills README row added; `cc-native/README.md` doc count `6 → 8` (also corrects a pre-existing off-by-one); `WorkflowTool` row in `CC-tools-inventory.md` cross-linked to the new analysis.

## Sources (all 1p, verified)

- https://code.claude.com/docs/en/workflows — workflows, script API, bundled /deep-research, ultracode triggers, limits
- https://code.claude.com/docs/en/model-config#adjust-effort-level — ultracode effort definition + constraints

## Validation

- `markdownlint-cli2` — 0 errors.
- `lychee` — 51 OK, **0 errors**.

Also answers the side question: `firecrawl.dev` is already tracked (dedicated `CC-web-scraping-plugins-analysis.md`).

Generated with Claude <noreply@anthropic.com>