### PR TITLE
docs: document /workflows command + re-stamp two session frontmatters

### DIFF
--- a/docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md
+++ b/docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md
@@ -64,6 +64,25 @@ The one built-in workflow Claude Code ships ([bundled workflows][cc-bundled]):
 
 **Workflow vs harness**: `/deep-research` is the **only** bundled workflow Claude Code currently ships, and it is a *workflow* — not a skill. "Harness" describes its *pattern* (fan-out → cross-check → vote → synthesize), not its mechanism; the mechanism is a dynamic workflow. A project may also define a same-named custom `deep-research` **skill** that labels itself a "harness" and mirrors the behavior, but the first-party artifact is the bundled workflow.
 
+## Managing Runs (`/workflows`)
+
+Runs execute in the background, so the session stays responsive. Run `/workflows` to **list running and completed runs** and open a progress view showing each phase with its agent count, token total, and elapsed time; a one-line summary also appears in the task panel below the input box ([watch the run][cc-watch]).
+
+Progress-view controls ([watch the run][cc-watch]):
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Select a phase or agent |
+| `Enter` / `→` | Drill into a phase, then an agent (its prompt, recent tool calls, result) |
+| `Esc` | Back out one level |
+| `j` / `k` | Scroll within the agent detail |
+| `p` | Pause or resume the run |
+| `x` | Stop the selected agent, or the whole workflow |
+| `r` | Restart the selected running agent |
+| `s` | Save the run's script as a `/<name>` command |
+
+**Resume** is **same-session only**: a paused or stopped run resumes with completed agents returning cached results and the rest running live (select it and press `p`, or ask Claude to relaunch). Exiting Claude Code restarts a running workflow fresh in the next session ([manage runs][cc-manage]).
+
 ## Disabling
 
 Workflows run in the CLI, Desktop, IDE extensions, headless (`claude -p`), and the [Agent SDK][cc-agent-sdk]. Disable via *Dynamic workflows* off in `/config`, `"disableWorkflows": true` in settings, or `CLAUDE_CODE_DISABLE_WORKFLOWS=1`. When disabled, bundled workflow commands are unavailable, the `ultracode` keyword stops triggering, and `ultracode` is removed from the `/effort` menu ([workflows][cc-workflows]).
@@ -88,6 +107,8 @@ Workflows run in the CLI, Desktop, IDE extensions, headless (`claude -p`), and t
 |---|---|
 | [Dynamic workflows][cc-workflows] | Workflow tool, script API, ultracode triggers, limits, disabling |
 | [Bundled workflows][cc-bundled] | The `/deep-research` table + walkthrough |
+| [Watch the run][cc-watch] | `/workflows` progress view + key controls |
+| [Manage runs][cc-manage] | Resume / pause / stop after launch |
 | [Model configuration — effort][cc-effort] | ultracode effort setting definition and constraints |
 | [Subagents][cc-subagents] | The worker primitive workflows orchestrate |
 | [Run agents in parallel][cc-agents] | Subagents vs skills vs teams vs workflows |
@@ -96,6 +117,8 @@ Workflows run in the CLI, Desktop, IDE extensions, headless (`claude -p`), and t
 
 [cc-workflows]: https://code.claude.com/docs/en/workflows
 [cc-bundled]: https://code.claude.com/docs/en/workflows#bundled-workflows
+[cc-watch]: https://code.claude.com/docs/en/workflows#watch-the-run
+[cc-manage]: https://code.claude.com/docs/en/workflows#manage-runs
 [cc-effort]: https://code.claude.com/docs/en/model-config#adjust-effort-level
 [cc-subagents]: https://code.claude.com/docs/en/sub-agents
 [cc-agents]: https://code.claude.com/docs/en/agents

--- a/docs/cc-native/ci-remote/CC-github-actions-analysis.md
+++ b/docs/cc-native/ci-remote/CC-github-actions-analysis.md
@@ -3,8 +3,8 @@ title: CC GitHub Actions — claude-code-action & Claude GitHub App
 source: https://code.claude.com/docs/en/github-actions, https://github.com/apps/claude, https://github.com/anthropics/claude-code-action/blob/main/action.yml, https://github.com/anthropics/claude-code-action/discussions/578, https://code.claude.com/docs/en/amazon-bedrock, https://code.claude.com/docs/en/google-vertex-ai, https://code.claude.com/docs/en/microsoft-foundry, https://dev.to/myougatheaxo/automate-your-entire-pr-workflow-with-claude-code-description-review-tests-1i41
 purpose: Evaluate Claude Code GitHub Actions for PR automation, code review, issue triage, and scheduled workflows — setup, capabilities, limitations, and cost.
 created: 2026-03-12
-updated: 2026-05-25
-validated_links: 2026-05-25
+updated: 2026-06-11
+validated_links: 2026-06-11
 ---
 
 **Status**: Research (informational — not implementation requirements)

--- a/docs/cc-native/configuration/CC-tools-inventory.md
+++ b/docs/cc-native/configuration/CC-tools-inventory.md
@@ -2,8 +2,8 @@
 title: CC Tools Inventory
 purpose: Point-in-time snapshot of all CC built-in tools, slash commands, and configuration surfaces with permission requirements and categories.
 created: 2026-03-27
-updated: 2026-04-13
-validated_links: 2026-04-13
+updated: 2026-06-11
+validated_links: 2026-06-11
 ---
 
 **Status**: Adopt


### PR DESCRIPTION
## Summary

Two commits:

1. **`docs(agents-skills)`** — adds a **"Managing Runs (`/workflows`)"** section to `CC-dynamic-workflows-analysis.md`. The `/workflows` command was previously only *mentioned* (for saving a run + watching token totals) but never documented. Now covers: listing running/completed runs, the progress view, the key controls (`↑/↓`, `Enter/→`, `Esc`, `j/k`, `p` pause/resume, `x` stop, `r` restart, `s` save), and same-session resume semantics. Backed by 1p `workflows#watch-the-run` / `#manage-runs`.
2. **`docs`** — re-stamps `updated`/`validated_links` to `2026-06-11` on two docs edited earlier this session without a re-stamp: `CC-github-actions-analysis.md` (#221 disambiguation note added a `copilot-cli` URL) and `CC-tools-inventory.md` (#226 WorkflowTool cross-ref).

## Validation

- `markdownlint-cli2` — 0 errors (all 3 files).
- `lychee` — 0 errors on the workflows doc.

Generated with Claude <noreply@anthropic.com>