### PR TITLE
docs(graphify): on-demand knowledge graph — docs, make recipes, gh-pages publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ Thumbs.db
 # Python artifacts
 __pycache__/
 *.pyc
+
+# graphify knowledge graph — generated, regenerable; published to the gh-pages
+# branch (https://qte77.github.io/ai-agents-research/), never tracked on main.
+graphify-out/

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ endif
 .PHONY: \
 	setup_node setup_lychee setup_mdlint setup_actionlint setup_skills setup_all \
 	check_links check_docs check_actions autofix lint \
+	graph-build graph-html graph-query graph-explain graph-path graph-publish \
 	help
 .DEFAULT_GOAL := help
 
@@ -21,6 +22,15 @@ ACTIONLINT_VERSION ?= 1.7.12
 NODE_DIR           := $(HOME)/.local/share/node
 NODE_BIN           := $(NODE_DIR)/bin
 LOCAL_BIN          := $(HOME)/.local/bin
+
+# graphify knowledge graph — https://qte77.github.io/ai-agents-research/
+# GRAPHIFY: binary (override for a side-loaded build, e.g.
+#   GRAPHIFY=/workspaces/external/graphify/.venv/bin/graphify)
+# GRAPHIFY_BACKEND: LLM backend for headless `make graph-build` (needs its API key)
+# PYTHON: interpreter for the stdlib-only publish helper (no deps, so no uv needed)
+GRAPHIFY           ?= graphify
+GRAPHIFY_BACKEND   ?= gemini
+PYTHON             ?= python3
 
 # -- OS / arch detection --
 UNAME_S := $(shell uname -s)
@@ -230,6 +240,37 @@ check_actions: ## Lint GitHub Actions workflows + composite actions
 	actionlint -color
 
 lint: check_links check_docs check_actions ## Run all linters (links + markdown + actions)
+
+
+# MARK: GRAPH
+
+
+# Query/navigate ops are free (no LLM). Building needs an extraction model: the
+# /graphify skill (key-free, uses the Claude Code session) or `graphify extract`
+# with an API key. Config (GRAPHIFY / GRAPHIFY_BACKEND / PYTHON) is at the top.
+
+graph-build: ## Headless full rebuild (AST + semantic) — needs an LLM backend API key
+	$(GRAPHIFY) extract . --backend $(GRAPHIFY_BACKEND)
+	$(GRAPHIFY) label . --backend $(GRAPHIFY_BACKEND)
+
+graph-html: ## Re-render graphify-out/graph.html from graph.json (no LLM)
+	if [ ! -f graphify-out/graph.json ]; then echo "no graph.json — build first (/graphify skill or make graph-build)"; exit 1; fi
+	$(GRAPHIFY) export html
+
+graph-query: ## Query the graph: make graph-query Q="how does X work?"
+	if [ -z "$(Q)" ]; then echo 'Usage: make graph-query Q="<question>"'; exit 2; fi
+	$(GRAPHIFY) query "$(Q)"
+
+graph-explain: ## Explain a node + neighbors: make graph-explain N="Node Label"
+	if [ -z "$(N)" ]; then echo 'Usage: make graph-explain N="<node>"'; exit 2; fi
+	$(GRAPHIFY) explain "$(N)"
+
+graph-path: ## Shortest path between nodes: make graph-path A="Node A" B="Node B"
+	if [ -z "$(A)" ] || [ -z "$(B)" ]; then echo 'Usage: make graph-path A="<node>" B="<node>"'; exit 2; fi
+	$(GRAPHIFY) path "$(A)" "$(B)"
+
+graph-publish: ## Push graphify-out/graph.html to the gh-pages branch (refresh the live page)
+	$(PYTHON) scripts/graphify-publish-pages.py
 
 
 # MARK: HELP

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,6 +97,28 @@ Three lint jobs run on every PR touching docs, workflows, or actions:
 
 The rxiv triage job additionally runs `markdownlint-cli2` against the assembled would-be PR content (with the action's H1 prepend simulated) and fails the job before opening a triage PR if the output is md-dirty.
 
+## Knowledge Graph (graphify)
+
+An optional graphify knowledge graph maps the corpus — concepts, cross-document references, and community structure — for navigation and gap-finding. It is **on-demand only**: no hooks or `CLAUDE.md` mandates run it automatically (that per-tool-call overhead was deliberately removed), so it adds no cost to normal sessions. Build output (`graphify-out/`) is gitignored; the rendered graph is published to the `gh-pages` branch.
+
+**Live graph:** <https://qte77.github.io/ai-agents-research/> — refresh with `make graph-publish` after a rebuild.
+
+**Build** (semantic extraction needs an LLM):
+
+- Interactive, key-free — the `/graphify` Claude Code skill (uses the session as the extraction model).
+- Headless, for CI/scripts — `graphify extract . --backend gemini` (or `claude`, `openai`, …) with the matching API key, then `graphify label .` to name communities. Also exposed as `make graph-build`.
+
+**Navigate** (free, no LLM — operate on `graphify-out/graph.json`):
+
+| Action | Command |
+|---|---|
+| Query | `make graph-query Q="<question>"` |
+| Explain a node | `make graph-explain N="<node>"` |
+| Shortest path | `make graph-path A="<node>" B="<node>"` |
+| Re-render viz | `make graph-html` |
+
+`graphify` is side-loaded (not on `PATH`); set `GRAPHIFY=/path/to/graphify` to point the recipes at a specific build.
+
 ## Downstream Consumers
 
 Research from this repository feeds directly into implementation repos:

--- a/scripts/graphify-publish-pages.py
+++ b/scripts/graphify-publish-pages.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Publish graphify-out/graph.html to the gh-pages branch as index.html.
+
+Idempotent: updates the existing gh-pages branch (creates it if missing). Uses
+the GitHub API only — it never touches the local git tree, so it is safe to run
+with uncommitted work on main. Requires the `gh` CLI authenticated for the repo.
+
+Run from the repo root, or via `make graph-publish`.
+"""
+import base64
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = os.environ.get("GRAPHIFY_PAGES_REPO", "qte77/ai-agents-research")
+HTML = Path("graphify-out/graph.html")
+
+if not HTML.exists():
+    sys.exit("graphify-out/graph.html not found — run `make graph-html` (or build) first")
+
+# Invalid GH_TOKEN/GITHUB_TOKEN env vars can shadow the stored gh credential.
+env = dict(os.environ)
+env.pop("GH_TOKEN", None)
+env.pop("GITHUB_TOKEN", None)
+
+
+def gh(method, path, body=None):
+    cmd = ["gh", "api", "--method", method, path]
+    inp = json.dumps(body) if body is not None else None
+    if body is not None:
+        cmd += ["--input", "-"]
+    r = subprocess.run(cmd, input=inp, capture_output=True, text=True, env=env)
+    if r.returncode != 0:
+        sys.exit(f"gh api {method} {path} failed:\n{r.stderr}\n{r.stdout}")
+    return json.loads(r.stdout) if r.stdout.strip() else {}
+
+
+# Current gh-pages head (used as the commit parent), if the branch exists.
+parent = None
+probe = subprocess.run(
+    ["gh", "api", f"repos/{REPO}/git/ref/heads/gh-pages"],
+    capture_output=True, text=True, env=env,
+)
+if probe.returncode == 0 and probe.stdout.strip():
+    parent = json.loads(probe.stdout)["object"]["sha"]
+
+index_blob = gh("POST", f"repos/{REPO}/git/blobs",
+                {"content": base64.b64encode(HTML.read_bytes()).decode(), "encoding": "base64"})
+nojekyll_blob = gh("POST", f"repos/{REPO}/git/blobs", {"content": "", "encoding": "utf-8"})
+tree = gh("POST", f"repos/{REPO}/git/trees", {"tree": [
+    {"path": "index.html", "mode": "100644", "type": "blob", "sha": index_blob["sha"]},
+    {"path": ".nojekyll", "mode": "100644", "type": "blob", "sha": nojekyll_blob["sha"]},
+]})
+commit = gh("POST", f"repos/{REPO}/git/commits", {
+    "message": "Refresh graphify knowledge graph (GitHub Pages)\n\nCo-Authored-By: Claude <noreply@anthropic.com>",
+    "tree": tree["sha"],
+    "parents": [parent] if parent else [],
+})
+if parent:
+    gh("PATCH", f"repos/{REPO}/git/refs/heads/gh-pages", {"sha": commit["sha"]})
+else:
+    gh("POST", f"repos/{REPO}/git/refs", {"ref": "refs/heads/gh-pages", "sha": commit["sha"]})
+
+print(f"Published graph.html ({HTML.stat().st_size:,} bytes) to gh-pages @ {commit['sha'][:12]}")
+print("Live: https://qte77.github.io/ai-agents-research/")


### PR DESCRIPTION
## Summary

Documentation and tooling for the optional graphify knowledge graph, now published at <https://qte77.github.io/ai-agents-research/>.

- **chore(gitignore):** ignore `graphify-out/` (regenerable; the rendered graph lives on the `gh-pages` branch, not `main`).
- **build(Makefile + scripts/):** `make graph-query|graph-explain|graph-path|graph-html` (free, no LLM), `make graph-build` (headless `graphify extract`), `make graph-publish` (refresh the live page via a stdlib-only GitHub-API helper). Config lives in the Makefile config block.
- **docs(architecture):** concise "Knowledge Graph (graphify)" section — on-demand only, build paths, navigation recipes.

## Context

The graph is **on-demand only** — earlier auto-wiring (PreToolUse hooks + `CLAUDE.md` blocks) was removed to avoid per-tool-call overhead. The live interactive graph is served from the `gh-pages` branch; `main` stays free of generated artifacts.

## Verification

- `markdownlint-cli2` on `docs/architecture.md`: 0 errors
- `lychee` on `docs/architecture.md`: 5/5 links OK
- `make graph-query` verified end-to-end against the built graph

Note: commits are unsigned (sandbox cannot sign); merging to `main` needs an owner `--admin` to satisfy `required_signatures` once CodeFactor + CodeQL are green.

Generated with Claude <noreply@anthropic.com>