### PR TITLE
docs: add AgentSeal + Understand Anything, cite CodeBurn optimize source

### DIFF
--- a/docs/cc-community/CC-ai-security-governance-analysis.md
+++ b/docs/cc-community/CC-ai-security-governance-analysis.md
@@ -2,7 +2,7 @@
 title: "AI Security & Governance Frameworks Analysis"
 purpose: Analysis of four AI security and governance frameworks (NIST AI RMF, EU AI Act, OWASP LLM Top 10, ISO 42001) applicable to multi-agent systems.
 created: 2026-03-01
-updated: 2026-04-23
+updated: 2026-06-11
 validated_links: 2026-04-23
 ---
 
@@ -357,6 +357,21 @@ ISO 42001 + 23894 (certifiable management system + risk methodology)
 | Agent hijacking | AML.T0056 | L7 Orchestration | MEASURE 2.6 | A.6.4 |
 | Evaluation bias | AML.T0043 | L2 Agent Logic | MEASURE 2.5 | A.7.4 |
 
+## Defensive Tooling
+
+The frameworks above model threats; [AgentSeal](https://github.com/getagentseal/agentseal) (getagentseal — same maker as the [CodeBurn](CC-community-tooling-landscape.md#codeburn-agentseal) token tracker) is a concrete open-source scanner that tests for several of them. `pip install agentseal` / `npm install agentseal`; no API key for local scans (~285 stars, Python + TypeScript).
+
+| Command | What it does | Maps to (this doc) |
+| --- | --- | --- |
+| `guard` | Offline scan of agent configs (skills, MCP) across 28+ agents for dangerous patterns | Supply chain — AML.T0040 / MAESTRO L6 |
+| `scan` | Tests system prompts against 225+ adversarial probes | Prompt injection / jailbreak — AML.T0051, AML.T0054 / MAESTRO L1 |
+| `scan-mcp` | Audits live MCP servers for tool-description poisoning | Agent hijacking / tool poisoning — AML.T0056 / MAESTRO L7 |
+| `shield` | Real-time file monitoring with threat alerts | Continuous monitoring — MAESTRO L4 |
+
+Backed by an MCP Security Registry (6,600+ indexed servers), semantic analysis (MiniLM-L6-v2 embeddings), and payload deobfuscation. It complements MAESTRO's prescriptive controls with an executable check: MAESTRO says *what* to defend; AgentSeal scans *whether* a given skill/MCP setup is exposed — operationalizing the Unified Mapping Table above.
+
+**Adoption caveat**: licensed FSL-1.1-Apache-2.0 (Functional Source License → Apache-2.0 after the change window) — source-available, not OSI-open at release. Review the license window before bundling it into permissively-licensed tooling.
+
 ## Recommendations for Agents-eval
 
 Given the project's open-source research context, full certification (ISO 42001)
@@ -383,3 +398,4 @@ is not warranted. A lightweight alignment approach:
 - [ISO/IEC 23894:2023](https://www.iso.org/standard/77304.html)
 - [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 - [12-Factor Agents](https://github.com/humanlayer/12-factor-agents)
+- [AgentSeal (getagentseal)](https://github.com/getagentseal/agentseal) — open-source scanner for agent skills/MCP configs (adversarial prompt probes, MCP poisoning audit)

--- a/docs/cc-community/CC-community-tooling-landscape.md
+++ b/docs/cc-community/CC-community-tooling-landscape.md
@@ -641,7 +641,7 @@ Per the [README][codeburn]: Claude Code, Claude Desktop, Codex, Cursor, cursor-a
 
 - **TUI dashboard** with gradient charts and responsive panels
 - **13 task categories** classified from tool patterns: Coding, Debugging, Feature Dev, Refactoring, Testing, Exploration, Planning, Delegation, Git Ops, Build/Deploy, Brainstorming, Conversation, General
-- **`codeburn optimize`** — surfaces waste patterns with copy-paste fixes
+- **[`codeburn optimize`](https://github.com/getagentseal/codeburn#optimize)** — surfaces nine waste patterns (files re-read across sessions, low Read:Edit ratio, unused MCP servers, ghost agents/skills/slash commands, bloated `CLAUDE.md`, wasted bash output, cache-creation overhead, context-heavy and low-worth sessions) with copy-paste token/$ fixes ranked into an A–F health grade
 - **`codeburn compare`** — side-by-side model performance metrics
 - **`codeburn report -p 30days`** — rolling-window analysis
 - **`codeburn export`** — CSV/JSON across multiple time periods

--- a/docs/cc-community/CC-repo-to-docs-tools-landscape.md
+++ b/docs/cc-community/CC-repo-to-docs-tools-landscape.md
@@ -1,11 +1,11 @@
 ---
 title: Repo-to-Docs AI Tools Landscape
-source: https://deepwiki.com, https://code2tutorial.com, https://gitsummarize.com
+source: https://deepwiki.com, https://code2tutorial.com, https://gitsummarize.com, https://github.com/egonex-ai/understand-anything
 purpose: Survey of AI-powered tools that generate documentation from GitHub repositories.
 category: landscape
 status: research
 created: 2026-04-06
-updated: 2026-04-09
+updated: 2026-06-11
 validated_links: 2026-04-06
 ---
 
@@ -16,6 +16,8 @@ validated_links: 2026-04-06
 Three tools represent an emerging category of **AI-powered repo-to-documentation generators**: DeepWiki (by Cognition/Devin) produces wiki-style reference docs with architecture diagrams, Code2Tutorial (by The-Pocket/PocketFlow) generates chapter-based educational tutorials, and GitSummarize (indie open-source) produces multi-level summaries via URL rewrite. All take a GitHub URL as input and produce structured natural-language documentation.
 
 **Relevance to agent workflows**: These tools can serve as context sources for coding agents -- pre-generated documentation reduces the need for expensive runtime codebase analysis. The repo-to-docs pattern also overlaps with the `llms.txt` standard and context engineering approaches documented in this repository.
+
+A fourth tool, **Understand Anything** (Egonex-AI, 57.4k stars), sits at the graph end of this space: it emits an interactive knowledge graph rather than prose -- the external analogue to this repo's own [graphify integration](../architecture.md#knowledge-graph-graphify).
 
 ## Comparison
 
@@ -68,6 +70,22 @@ python main.py --repo <github-url> --language English --max-abstractions 10
 
 Published examples: [FastAPI](https://the-pocket.github.io/PocketFlow-Tutorial-Codebase-Knowledge/), Flask, LangGraph, NumPy Core.
 
+## Understand Anything (Egonex-AI)
+
+**URL**: [github.com/egonex-ai/understand-anything](https://github.com/egonex-ai/understand-anything) | **Stars**: 57.4k | **License**: MIT | **Stack**: TypeScript (originally by Lum1104)
+
+Unlike the doc-*generators* in this landscape, Understand Anything emits an **interactive knowledge graph** -- files, functions, classes, and dependencies as color-coded, navigable nodes -- the external analogue to this repo's own [graphify integration](../architecture.md#knowledge-graph-graphify).
+
+Hybrid extraction: Tree-sitter for deterministic parsing (imports, definitions, call graphs) plus LLMs for semantic summaries and architecture classification, run through a **5-agent pipeline** (scanner -> analyzer -> architecture-mapper -> tour-builder -> reviewer) in parallel, with incremental updates.
+
+- **Structural + business-logic views** -- pan/zoom/search nodes; a domain view maps code to real processes
+- **Guided tours** -- auto-generated, dependency-ordered walkthroughs
+- **Diff impact analysis** -- which parts of the system a change touches
+- **Karpathy-pattern LLM-wiki support** -- entity extraction + relationship discovery over markdown KBs, directly overlapping this repo's three-layer architecture
+- **Version-controllable output** -- the graph is JSON; multi-platform (Claude Code, Cursor, VS Code Copilot, Codex, Gemini CLI)
+
+**Relevance**: it produces the same primitive graphify gives this repo (a queryable code/doc graph), but as an external multi-agent tool -- a useful benchmark for the graphify approach and its Karpathy-KB handling.
+
 ## GitSummarize
 
 **URL**: [gitsummarize.com](https://gitsummarize.com)
@@ -85,7 +103,7 @@ Three output levels: system architecture, directory-level summaries, file-level 
 
 ## Pattern Analysis
 
-All three tools share a common pipeline:
+All three doc-generators share a common pipeline:
 
 ```text
 GitHub URL --> Clone/Fetch --> AI Analysis --> Structured Output
@@ -120,9 +138,11 @@ Differentiation happens at the output stage:
 - [GitHub: The-Pocket/PocketFlow-Tutorial-Codebase-Knowledge](https://github.com/The-Pocket/PocketFlow-Tutorial-Codebase-Knowledge)
 - [gitsummarize.com](https://gitsummarize.com)
 - [GitHub: antarixxx/gitsummarize](https://github.com/antarixxx/gitsummarize)
+- [GitHub: egonex-ai/understand-anything](https://github.com/egonex-ai/understand-anything)
 
 ## Action Items
 
 - [ ] Evaluate DeepWiki output as pre-generated context for CC analysis workflows
 - [ ] Test Code2Tutorial on this repository for documentation generation
 - [ ] Monitor GitSummarize API for programmatic integration potential
+- [ ] Benchmark Understand Anything against the graphify integration (graph quality, Karpathy-KB handling, incremental updates)


### PR DESCRIPTION
## Summary

Three research additions, one per commit:

- **`docs(security)`** — `CC-ai-security-governance-analysis.md` gains a **Defensive Tooling** section for [AgentSeal](https://github.com/getagentseal/agentseal), mapping its `guard`/`scan`/`scan-mcp`/`shield` commands onto the doc's own threat IDs (AML.T0040/T0051/T0054/T0056, MAESTRO layers). It's the executable counterpart to the frameworks already analysed. Placed here (not the dev-tooling landscape) because topic cohesion beats shared-maker grouping. Notes the FSL-1.1-Apache-2.0 license caveat.
- **`docs(tooling)`** — the CodeBurn entry in `CC-community-tooling-landscape.md` now links the [`optimize` section](https://github.com/getagentseal/codeburn#optimize) (the actual source of its waste-pattern "rules") and enumerates all nine patterns + the A–F health grade.
- **`docs(repo-to-docs)`** — `CC-repo-to-docs-tools-landscape.md` gains [Understand Anything](https://github.com/egonex-ai/understand-anything) (Egonex-AI, 57.4k★, MIT) — a repo→interactive-knowledge-graph tool, cross-linked to this repo's graphify integration as its external analogue.

## Verification

- `markdownlint-cli2` on all three files: 0 errors
- `lychee` on all three files: 64 OK, 0 errors (4 redirect warnings only)

Note: unsigned sandbox commits → merging to `main` needs an owner `--admin` once CodeFactor + CodeQL are green. Does not touch `.claude/rules/` (separate tracking decision still pending).

Generated with Claude <noreply@anthropic.com>