### PR TITLE
fix(lychee): exclude timeout-prone techsy.io domain

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -59,4 +59,5 @@ exclude = [
     "minbook.dev",
     "emdash.dev",
     "apmdigest.com",  # valid (200) but slow — times out lychee even with retries
+    "techsy.io",  # valid but slow — times out in CI (community coverage link in CC-agent-teams-orchestration.md; sibling minbook.dev already excluded)
 ]


### PR DESCRIPTION
## Summary

The lychee link-check job was failing on every PR because https://techsy.io/...claude-code-leaked-features-2026 (a community-coverage reference in docs/cc-native/agents-skills/CC-agent-teams-orchestration.md) resolves but times out in CI's environment.

Adds techsy.io to the lychee.toml exclude list, following the established valid-but-slow pattern (apmdigest.com, and the sibling minbook.dev on the same line is already excluded).

## Validation

- Local lychee with config: techsy.io now Excluded, 0 errors
- 1-line config change only

Generated with Claude <noreply@anthropic.com>