### PR TITLE
docs(non-cc): add SearXNG, deepagents, and Autonomous Robots analyses

### DIFF
--- a/docs/non-cc/README.md
+++ b/docs/non-cc/README.md
@@ -26,6 +26,12 @@ Standalone analyses of coding agents and orchestration tools beyond Claude Code.
 |---|---|---|---|
 | [karpathy-llm-kb-analysis.md](karpathy-llm-kb-analysis.md) | Karpathy LLM Knowledge Base (markdown-first wiki) | Yes | Gist only |
 
+## Reference & Background
+
+| Document | Topic | Access |
+|---|---|---|
+| [intro-autonomous-robots-analysis.md](intro-autonomous-robots-analysis.md) | Introduction to Autonomous Robots (open textbook, MIT Press) | Open access |
+
 ## Context & Memory Infrastructure
 
 | Document | Type | Headless | Open Source |
@@ -38,6 +44,7 @@ Standalone analyses of coding agents and orchestration tools beyond Claude Code.
 |---|---|---|---|
 | [insforge-analysis.md](insforge-analysis.md) | InsForge (backend platform for agentic development) | Yes | Yes (Apache-2.0) |
 | [goclaw-analysis.md](goclaw-analysis.md) | GoClaw (multi-tenant agent gateway, Go, 7 channels) | Yes | Yes (CC BY-NC 4.0) |
+| [searxng-analysis.md](searxng-analysis.md) | SearXNG (self-hostable metasearch for agent web-search) | Yes | Yes (AGPL-3.0) |
 
 ## Frameworks
 
@@ -45,6 +52,7 @@ Standalone analyses of coding agents and orchestration tools beyond Claude Code.
 |---|---|---|---|
 | [simpleagents-analysis.md](simpleagents-analysis.md) | CraftsMan-Labs/SimpleAgents (Rust LLM SDK) | Yes | Yes (Apache-2.0) |
 | [autoagent-analysis.md](autoagent-analysis.md) | HKUDS/AutoAgent (zero-code agent OS) | Yes | Yes (MIT) |
+| [deepagents-analysis.md](deepagents-analysis.md) | langchain-ai/deepagents (deep-agents: planning + subagents + virtual FS, on LangGraph) | Yes | Yes (MIT) |
 
 ## Protocols & Interfaces
 

--- a/docs/non-cc/deepagents-analysis.md
+++ b/docs/non-cc/deepagents-analysis.md
@@ -1,0 +1,73 @@
+---
+title: deepagents Analysis
+source: https://github.com/langchain-ai/deepagents
+purpose: Architecture analysis of deepagents — LangChain's batteries-included harness for long-horizon agents with planning, sub-agent delegation, and a virtual filesystem, built on LangGraph.
+created: 2026-06-13
+updated: 2026-06-13
+validated_links: 2026-06-13
+---
+
+**Status**: Assess
+
+## What It Is
+
+`deepagents` is LangChain's opinionated, production-ready harness for building long-horizon "deep" agents — agents that plan, delegate work to sub-agents, manage files, and maintain context across extended task runs, all on a LangGraph runtime ([repo][repo]).
+
+- **License**: MIT
+- **Package**: `deepagents` ([PyPI][pypi])
+- **Version**: 0.6.10
+- **Stars**: 24.6k
+
+## Key Concepts
+
+| Pillar | What it provides |
+|---|---|
+| **LangGraph foundation** | Underlying graph runtime — streaming, persistence, and checkpointing |
+| **Sub-agent delegation** | Spawn isolated sub-agents with their own context windows for parallel or sequential work |
+| **Virtual filesystem** | Read / write / edit across pluggable backends (local, sandboxed, or remote) |
+| **Planning (todo list)** | Built-in task decomposition: the agent maintains and works through a dynamic todo list |
+| **Context management** | Thread summarisation and tool-output archiving to handle long conversations |
+| **Shell access** | Execute commands in a sandboxed environment |
+| **Persistent memory** | Cross-session recall via pluggable memory backends |
+| **Human-in-the-loop** | Review and approve tool calls before execution |
+| **Skills** | Loadable, reusable agent behaviours |
+| **LangSmith integration** | Built-in tracing and evaluation for production deployment |
+
+The public entry point is `create_deep_agent`, which returns a compiled LangGraph agent (the `model` argument is optional and defaults to a Claude model):
+
+```python
+from deepagents import create_deep_agent
+
+agent = create_deep_agent(
+    tools=[my_custom_tool],
+    system_prompt="You are a research assistant.",
+)
+result = agent.invoke({"messages": "Research LangGraph and write a summary"})
+```
+
+## Positioning
+
+| Dimension | deepagents | Plain LangGraph | AutoAgent ([analysis][autoagent]) | simpleagents ([analysis][simpleagents]) |
+|---|---|---|---|---|
+| Abstraction level | High — opinionated defaults | Low — graph primitives only | High — zero-code NL interface | SDK / infrastructure layer |
+| Sub-agent delegation | Yes (built-in) | Manual wiring | Yes (workflow editor) | Planned (issue #25) |
+| Virtual filesystem | Yes (pluggable backends) | No | Self-managing FS | No |
+| Planning | Todo-list tool | No | Self-play customisation | No |
+| Language | Python | Python | Python | Rust + polyglot bindings |
+| Model agnostic | Yes (any tool-calling LLM) | Yes | Via LiteLLM | Yes (OpenAI, Anthropic, OpenRouter) |
+| Production runtime | LangGraph + LangSmith | LangGraph | Docker sandbox | gRPC workers |
+
+### What deepagents adds over plain LangGraph
+
+LangGraph provides the graph execution primitive. `deepagents` layers opinionated defaults on top: a tuned system prompt for long-horizon work, a planning tool, a virtual filesystem, sub-agent spawning, context summarisation, shell execution, and memory — so teams do not need to wire each capability individually.
+
+### Where it sits in the ecosystem
+
+Among agent frameworks that target long-horizon tasks, deepagents is the closest to a "production harness with batteries included." It is narrower than AutoAgent (which is NL-driven and self-modifying) but deeper than plain LangGraph (which is a runtime only). The simpleagents framework targets a different niche (Rust-first SDK with polyglot bindings) and does not overlap in philosophy.
+
+## Sources
+
+[repo]: https://github.com/langchain-ai/deepagents
+[pypi]: https://pypi.org/project/deepagents/
+[autoagent]: autoagent-analysis.md
+[simpleagents]: simpleagents-analysis.md

--- a/docs/non-cc/intro-autonomous-robots-analysis.md
+++ b/docs/non-cc/intro-autonomous-robots-analysis.md
@@ -1,0 +1,70 @@
+---
+title: "Introduction to Autonomous Robots (Open Textbook)"
+purpose: Background reading on embodied autonomous agents — mechanics, sensing, planning, and coordination
+created: 2026-06-13
+updated: 2026-06-13
+validated_links: 2026-06-13
+---
+
+**Status**: Assess
+
+## What It Is
+
+*Introduction to Autonomous Robots: Mechanisms, Sensors, Actuators, and Algorithms* is a university-level open textbook by Nikolaus Correll, Bradley Hayes, Christoffer Heckman, and Alessandro Roncone (all at the University of Colorado Boulder). Published by MIT Press (1st ed., 2022; ISBN 9780262047555), it covers the computational foundations of mobile and manipulating robots — from kinematics and sensing to path planning, SLAM, and multi-robot coordination.
+
+The LaTeX source is hosted on GitHub under a Creative Commons CC-BY-NC-ND 4.0 licence, permitting non-commercial use with attribution. MIT Press holds copyright over the compiled print edition; no ready-made PDF is distributed online, but readers can compile one from source via LaTeX or Overleaf. The book is also available for purchase on Amazon.
+
+| Detail | Value |
+|---|---|
+| Authors | Correll, Hayes, Heckman, Roncone |
+| Publisher | MIT Press, Cambridge MA |
+| Edition / year | 1st, 2022 |
+| ISBN | 9780262047555 |
+| Source licence | CC-BY-NC-ND 4.0 |
+| LaTeX source | [GitHub repo][gh-repo] |
+| Project site | [introduction-to-autonomous-robots.github.io][web-book] |
+
+## Scope / Contents
+
+Chapters are inferred from the LaTeX source tree (`chapters/` directory in the GitHub repo):
+
+| Area | Chapters / topics |
+|---|---|
+| **Foundations** | Linear algebra, statistics, trigonometry, coordinate systems |
+| **Kinematics** | Forward, inverse, and differential kinematics; forces |
+| **Locomotion & manipulation** | Locomotion, grasping, manipulation |
+| **Sensing & perception** | Sensors, vision, features |
+| **Probabilistic methods** | Error propagation, localization, mapping, SLAM |
+| **Planning** | Path planning, task execution |
+| **Learning** | Backpropagation, deep learning |
+| **Multi-robot** | Swarm and coordination (implicit in task-execution and planning chapters) |
+
+The book is accompanied by MATLAB and Mathematica (Wolfram Language) worked examples and homework sets.
+
+## Relevance to ai-agents-research
+
+This is **adjacent / background reading**, not a tool or framework. The connection is conceptual: autonomous robots are physical embodiments of the same agent loop (perceive → reason → act → observe) that software agents implement in code.
+
+**What transfers:**
+
+- Planning under uncertainty (probabilistic localization, SLAM) is a well-studied analogue for software agents reasoning over partial information.
+- Sensing-to-action loops and error propagation give rigorous mathematical grounding to feedback cycles that software-agent designers treat informally.
+- Multi-robot coordination literature (task allocation, decentralised control) is a direct predecessor to multi-agent orchestration patterns.
+
+**What does not transfer:**
+
+- Kinematics, actuator physics, locomotion, and grasping are hardware-specific and have no software-agent equivalent.
+- SLAM and vision chapters assume physical sensors and spatial environments; LLM coding agents have no spatial grounding.
+- The book predates LLM-based agents entirely; it does not address prompt engineering, tool use, or language-model reasoning.
+
+**Verdict:** Useful as a conceptual reference for researchers bridging the robotics and software-agent traditions, or when designing multi-agent coordination schemes that benefit from formal treatment. Not applicable to day-to-day Claude Code or LLM-agent implementation work.
+
+## Sources
+
+| Source | Notes |
+|---|---|
+| [GitHub repo — Introduction-to-Autonomous-Robots][gh-repo] | LaTeX source, licence text, README with citation, chapter file list |
+| [Project website — introduction-to-autonomous-robots.github.io][web-book] | Author list, publisher, edition, licensing statement |
+
+[gh-repo]: https://github.com/Introduction-to-Autonomous-Robots/Introduction-to-Autonomous-Robots
+[web-book]: https://introduction-to-autonomous-robots.github.io/

--- a/docs/non-cc/searxng-analysis.md
+++ b/docs/non-cc/searxng-analysis.md
@@ -1,0 +1,45 @@
+---
+title: SearXNG Analysis
+source: https://github.com/searxng/searxng
+purpose: Analysis of SearXNG as a self-hostable privacy-respecting metasearch engine usable as a web-search backend for AI agent and deep-research workflows.
+created: 2026-06-13
+updated: 2026-06-13
+validated_links: 2026-06-13
+---
+
+**Status**: Assess
+
+## What It Is
+
+SearXNG is a free, self-hostable metasearch engine that aggregates results from up to 268 search services — including Google, Bing, DuckDuckGo, Brave, and Startpage — without tracking or profiling users ([repo][repo]).
+
+- **License**: AGPL-3.0
+- **Language**: Python (81.5%)
+- **Stars**: 32,000
+
+## How It Works
+
+SearXNG fans out each query to a configurable set of search engines in parallel, merges and deduplicates the results, and returns them through a single uniform API. The engine list and weights are declared in `settings.yml`; no engine-specific credentials are required for the default set.
+
+**JSON API.** Operators enable the JSON output format in `settings.yml`. Clients then query either `GET /` or `GET /search` with `?q=<query>&format=json`. Optional parameters include `categories`, `engines`, `language`, `pageno`, `time_range`, and `safesearch`. The response contains a flat list of result objects (url, title, content, engine, score). No authentication token is required — the instance is the access boundary. The full parameter set is documented in the [search API reference][api].
+
+**Self-hosting.** The canonical deployment path is Docker Compose using the image from the project's container directory. NGINX or Apache sit in front as the TLS terminator. For tighter integration, Granian (an ASGI server) or uWSGI are documented alternatives. The `settings.yml` file controls everything: active engines, rate limits, safe-search defaults, and format allowlists. See the [SearXNG documentation][docs] for the complete configuration reference.
+
+**No user tracking.** SearXNG keeps no query logs by default. Cookies and JavaScript are optional — the engine works with plain HTTP GET requests, which is the typical agent access pattern. Tor exit node compatibility is documented for operators who want an additional anonymity layer.
+
+## Relevance to Agent Workflows
+
+A research harness that calls external search engines faces three compounding problems: API-key sprawl across providers, per-engine rate limits and quota costs, and result schema differences that require per-engine parsing. Self-hosting SearXNG collapses all three:
+
+- **No API-key sprawl.** The instance aggregates engines internally; the agent sends one keyless HTTP call to the local SearXNG endpoint.
+- **No per-engine rate limits visible to the agent.** SearXNG distributes requests across engines and can rotate or weight them; individual engine limits are managed at the infra layer, not in agent code.
+- **Uniform result schema.** Every engine's output is normalized to the same JSON structure before reaching the agent, removing per-source parsing logic.
+- **Privacy boundary.** Queries from an agentic pipeline never reach a third-party search provider directly, preventing query-pattern leakage associated with a project or tenant.
+
+The practical limitation is operational: the operator must run and maintain the instance, keep the Docker image updated, and tune `settings.yml` when upstream search engines change their response format. For one-off or low-volume use, a managed search API (Tavily, Brave Search API) has lower setup cost. SearXNG's value inflects at scale — many concurrent research agents, multi-tenant deployments, or environments where sending queries to external providers is a compliance concern.
+
+## Sources
+
+[repo]: https://github.com/searxng/searxng
+[docs]: https://docs.searxng.org/
+[api]: https://docs.searxng.org/dev/search_api.html


### PR DESCRIPTION
## Summary

Adds three standalone analyses to docs/non-cc/, following the directory's one-doc-per-tool convention, plus index rows.

- searxng-analysis.md — self-hostable metasearch as an agent web-search backend (Infrastructure)
- deepagents-analysis.md — LangChain deep-agents framework (Frameworks)
- intro-autonomous-robots-analysis.md — open MIT Press textbook as adjacent background reading (new Reference & Background section)

All sources first-party verified; reference-style citations.

## Validation

- markdownlint-cli2: 0 errors
- lychee: 0 broken links

Generated with Claude <noreply@anthropic.com>