### PR TITLE
docs: document the full /effort levels + fix stale xhigh-missing rows

### DIFF
--- a/docs/cc-native/configuration/CC-cli-reference.md
+++ b/docs/cc-native/configuration/CC-cli-reference.md
@@ -2,8 +2,8 @@
 title: CC CLI Reference
 purpose: Single canonical reference for all claude CLI flags, subcommands, and constraints. Other docs cross-ref here for flag definitions.
 created: 2026-04-13
-updated: 2026-04-13
-validated_links: 2026-04-13
+updated: 2026-06-11
+validated_links: 2026-06-11
 ---
 
 **Status**: Adopt
@@ -72,7 +72,7 @@ For env vars see [CC-env-vars-reference.md](CC-env-vars-reference.md). For tools
 | Flag | Description | Constraints | Source |
 |---|---|---|---|
 | `--model` | Model alias (`sonnet`, `opus`) or full ID | — | [model-config][model-config] |
-| `--effort` | Reasoning effort: `low`, `medium`, `high`, `max` (Opus 4.6 only) | Session-scoped, not persisted | [model-config][model-config] |
+| `--effort` | Reasoning effort: `low`, `medium`, `high`, `xhigh`, `max`, `auto` — support varies by model (see [Effort Levels](CC-model-provider-configuration.md#effort-levels)) | Session-scoped, not persisted | [model-config][model-config] |
 | `--fallback-model` | Auto-fallback model when primary is overloaded | `--print` only | [cli-ref][cli-ref] |
 | `--max-turns` | Limit agentic turns; exits with error when reached | `--print` only | [cli-ref][cli-ref] |
 | `--max-budget-usd` | Maximum dollar spend before stopping | `--print` only | [cli-ref][cli-ref] |

--- a/docs/cc-native/configuration/CC-env-vars-reference.md
+++ b/docs/cc-native/configuration/CC-env-vars-reference.md
@@ -2,8 +2,8 @@
 title: CC Environment Variables Reference
 purpose: Consolidated reference for CLAUDE_CODE_* and related env vars relevant to autonomous agent workflows, including undocumented vars from binary string extraction.
 created: 2026-03-27
-updated: 2026-04-24
-validated_links: 2026-04-24
+updated: 2026-06-11
+validated_links: 2026-06-11
 ---
 
 **Status**: Adopt
@@ -24,7 +24,7 @@ This doc covers vars observed in agent workflows. For the **complete authoritati
 |---|---|---|---|
 | `ANTHROPIC_MODEL` | `sonnet` | Primary model alias or full ID | [env-vars][env-vars] |
 | `CLAUDE_CODE_SUBAGENT_MODEL` | (inherits primary) | Model for Agent tool subagents and teammates | [env-vars][env-vars] |
-| `CLAUDE_CODE_EFFORT_LEVEL` | (unset) | Reasoning effort: `low`, `medium`, `high`, `max` (Opus 4.6 only), `auto` | [env-vars][env-vars] |
+| `CLAUDE_CODE_EFFORT_LEVEL` | (unset) | Reasoning effort: `low`, `medium`, `high`, `xhigh`, `max`, `auto` — support varies by model (see [Effort Levels](CC-model-provider-configuration.md#effort-levels)) | [env-vars][env-vars] |
 
 Cross-ref: [CC-model-provider-configuration.md](CC-model-provider-configuration.md)
 

--- a/docs/cc-native/configuration/CC-model-provider-configuration.md
+++ b/docs/cc-native/configuration/CC-model-provider-configuration.md
@@ -3,8 +3,8 @@ title: CC Model & Provider Configuration
 source: https://code.claude.com/docs/en/settings#environment-variables, https://openrouter.ai/docs/guides/coding-agents/claude-code-integration, https://ollama.com/blog/claude, https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models
 purpose: Reference for configuring CC with alternative models, endpoints, API keys, third-party providers (OpenRouter, Bedrock, Vertex, Foundry), local models (Ollama, llama.cpp, LM Studio), and LLM gateway proxies.
 created: 2026-03-07
-updated: 2026-06-10
-validated_links: 2026-06-10
+updated: 2026-06-11
+validated_links: 2026-06-11
 ---
 
 **Status**: Reference (actionable configuration guide)
@@ -22,6 +22,31 @@ validated_links: 2026-06-10
 | `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` | Disable adaptive reasoning | `1` |
 
 All variables can also be set in `settings.json` under the `env` key. ([source][cc-settings])
+
+### Effort Levels
+
+`CLAUDE_CODE_EFFORT_LEVEL` (above), the `/effort` command, the `--effort` flag, and per-skill/subagent `effort` frontmatter all select an **adaptive-reasoning effort level**. The levels available depend on the model ([source][cc-effort]):
+
+| Level | Models | Notes |
+|---|---|---|
+| `low` | all effort-capable | Short, scoped, latency-sensitive work |
+| `medium` | all effort-capable | Cost-sensitive work trading some intelligence |
+| `high` | all effort-capable | Balance — **default** on Fable 5, Opus 4.8, Opus 4.6, Sonnet 4.6 |
+| `xhigh` | Fable 5, Opus 4.8, Opus 4.7 | Deeper reasoning, higher spend — **default** on Opus 4.7 |
+| `max` | all effort-capable | Deepest reasoning, no token cap; can overthink |
+
+Opus 4.6 and Sonnet 4.6 support `low`/`medium`/`high`/`max` (no `xhigh`). Setting an unsupported level falls back to the highest the model supports (e.g. `xhigh` runs as `high` on Opus 4.6).
+
+**Precedence & persistence** ([source][cc-effort]):
+
+- Precedence: `CLAUDE_CODE_EFFORT_LEVEL` > configured level (`effortLevel` / `/effort`) > model default. Skill/subagent `effort` frontmatter overrides the session level while active (but not the env var).
+- `low`/`medium`/`high`/`xhigh` **persist** across sessions; `max` is **session-only** (except via `CLAUDE_CODE_EFFORT_LEVEL`). `effortLevel` in `settings.json` accepts only `low`/`medium`/`high`/`xhigh` — `max` and `ultracode` are not accepted there.
+- `/effort auto` (or `CLAUDE_CODE_EFFORT_LEVEL=auto`) resets to the model default.
+
+**Related, but not effort levels**:
+
+- **`ultracode`** — a session setting that sends `xhigh` *and* auto-orchestrates dynamic workflows; not part of `effortLevel`/`--effort`/`CLAUDE_CODE_EFFORT_LEVEL`. See [CC-dynamic-workflows-analysis.md](../agents-skills/CC-dynamic-workflows-analysis.md#ultracode-effort-setting).
+- **`ultrathink`** — include it anywhere in a prompt for one-off deeper reasoning on that turn; Claude Code adds an in-context instruction but the **effort level sent to the API is unchanged**. Phrases like "think", "think hard", and "think more" are *not* recognized keywords ([source][cc-ultrathink]).
 
 ### Claude Fable 5 (newest model)
 
@@ -300,6 +325,8 @@ When routing through gateways, additionally set ([source][cc-settings]):
 ## References
 
 - [CC Settings — Environment Variables][cc-settings]
+- [CC Model Configuration — Effort Levels][cc-effort]
+- [CC Model Configuration — ultrathink][cc-ultrathink]
 - [Anthropic — Introducing Claude Fable 5 & Mythos 5][fable5-intro]
 - [Anthropic — Models Overview][models-overview]
 - [Anthropic — Pricing][models-pricing]
@@ -314,6 +341,8 @@ When routing through gateways, additionally set ([source][cc-settings]):
 - [Local setup guide][local-setup]
 
 [cc-settings]: https://code.claude.com/docs/en/settings#environment-variables
+[cc-effort]: https://code.claude.com/docs/en/model-config#adjust-effort-level
+[cc-ultrathink]: https://code.claude.com/docs/en/model-config#use-ultrathink-for-one-off-deep-reasoning
 [openrouter]: https://openrouter.ai/docs/guides/coding-agents/claude-code-integration
 [ollama-claude]: https://ollama.com/blog/claude
 [llamacpp-anthropic]: https://huggingface.co/blog/ggml-org/anthropic-messages-api-in-llamacpp


### PR DESCRIPTION
## Summary

Answers "are all `/effort` levels documented?" — previously **no**: the scale was scattered and two rows were stale. This adds a complete, 1p-backed treatment.

- **New "Effort Levels" section** in `CC-model-provider-configuration.md` (the authoritative home): full `low`/`medium`/`high`/`xhigh`/`max` table with **per-model support** and **defaults** (`high` default; `xhigh` default on Opus 4.7; `xhigh` only on Fable 5 / Opus 4.8 / Opus 4.7), precedence + persistence rules, and the related `ultracode` (session setting) and `ultrathink` (one-off keyword) — each cross-linked/cited.
- **Fix stale rows**: `CC-cli-reference.md` `--effort` and `CC-env-vars-reference.md` `CLAUDE_CODE_EFFORT_LEVEL` both omitted `xhigh` and carried an "Opus 4.6 only" note — corrected and pointed at the new section.
- **1p sourcing**: `code.claude.com/docs/en/model-config#adjust-effort-level` and `#use-ultrathink-for-one-off-deep-reasoning`. Frontmatter re-stamped on all three.

## Validation

- `markdownlint-cli2` — 0 errors.
- `lychee` — 0 errors (94 OK; cross-file `#effort-levels` / `#ultracode-effort-setting` anchors validated).

Generated with Claude <noreply@anthropic.com>