### PR TITLE
docs: split oversized model-provider + tooling landscapes into topic files

### DIFF
--- a/docs/cc-community/CC-ai-security-governance-analysis.md
+++ b/docs/cc-community/CC-ai-security-governance-analysis.md
@@ -359,7 +359,7 @@ ISO 42001 + 23894 (certifiable management system + risk methodology)
 
 ## Defensive Tooling
 
-The frameworks above model threats; [AgentSeal](https://github.com/getagentseal/agentseal) (getagentseal — same maker as the [CodeBurn](CC-community-tooling-landscape.md#codeburn-agentseal) token tracker) is a concrete open-source scanner that tests for several of them. `pip install agentseal` / `npm install agentseal`; no API key for local scans (~285 stars, Python + TypeScript).
+The frameworks above model threats; [AgentSeal](https://github.com/getagentseal/agentseal) (getagentseal — same maker as the [CodeBurn](CC-usage-tooling-landscape.md#codeburn-agentseal) token tracker) is a concrete open-source scanner that tests for several of them. `pip install agentseal` / `npm install agentseal`; no API key for local scans (~285 stars, Python + TypeScript).
 
 | Command | What it does | Maps to (this doc) |
 | --- | --- | --- |

--- a/docs/cc-community/CC-code-tooling-landscape.md
+++ b/docs/cc-community/CC-code-tooling-landscape.md
@@ -1,0 +1,221 @@
+---
+title: CC Code-Analysis Tooling Landscape
+purpose: Code-understanding tools that integrate with Claude Code — knowledge graphs, semantic LSP, structural search, and repository packers.
+category: landscape
+status: research
+created: 2026-06-14
+updated: 2026-06-14
+validated_links: 2026-06-14
+---
+
+**Status**: Research (informational)
+
+Code-analysis and code-context tools for Claude Code: knowledge-graph builders, live-LSP semantic toolkits, structural search/rewrite, and one-shot repository packers. Split out of [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) (which keeps the cross-tool comparison table). They split along **precompute-a-graph** (Graphify, Code-Review-Graph, codebase-memory-mcp) vs. **live-LSP** (Serena) vs. **on-demand structural search** (ast-grep MCP) vs. **one-shot export** (Repomix, code2prompt).
+
+## Graphify (safishamsi)
+
+**Repo**: [safishamsi/graphify][graphify] | **Stars**: 16.5K | **License**: MIT
+
+Transforms codebases, documentation, papers, and images into queryable knowledge graphs. Two-pass architecture: AST extraction via tree-sitter (local, deterministic) then LLM-powered semantic extraction (parallel subagents). Results merge into a NetworkX graph, clustered via Leiden community detection, exported as interactive HTML, JSON, and markdown reports.
+
+### CC Integration
+
+| Surface | Mechanism |
+|---------|-----------|
+| **Slash commands** | `/graphify .`, `/graphify query "..."`, `/graphify path`, `/graphify explain` |
+| **PreToolUse hook** | Fires before Glob/Grep to surface graph structure instead of keyword search |
+| **CLAUDE.md** | `graphify claude install` injects section directing Claude to read `GRAPH_REPORT.md` |
+| **MCP server** | `python -m graphify.serve graph.json` exposes `query_graph`, `get_node`, `get_neighbors`, `shortest_path` |
+
+### Key Features
+
+- **71.5x token reduction** on mixed corpora versus raw file reading
+- **20+ languages**: Python, TypeScript, Go, Rust, Java, C/C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia
+- **Multimodal**: code, PDFs, markdown, screenshots, diagrams
+- **Confidence tagging**: EXTRACTED (1.0), INFERRED (0.0–1.0), AMBIGUOUS
+- **SHA256 caching**: only changed files reprocess; `--watch` mode for auto-sync
+- **Wiki generation**: `--wiki` flag for agent-navigable knowledge bases
+- **Privacy**: code processed locally via tree-sitter; only docs/images sent to LLM APIs
+
+### Installation
+
+```bash
+pip install graphifyy && graphify install
+```
+
+Multi-platform: `--platform codex`, `opencode`, `claw`, `droid`, `trae`.
+
+### Adoption Considerations
+
+**Strengths**: Deepest CC integration in this category (hooks + slash commands + MCP + CLAUDE.md). No embeddings — Leiden clustering uses graph topology directly. Hyperedge support for n-way relationships. Rationale extraction from `# NOTE:`, `# HACK:`, `# WHY:` comments.
+
+**Risks**: LLM-dependent for semantic pass (cost scales with repo size). PyPI package name is `graphifyy` (doubled y). Early stage relative to star count.
+
+Cross-ref: [CC-repo-to-docs-tools-landscape.md](CC-repo-to-docs-tools-landscape.md) — complementary repo-to-docs generators
+
+---
+
+## Code-Review-Graph (tirth8205)
+
+**Repo**: [tirth8205/code-review-graph][code-review-graph] | **Stars**: 7.1K | **License**: MIT
+
+Persistent structural knowledge graph of codebases via tree-sitter AST parsing. Computes "blast radius" of changes — which functions, classes, and files are affected — to provide AI assistants with precisely scoped review context.
+
+### Key Claims
+
+- **8.2x average token reduction** across 6 repositories
+- **Up to 49x fewer tokens** for monorepo daily tasks
+- **100% recall** in impact analysis (no missed affected files)
+- **Sub-2s incremental updates** (re-parses only modified files)
+
+### CC Integration
+
+`code-review-graph install` auto-configures Claude Code (plus Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity). Exposes 22 MCP tools:
+
+- Impact radius computation
+- Token-optimized review context generation
+- Graph querying (callers, callees, test coverage)
+- Semantic search across codebase entities
+
+### Language Support (19)
+
+Python, TypeScript, JavaScript, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, PHP, Swift, Scala, Lua, Elixir, Dart, R, Jupyter notebooks.
+
+### Architecture
+
+- **Storage**: SQLite in `.code-review-graph/` — no external dependencies
+- **Parsing**: tree-sitter grammars for structural extraction
+- **Monorepo optimized**: reduces review context from 27,700+ files to ~15 files
+
+### Adoption Considerations
+
+**Strengths**: Complementary to graphify (structural blast-radius vs. semantic knowledge graph). Zero external dependencies (SQLite-only). One-command multi-editor install. Research-grade recall claims.
+
+**Risks**: Token reduction claims are self-reported (no independent benchmark). Overlaps with graphify's AST extraction layer. Early stage.
+
+Cross-ref: [CC-repo-to-docs-tools-landscape.md](CC-repo-to-docs-tools-landscape.md) — related code understanding tools
+
+---
+
+## codebase-memory-mcp (DeusData)
+
+**Repo**: [DeusData/codebase-memory-mcp][codebase-memory-mcp] | **Stars**: 3.2K | **License**: MIT | **Version**: v0.7.0 (2026-05-30)
+
+Single static binary that builds a persistent code knowledge graph for agents — no runtime dependencies, no external API. Combines 159 vendored tree-sitter grammars (syntactic parse), a clean-room hybrid-LSP type-resolution layer (Python, TS/JS, PHP, C#, Go, C/C++), and bundled `nomic-embed-code` embeddings (semantic search) into a SQLite-backed graph of typed nodes (Function, Class, Route) and edges (CALLS, IMPORTS, HTTP_CALLS).
+
+### CC Integration
+
+| Surface | Mechanism |
+|---------|-----------|
+| **MCP server** | 14 tools — `index_repository`, `search_graph`, `trace_path`, `query_graph` (Cypher-like read-only), `get_architecture`, `detect_changes`, `manage_adr`, `ingest_traces` |
+| **PreToolUse hook** | Augments Grep/Glob with graph results before keyword search |
+| **Auto-config** | `install` wires up Claude Code, Codex, Gemini CLI, Zed, OpenCode, Aider + others (PreToolUse hook for CC; SessionStart reminders for the rest) |
+
+### Key Features
+
+- **99.2% token reduction** claim: ~3,400 tokens for 5 structural queries vs ~412,000 via file-by-file grep
+- **159 languages** (88 full AST, 71 additional); Linux kernel (~28M LOC) indexed in ~3 min, sub-ms queries
+- **Install**: one-line `curl … | bash`, plus AUR / Homebrew / PyPI / npm; macOS / Linux / Windows
+
+### Adoption Considerations
+
+**Strengths**: Zero-dependency single binary (vs graphify's PyPI + LLM calls). Bundled local embeddings — semantic search with no API cost or data egress. Broadest language coverage in this category.
+
+**Risks**: 99.2% reduction is self-reported (no independent benchmark). Hybrid-LSP type resolution is a clean-room reimplementation (only 7 languages fully resolved). Overlaps graphify and Code-Review-Graph on the AST/graph layer. Early stage (v0.x).
+
+Cross-ref: Graphify and Code-Review-Graph above — same code→graph category; Serena below — live-LSP alternative
+
+---
+
+## Serena (oraios)
+
+**Repo**: [oraios/serena][serena] | **Stars**: 25.2K | **License**: MIT | **Version**: v1.5.3 (2026-05-26)
+
+LSP-based semantic coding toolkit — "an IDE for your agent." Unlike the AST/graph tools above (which precompute a graph), Serena drives live language servers via the Language Server Protocol, giving agents symbol-level operations: find symbol, find references, type hierarchy, rename/move refactor, safe delete, and diagnostics — atomic cross-file edits instead of text-replace guesswork.
+
+### CC Integration
+
+| Surface | Mechanism |
+|---------|-----------|
+| **MCP server** | 20+ symbol-level tools, configured as a launch command in CC. In a harness like CC the overlapping file/search/shell tools are often disabled, leaving Serena's semantic tools |
+| **Memory** | Project memory files for long-lived workflows |
+| **Install** | `uv tool install -p 3.13 serena-agent` then `serena init` |
+
+### Key Features
+
+- **40+ languages** via open-source language servers (Python, TS/JS, Go, Rust, C/C++, C#, Java, Kotlin, Scala, …); optional paid JetBrains backend
+- Symbol-level retrieval/edit "especially in larger and more complex codebases"
+- Free and OSS; reuses LLMs you already have
+
+### Adoption Considerations
+
+**Strengths**: Live LSP semantics (always current, no index to rebuild) vs the precomputed-graph approach of graphify / Code-Review-Graph / codebase-memory-mcp. Most-starred tool in this category. Symbol-aware refactors agents can't safely do via text edits.
+
+**Risks**: Per-language LSP setup adds moving parts. Overlap with CC's built-in tools means the payoff is mainly in larger codebases. No headline token-reduction metric — efficiency comes from precise symbol queries, not corpus compression.
+
+Cross-ref: [CC-official-plugins-landscape.md](../cc-native/plugins-ecosystem/CC-official-plugins-landscape.md) — previously only named there (partner marketplace); analyzed here
+
+---
+
+## ast-grep MCP (ast-grep)
+
+**Repo**: [ast-grep/ast-grep-mcp][ast-grep-mcp] | **Stars**: 419 | **License**: MIT | **Version**: unreleased (main branch)
+
+Experimental MCP wrapper around the [ast-grep][ast-grep] Rust structural search/rewrite CLI. Exposes tree-sitter AST pattern matching to agents so they search by *syntax structure* (functions, classes, imports, call shapes) instead of text — fewer false positives than Grep, and structure-preserving rewrites.
+
+### CC Integration
+
+| Surface | Mechanism |
+|---------|-----------|
+| **MCP server** | 4 tools — `dump_syntax_tree`, `test_match_code_rule`, `find_code`, `find_code_by_rule` (YAML rules) |
+| **Runtime** | Python + FastMCP; `uvx --from git+https://github.com/ast-grep/ast-grep-mcp`; JSON client config (CC / Cursor / Claude Desktop) |
+
+### Key Features
+
+- Structural patterns across JS/TS, Python, Rust, Go, Java, C/C++, C# and more (custom languages supported)
+- **~75% fewer tokens** with the text output format vs JSON metadata
+- `dump_syntax_tree` lets the agent learn a language's node types before writing a pattern
+
+### Adoption Considerations
+
+**Strengths**: Lightweight and on-demand — no index to build (vs the persistent-graph tools above). Precise structural search/rewrite; pairs well with a graph tool for navigation plus a pattern tool for edits.
+
+**Risks**: Experimental, no tagged releases, low star count (the parent ast-grep CLI is mature; the MCP wrapper is early). Requires writing ast-grep patterns / YAML rules to get full value.
+
+Cross-ref: complements the persistent-graph tools above (search/rewrite vs navigation)
+
+---
+
+## Repomix & code2prompt (repository packers)
+
+A distinct sub-category: one-shot **context export** rather than a live MCP graph. Both flatten a repo into a single LLM-ready artifact with token counting, for pasting into a chat or seeding an agent's first turn.
+
+### Repomix (yamadashy)
+
+**Repo**: [yamadashy/repomix][repomix] | **Stars**: 26.2K | **License**: MIT | **Version**: v1.14.1 (2026-05-27)
+
+Packs a repository into one AI-friendly file (XML / Markdown / JSON / plain text), respecting `.gitignore` and scanning for secrets via Secretlint. `--compress` uses tree-sitter to keep classes/functions/interfaces and drop bodies — **~70% token reduction** while preserving structure. Reports per-file and repo-wide token counts (`o200k_base` / `cl100k_base`). **CC integration**: MCP server (`pack_codebase`, `pack_remote_repository`, `read_repomix_output`, `grep_repomix_output`, …) plus official CC plugins — `repomix-mcp`, `repomix-commands`, `repomix-explorer` via `/plugin marketplace add yamadashy/repomix`. Run with `npx repomix@latest`.
+
+### code2prompt (mufeedvh)
+
+**Repo**: [mufeedvh/code2prompt][code2prompt] | **Stars**: 7.4K | **License**: MIT | **Version**: v4.2.0 (2025-12-11)
+
+Rust CLI that renders a codebase into a single prompt with a source tree, Handlebars templating, git integration, and token counting. Ships an MCP server and a Python SDK (`pip install code2prompt-rs`); also `cargo install` / Homebrew.
+
+### Adoption Considerations
+
+**Use when**: you want a deterministic, whole-repo snapshot for a one-off question, an agent's first turn, or a non-CC LLM — no server to run. **Prefer the graph/LSP tools above** (codebase-memory-mcp, graphify, Serena) for repeated, large-codebase work, where re-sending a packed corpus every turn would blow the context budget. Repomix's `--compress` and these packers are complementary to RTK (output-side) and Boucle (read dedup), both in the [main tooling landscape](CC-community-tooling-landscape.md).
+
+## Cross-References
+
+- [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) — full cross-tool comparison + the rest of the CC tooling landscape
+- [CC-repo-to-docs-tools-landscape.md](CC-repo-to-docs-tools-landscape.md) — repo-to-docs generators
+
+[graphify]: https://github.com/safishamsi/graphify
+[code-review-graph]: https://github.com/tirth8205/code-review-graph
+[codebase-memory-mcp]: https://github.com/DeusData/codebase-memory-mcp
+[serena]: https://github.com/oraios/serena
+[ast-grep-mcp]: https://github.com/ast-grep/ast-grep-mcp
+[ast-grep]: https://github.com/ast-grep/ast-grep
+[repomix]: https://github.com/yamadashy/repomix
+[code2prompt]: https://github.com/mufeedvh/code2prompt

--- a/docs/cc-community/CC-community-tooling-landscape.md
+++ b/docs/cc-community/CC-community-tooling-landscape.md
@@ -1,12 +1,12 @@
 ---
 title: CC Community Tooling Landscape
-purpose: Survey of community developer tools that integrate with or enhance Claude Code — context compression, meta-prompting, spec-driven development, agent frameworks, file read deduplication, persistent memory, knowledge graphs, code analysis.
+purpose: Survey of community developer tools that integrate with or enhance Claude Code — context compression, meta-prompting, spec-driven development, agent frameworks, file-read deduplication, source enrichment, provider management, design systems. Memory, code-analysis, and usage-observability tools live in linked topic docs; this doc keeps the cross-tool comparison.
 category: landscape
 status: research
 platform_scope: [claude-code, cursor, codex, gemini-cli, opencode, windsurf, zed, antigravity]
 created: 2026-03-13
 updated: 2026-06-14
-validated_links: 2026-06-10
+validated_links: 2026-06-14
 ---
 
 **Status**: Research (informational)
@@ -35,7 +35,7 @@ Rust-based CLI proxy that intercepts shell command outputs and compresses them b
 
 **Recommendation**: Keep installed — free savings on verbose output with negligible overhead. Set expectations accordingly.
 
-Cross-ref: [CC-hooks-system-analysis.md](../cc-native/configuration/CC-hooks-system-analysis.md); [CC-community-skills-landscape.md](CC-community-skills-landscape.md) — caveman (output-side compression); CodeBurn / ccusage / Claude-Code-Usage-Monitor below (measurement layer)
+Cross-ref: [CC-hooks-system-analysis.md](../cc-native/configuration/CC-hooks-system-analysis.md); [CC-community-skills-landscape.md](CC-community-skills-landscape.md) — caveman (output-side compression); the [usage-observability tools](CC-usage-tooling-landscape.md) (measurement layer)
 
 ---
 
@@ -181,95 +181,6 @@ Open-source Python agent harness framework — infrastructure plumbing between L
 
 ---
 
-## ByteRover CLI (campfirein)
-
-**Repo**: [campfirein/byterover-cli][byterover] | **Stars**: 4.1K | **License**: Elastic License 2.0 | **Paper**: [arXiv:2604.01599][byterover-paper]
-
-Portable memory layer for autonomous coding agents. Persistent hierarchical context trees (Domain→Topic→Subtopic→Entry) with cloud sync and sub-100ms retrieval without vector databases.
-
-### Architecture
-
-- **Context Tree**: LLM-curated hierarchical knowledge storage in human-readable markdown
-- **Adaptive Knowledge Lifecycle**: Importance scoring + recency decay
-- **5-tier progressive retrieval**: Escalates to LLM reasoning only for novel queries
-- **MCP integration**: `brv mcp` starts an MCP server for CC to access memory natively
-
-### CC Integration
-
-ByteRover integrates with Claude Code via MCP protocol. Run `brv mcp` to expose the memory layer as an MCP server, giving CC access to persistent cross-session knowledge, semantic search, and context tree operations.
-
-### Adoption Considerations
-
-**Strengths**: Research-backed ([arXiv:2604.01599][byterover-paper] — SOTA on LoCoMo benchmark), 20+ LLM provider support, cloud sync with SOC 2 Type II, active development (48 releases, 2,391 commits).
-
-**Risks**: Elastic License 2.0 (not OSS — requires commercial agreement for production). Cloud dependency for sync features. Overlaps with CC's built-in memory system (`~/.claude/memory/`). Standalone daemon CLI — install alongside CC via MCP, not embeddable in plugins.
-
-Cross-ref: [CC-memory-system-analysis.md](../cc-native/context-memory/CC-memory-system-analysis.md) — CC's native memory for comparison
-
----
-
-## Claude-Mem (thedotmack / Alex Newman)
-
-**Repo**: [thedotmack/claude-mem][claude-mem] | **Stars**: 45.2K | **License**: AGPL-3.0 | **Version**: 6.5.0
-
-Persistent memory compression system for Claude Code. Automatically captures everything Claude does during coding sessions, compresses it with AI, and injects relevant context back into future sessions for continuity.
-
-### Architecture
-
-| Component | Purpose |
-|-----------|---------|
-| **Lifecycle Hooks** (5) | SessionStart, UserPromptSubmit, PostToolUse, Stop, SessionEnd |
-| **Worker Service** | Express API on port 37777, managed by Bun runtime, includes web viewer UI |
-| **SQLite Storage** | Sessions, observations, summaries with FTS5 full-text search |
-| **Chroma Vector DB** | Hybrid semantic/keyword search |
-| **MCP Tools** | 3-layer progressive disclosure workflow |
-
-### MCP Search Pattern (Token-Efficient)
-
-| Tool | Purpose | Cost |
-|------|---------|------|
-| `search` | Compact index retrieval with IDs | ~50–100 tokens/result |
-| `timeline` | Chronological context around observations | moderate |
-| `get_observations` | Full detail for filtered IDs | ~500–1,000 tokens/result |
-
-Progressive disclosure: start with index → assess via timeline → fetch full detail only for relevant matches. Estimated **10x token savings** over naive retrieval.
-
-### Installation
-
-```bash
-npx claude-mem install                          # CLI install
-/plugin marketplace add thedotmack/claude-mem   # marketplace install
-```
-
-**Note**: npm global install provides only the SDK library; proper plugin registration requires `npx claude-mem install`.
-
-### Key Features
-
-- AI-compressed semantic summaries of session activity
-- Automatic context injection into new sessions
-- `<private>` tags for content exclusion
-- Citation system referencing past observations by ID
-- Web viewer UI at localhost:37777
-- Notification integrations (Telegram, Discord, Slack)
-
-### Live Observer Architecture
-
-A dedicated observer AI watches each session in real-time, generating searchable observations with before-and-after context — capturing causality and decision chains, not just snapshots. Observations are auto-categorized by type (decisions, bugfixes, features, discoveries) and queryable by file path or semantic concept (e.g., "decisions about token refresh").
-
-### RAD Protocol (Coming Soon)
-
-**Real-Time Agent Data** — an open protocol standardizing how AI agents capture and retrieve working memory. Positioned as a counterpart to RAG (Retrieval Augmented Generation). Hook-based architecture for temporal awareness.
-
-### Adoption Considerations
-
-**Strengths**: Largest community memory solution (45.2K stars), progressive disclosure saves tokens, hybrid search (FTS5 + vector), multi-platform (CC + Gemini CLI), web UI for browsing history, [dedicated docs site][claude-mem-docs].
-
-**Risks**: AGPL-3.0 (copyleft — commercial use requires compliance). Ragtime subdirectory under separate PolyForm Noncommercial License. Heavy dependencies (Bun + uv + Chroma). Overlaps with CC's built-in memory system and ByteRover.
-
-Cross-ref: [CC-memory-system-analysis.md](../cc-native/context-memory/CC-memory-system-analysis.md) — CC's native memory for comparison
-
----
-
 ## CC Switch (farion1231)
 
 **Repo**: [farion1231/cc-switch][cc-switch] | **Stars**: 38.9K | **License**: TBD | **Commits**: 1,376
@@ -374,421 +285,13 @@ Cross-ref: [CC-domain-claudemd-showcase.md](CC-domain-claudemd-showcase.md) — 
 
 ---
 
-## Graphify (safishamsi)
+## Detailed Tool Landscapes
 
-**Repo**: [safishamsi/graphify][graphify] | **Stars**: 16.5K | **License**: MIT
+Per-tool entries for three categories have moved to focused topic docs; the cross-tool comparison below still covers all of them:
 
-Transforms codebases, documentation, papers, and images into queryable knowledge graphs. Two-pass architecture: AST extraction via tree-sitter (local, deterministic) then LLM-powered semantic extraction (parallel subagents). Results merge into a NetworkX graph, clustered via Leiden community detection, exported as interactive HTML, JSON, and markdown reports.
-
-### CC Integration
-
-| Surface | Mechanism |
-|---------|-----------|
-| **Slash commands** | `/graphify .`, `/graphify query "..."`, `/graphify path`, `/graphify explain` |
-| **PreToolUse hook** | Fires before Glob/Grep to surface graph structure instead of keyword search |
-| **CLAUDE.md** | `graphify claude install` injects section directing Claude to read `GRAPH_REPORT.md` |
-| **MCP server** | `python -m graphify.serve graph.json` exposes `query_graph`, `get_node`, `get_neighbors`, `shortest_path` |
-
-### Key Features
-
-- **71.5x token reduction** on mixed corpora versus raw file reading
-- **20+ languages**: Python, TypeScript, Go, Rust, Java, C/C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia
-- **Multimodal**: code, PDFs, markdown, screenshots, diagrams
-- **Confidence tagging**: EXTRACTED (1.0), INFERRED (0.0–1.0), AMBIGUOUS
-- **SHA256 caching**: only changed files reprocess; `--watch` mode for auto-sync
-- **Wiki generation**: `--wiki` flag for agent-navigable knowledge bases
-- **Privacy**: code processed locally via tree-sitter; only docs/images sent to LLM APIs
-
-### Installation
-
-```bash
-pip install graphifyy && graphify install
-```
-
-Multi-platform: `--platform codex`, `opencode`, `claw`, `droid`, `trae`.
-
-### Adoption Considerations
-
-**Strengths**: Deepest CC integration in this category (hooks + slash commands + MCP + CLAUDE.md). No embeddings — Leiden clustering uses graph topology directly. Hyperedge support for n-way relationships. Rationale extraction from `# NOTE:`, `# HACK:`, `# WHY:` comments.
-
-**Risks**: LLM-dependent for semantic pass (cost scales with repo size). PyPI package name is `graphifyy` (doubled y). Early stage relative to star count.
-
-Cross-ref: [CC-repo-to-docs-tools-landscape.md](CC-repo-to-docs-tools-landscape.md) — complementary repo-to-docs generators
-
----
-
-## MemPalace (milla-jovovich)
-
-**Repo**: [milla-jovovich/mempalace][mempalace] | **Stars**: 33.6K | **License**: MIT | **Version**: 3.0.0
-
-Local-first AI memory system storing conversation histories verbatim using a spatial "palace" metaphor. Achieved 96.6% R@5 on [LongMemEval benchmark][longmemeval] — the highest published result — without cloud dependencies.
-
-### Palace Architecture
-
-| Layer | Metaphor | Purpose |
-|-------|----------|---------|
-| **Wings** | Projects or people | Top-level partitioning |
-| **Rooms** | Topic categories | Within-wing organization |
-| **Halls** | Memory types | Cross-wing shared categories (facts, events, discoveries) |
-| **Closets** | Summaries | Pointers to original content |
-| **Drawers** | Verbatim files | Raw original data |
-| **Tunnels** | Cross-references | Links between rooms across wings |
-
-34% retrieval improvement over unstructured search from this hierarchical organization.
-
-### Memory Stack
-
-| Layer | Content | Size | Timing |
-|-------|---------|------|--------|
-| L0 | Identity/system prompt | ~50 tokens | Always loaded |
-| L1 | Critical facts | ~120 tokens (AAAK) | Always loaded |
-| L2 | Room recall (recent sessions) | On demand | When topic emerges |
-| L3 | Deep semantic search | On demand | When explicitly queried |
-
-### CC Integration
-
-```bash
-claude plugin marketplace add milla-jovovich/mempalace   # marketplace install
-claude mcp add mempalace -- python -m mempalace.mcp_server  # MCP install
-```
-
-19 MCP tools for search and memory operations. Also supports ChatGPT, Cursor, Gemini, and local models (Ollama, Mistral).
-
-### Adoption Considerations
-
-**Strengths**: Highest published LongMemEval score (96.6% raw mode, reproducible via `/benchmarks`). Free and fully local. ChromaDB + SQLite knowledge graph. Specialist agent support with per-agent memory wings.
-
-**Risks**: AAAK compression is lossy and regresses to 84.2% ([README candid note][mempalace]). Overlaps with CC's built-in memory, ByteRover, and Claude-Mem. ChromaDB dependency adds install complexity.
-
-Cross-ref: [CC-memory-system-analysis.md](../cc-native/context-memory/CC-memory-system-analysis.md) — CC's native memory for comparison
-
----
-
-## MemSearch (zilliztech)
-
-**Repo**: [zilliztech/memsearch][memsearch] | **Stars**: ~2K | **License**: MIT | **Version**: v0.4.7
-
-Persistent, cross-session semantic memory for AI coding agents from the Milvus/Zilliz team. Stores conversation history as human-readable Markdown and indexes it with Milvus for hybrid vector + BM25 search. Unlike MCP-based memory tools, it ships as a **native Claude Code plugin** — "4 shell hooks + 1 skill + 1 watch process, no MCP, no sidecar service" ([CC plugin docs][memsearch-docs]).
-
-### Architecture
-
-- **Markdown is the source of truth** (`.memsearch/memory/*.md`); the Milvus index is a derived "shadow" cache, rebuildable at any time
-- **3-layer progressive retrieval**: search → expand → transcript
-- **Hybrid search**: dense vector embeddings + BM25 sparse + RRF reranking
-- **Local-first embeddings**: ONNX bge-m3 int8 by default (CPU, no API key); pluggable to OpenAI, Google, Voyage, Ollama
-- **SHA-256 dedup** avoids re-indexing unchanged content; a live file watcher auto-indexes edits
-- **Backend options**: Milvus Lite (embedded default), self-hosted Milvus, or Zilliz Cloud (free tier)
-
-### CC Integration
-
-```bash
-/plugin marketplace add zilliztech/memsearch
-/plugin install memsearch
-```
-
-The memory-recall skill runs in a `context: fork` subagent, so intermediate search results never pollute the main context — and because there is no MCP server, no tool definitions consume context tokens permanently. The same Markdown store is shared across Claude Code, OpenCode, Codex CLI, and OpenClaw.
-
-### Adoption Considerations
-
-**Strengths**: Zero permanent context overhead (no MCP tool defs); human-readable Markdown that survives index loss; local embeddings need no API key; one memory store across multiple agent CLIs.
-
-**Risks**: Overlaps with CC's built-in memory, Claude-Mem, MemPalace, and ByteRover — pick one. Milvus/Zilliz dependency for the index. Pre-1.0 (v0.4.7), active release cadence. Distinct from Zilliz's separate `claude-context` code-search MCP — do not conflate the two.
-
-Cross-ref: [CC-remote-access-landscape.md](../cc-native/ci-remote/CC-remote-access-landscape.md) — memsearch as a mobile/remote supporting tool
-
----
-
-## Code-Review-Graph (tirth8205)
-
-**Repo**: [tirth8205/code-review-graph][code-review-graph] | **Stars**: 7.1K | **License**: MIT
-
-Persistent structural knowledge graph of codebases via tree-sitter AST parsing. Computes "blast radius" of changes — which functions, classes, and files are affected — to provide AI assistants with precisely scoped review context.
-
-### Key Claims
-
-- **8.2x average token reduction** across 6 repositories
-- **Up to 49x fewer tokens** for monorepo daily tasks
-- **100% recall** in impact analysis (no missed affected files)
-- **Sub-2s incremental updates** (re-parses only modified files)
-
-### CC Integration
-
-`code-review-graph install` auto-configures Claude Code (plus Cursor, Windsurf, Zed, Continue, OpenCode, Antigravity). Exposes 22 MCP tools:
-
-- Impact radius computation
-- Token-optimized review context generation
-- Graph querying (callers, callees, test coverage)
-- Semantic search across codebase entities
-
-### Language Support (19)
-
-Python, TypeScript, JavaScript, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, PHP, Swift, Scala, Lua, Elixir, Dart, R, Jupyter notebooks.
-
-### Architecture
-
-- **Storage**: SQLite in `.code-review-graph/` — no external dependencies
-- **Parsing**: tree-sitter grammars for structural extraction
-- **Monorepo optimized**: reduces review context from 27,700+ files to ~15 files
-
-### Adoption Considerations
-
-**Strengths**: Complementary to graphify (structural blast-radius vs. semantic knowledge graph). Zero external dependencies (SQLite-only). One-command multi-editor install. Research-grade recall claims.
-
-**Risks**: Token reduction claims are self-reported (no independent benchmark). Overlaps with graphify's AST extraction layer. Early stage.
-
-Cross-ref: [CC-repo-to-docs-tools-landscape.md](CC-repo-to-docs-tools-landscape.md) — related code understanding tools
-
----
-
-## codebase-memory-mcp (DeusData)
-
-**Repo**: [DeusData/codebase-memory-mcp][codebase-memory-mcp] | **Stars**: 3.2K | **License**: MIT | **Version**: v0.7.0 (2026-05-30)
-
-Single static binary that builds a persistent code knowledge graph for agents — no runtime dependencies, no external API. Combines 159 vendored tree-sitter grammars (syntactic parse), a clean-room hybrid-LSP type-resolution layer (Python, TS/JS, PHP, C#, Go, C/C++), and bundled `nomic-embed-code` embeddings (semantic search) into a SQLite-backed graph of typed nodes (Function, Class, Route) and edges (CALLS, IMPORTS, HTTP_CALLS).
-
-### CC Integration
-
-| Surface | Mechanism |
-|---------|-----------|
-| **MCP server** | 14 tools — `index_repository`, `search_graph`, `trace_path`, `query_graph` (Cypher-like read-only), `get_architecture`, `detect_changes`, `manage_adr`, `ingest_traces` |
-| **PreToolUse hook** | Augments Grep/Glob with graph results before keyword search |
-| **Auto-config** | `install` wires up Claude Code, Codex, Gemini CLI, Zed, OpenCode, Aider + others (PreToolUse hook for CC; SessionStart reminders for the rest) |
-
-### Key Features
-
-- **99.2% token reduction** claim: ~3,400 tokens for 5 structural queries vs ~412,000 via file-by-file grep
-- **159 languages** (88 full AST, 71 additional); Linux kernel (~28M LOC) indexed in ~3 min, sub-ms queries
-- **Install**: one-line `curl … | bash`, plus AUR / Homebrew / PyPI / npm; macOS / Linux / Windows
-
-### Adoption Considerations
-
-**Strengths**: Zero-dependency single binary (vs graphify's PyPI + LLM calls). Bundled local embeddings — semantic search with no API cost or data egress. Broadest language coverage in this category.
-
-**Risks**: 99.2% reduction is self-reported (no independent benchmark). Hybrid-LSP type resolution is a clean-room reimplementation (only 7 languages fully resolved). Overlaps graphify and Code-Review-Graph on the AST/graph layer. Early stage (v0.x).
-
-Cross-ref: Graphify and Code-Review-Graph above — same code→graph category; Serena below — live-LSP alternative
-
----
-
-## Serena (oraios)
-
-**Repo**: [oraios/serena][serena] | **Stars**: 25.2K | **License**: MIT | **Version**: v1.5.3 (2026-05-26)
-
-LSP-based semantic coding toolkit — "an IDE for your agent." Unlike the AST/graph tools above (which precompute a graph), Serena drives live language servers via the Language Server Protocol, giving agents symbol-level operations: find symbol, find references, type hierarchy, rename/move refactor, safe delete, and diagnostics — atomic cross-file edits instead of text-replace guesswork.
-
-### CC Integration
-
-| Surface | Mechanism |
-|---------|-----------|
-| **MCP server** | 20+ symbol-level tools, configured as a launch command in CC. In a harness like CC the overlapping file/search/shell tools are often disabled, leaving Serena's semantic tools |
-| **Memory** | Project memory files for long-lived workflows |
-| **Install** | `uv tool install -p 3.13 serena-agent` then `serena init` |
-
-### Key Features
-
-- **40+ languages** via open-source language servers (Python, TS/JS, Go, Rust, C/C++, C#, Java, Kotlin, Scala, …); optional paid JetBrains backend
-- Symbol-level retrieval/edit "especially in larger and more complex codebases"
-- Free and OSS; reuses LLMs you already have
-
-### Adoption Considerations
-
-**Strengths**: Live LSP semantics (always current, no index to rebuild) vs the precomputed-graph approach of graphify / Code-Review-Graph / codebase-memory-mcp. Most-starred tool in this category. Symbol-aware refactors agents can't safely do via text edits.
-
-**Risks**: Per-language LSP setup adds moving parts. Overlap with CC's built-in tools means the payoff is mainly in larger codebases. No headline token-reduction metric — efficiency comes from precise symbol queries, not corpus compression.
-
-Cross-ref: [CC-official-plugins-landscape.md](../cc-native/plugins-ecosystem/CC-official-plugins-landscape.md) — previously only named there (partner marketplace); analyzed here
-
----
-
-## ast-grep MCP (ast-grep)
-
-**Repo**: [ast-grep/ast-grep-mcp][ast-grep-mcp] | **Stars**: 419 | **License**: MIT | **Version**: unreleased (main branch)
-
-Experimental MCP wrapper around the [ast-grep][ast-grep] Rust structural search/rewrite CLI. Exposes tree-sitter AST pattern matching to agents so they search by *syntax structure* (functions, classes, imports, call shapes) instead of text — fewer false positives than Grep, and structure-preserving rewrites.
-
-### CC Integration
-
-| Surface | Mechanism |
-|---------|-----------|
-| **MCP server** | 4 tools — `dump_syntax_tree`, `test_match_code_rule`, `find_code`, `find_code_by_rule` (YAML rules) |
-| **Runtime** | Python + FastMCP; `uvx --from git+https://github.com/ast-grep/ast-grep-mcp`; JSON client config (CC / Cursor / Claude Desktop) |
-
-### Key Features
-
-- Structural patterns across JS/TS, Python, Rust, Go, Java, C/C++, C# and more (custom languages supported)
-- **~75% fewer tokens** with the text output format vs JSON metadata
-- `dump_syntax_tree` lets the agent learn a language's node types before writing a pattern
-
-### Adoption Considerations
-
-**Strengths**: Lightweight and on-demand — no index to build (vs the persistent-graph tools above). Precise structural search/rewrite; pairs well with a graph tool for navigation plus a pattern tool for edits.
-
-**Risks**: Experimental, no tagged releases, low star count (the parent ast-grep CLI is mature; the MCP wrapper is early). Requires writing ast-grep patterns / YAML rules to get full value.
-
-Cross-ref: complements the persistent-graph tools above (search/rewrite vs navigation)
-
----
-
-## Repomix & code2prompt (repository packers)
-
-A distinct sub-category: one-shot **context export** rather than a live MCP graph. Both flatten a repo into a single LLM-ready artifact with token counting, for pasting into a chat or seeding an agent's first turn.
-
-### Repomix (yamadashy)
-
-**Repo**: [yamadashy/repomix][repomix] | **Stars**: 26.2K | **License**: MIT | **Version**: v1.14.1 (2026-05-27)
-
-Packs a repository into one AI-friendly file (XML / Markdown / JSON / plain text), respecting `.gitignore` and scanning for secrets via Secretlint. `--compress` uses tree-sitter to keep classes/functions/interfaces and drop bodies — **~70% token reduction** while preserving structure. Reports per-file and repo-wide token counts (`o200k_base` / `cl100k_base`). **CC integration**: MCP server (`pack_codebase`, `pack_remote_repository`, `read_repomix_output`, `grep_repomix_output`, …) plus official CC plugins — `repomix-mcp`, `repomix-commands`, `repomix-explorer` via `/plugin marketplace add yamadashy/repomix`. Run with `npx repomix@latest`.
-
-### code2prompt (mufeedvh)
-
-**Repo**: [mufeedvh/code2prompt][code2prompt] | **Stars**: 7.4K | **License**: MIT | **Version**: v4.2.0 (2025-12-11)
-
-Rust CLI that renders a codebase into a single prompt with a source tree, Handlebars templating, git integration, and token counting. Ships an MCP server and a Python SDK (`pip install code2prompt-rs`); also `cargo install` / Homebrew.
-
-### Adoption Considerations
-
-**Use when**: you want a deterministic, whole-repo snapshot for a one-off question, an agent's first turn, or a non-CC LLM — no server to run. **Prefer the graph/LSP tools above** (codebase-memory-mcp, graphify, Serena) for repeated, large-codebase work, where re-sending a packed corpus every turn would blow the context budget. Repomix's `--compress` and these packers are complementary to RTK (output-side) and Boucle (read dedup), both above.
-
----
-
-## CodeBurn (AgentSeal)
-
-**Repo**: [getagentseal/codeburn][codeburn] | **Stars**: 4K | **License**: MIT | **Latest**: Menubar v0.9.0 (2026-04-25) | **Stack**: TypeScript, Node.js 20+
-
-Local-first TUI dashboard that tracks AI coding token usage and cost across multiple coding agents. Reads session data directly from disk — no API keys, no proxy ([README][codeburn]).
-
-### Supported Agents
-
-Per the [README][codeburn]: Claude Code, Claude Desktop, Codex, Cursor, cursor-agent, OpenCode, Pi, OMP (Oh My Pi), GitHub Copilot.
-
-### Data Sources (Read-Only, On-Disk)
-
-| Agent | Path |
-|---|---|
-| Claude | `~/.claude/projects/` (JSONL) |
-| Cursor | `~/Library/Application Support/Cursor/` (SQLite, macOS) |
-| Codex | `~/.codex/sessions/` (JSONL with timestamped token events) |
-| OpenCode | `~/.local/share/opencode/` (SQLite) |
-| GitHub Copilot | `~/.copilot/session-state/` |
-
-### Features
-
-- **TUI dashboard** with gradient charts and responsive panels
-- **13 task categories** classified from tool patterns: Coding, Debugging, Feature Dev, Refactoring, Testing, Exploration, Planning, Delegation, Git Ops, Build/Deploy, Brainstorming, Conversation, General
-- **[`codeburn optimize`](https://github.com/getagentseal/codeburn#optimize)** — surfaces nine waste patterns (files re-read across sessions, low Read:Edit ratio, unused MCP servers, ghost agents/skills/slash commands, bloated `CLAUDE.md`, wasted bash output, cache-creation overhead, context-heavy and low-worth sessions) with copy-paste token/$ fixes ranked into an A–F health grade
-- **`codeburn compare`** — side-by-side model performance metrics
-- **`codeburn report -p 30days`** — rolling-window analysis
-- **`codeburn export`** — CSV/JSON across multiple time periods
-- **Subscription tracking** — Claude Pro/Max, Cursor Pro
-- **Currency conversion** — 162 ISO 4217 codes
-- **Pricing data** sourced from LiteLLM with 24h cached refresh; hardcoded fallbacks for Claude and GPT-5 to prevent fuzzy-match errors
-
-### Platform Support
-
-macOS (native menubar app via `codeburn menubar`), Linux (CLI), Windows (CLI; Cursor support requires `better-sqlite3`).
-
-### Installation
-
-```bash
-npm install -g codeburn
-# or run without installing:
-npx codeburn
-```
-
-### Key Differentiator
-
-Where RTK reduces tokens *entering* context and caveman compresses tokens *leaving* the assistant, **CodeBurn observes** what was actually spent — across agents, models, and projects. Complementary to both: optimization needs measurement. Local-first (no API keys, no telemetry) makes it usable in air-gapped or compliance-sensitive environments.
-
-Cross-ref: [CC-community-skills-landscape.md](CC-community-skills-landscape.md) — caveman (output compression skill); [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-analysis.md) — CC's native session-cost extraction via JSONL/jq
-
----
-
-## ccusage (ryoppippi)
-
-**Repo**: [ryoppippi/ccusage][ccusage] | **Stars**: 13.4K | **License**: MIT | **Version**: v18.0.11 (2026-04-19) | **Stack**: TypeScript
-
-CLI tool that analyzes Claude Code / Codex CLI usage from local JSONL files. Established reference tool in the CC usage-tracking space — predates and is broader-adopted than CodeBurn ([README][ccusage]).
-
-### Reports
-
-- **Daily** — token usage and costs aggregated by date
-- **Monthly** — long-horizon aggregation
-- **Session** — usage grouped by conversation
-- **Blocks** — 5-hour billing windows (matches Anthropic's plan limits)
-- **Statusline** (Beta) — integration for hooks
-
-### Capabilities
-
-Per the [README][ccusage]:
-
-- **Model tracking** — per-model breakdown with `--breakdown`
-- **Cache token support** — tracks cache creation and cache read tokens separately (codeburn does not split these)
-- **Offline mode** — `--offline` uses pre-cached pricing (no network)
-- **MCP integration** — built-in MCP server for in-session queries
-- **Multi-instance** — group usage by project
-- **JSON export**
-
-### Installation
-
-```bash
-npx ccusage@latest          # recommended — always latest
-bunx ccusage
-pnpm dlx ccusage
-```
-
-Reads `~/.claude/projects/` JSONL by default; data path is configurable.
-
-### Key Differentiator
-
-Where CodeBurn is **multi-agent** (Claude/Codex/Cursor/OpenCode/Copilot in one TUI), ccusage is **CC/Codex-focused** with deeper CC-specific features (cache token split, MCP server, statusline hook). The two are complementary, not redundant: ccusage for CC-deep analysis and in-session queries via MCP; CodeBurn for cross-agent comparison.
-
-Cross-ref: [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-analysis.md) — manual JSONL/jq extraction patterns ccusage automates; [CC-hooks-system-analysis.md](../cc-native/configuration/CC-hooks-system-analysis.md) — statusline hook integration point
-
----
-
-## Claude-Code-Usage-Monitor (Maciek-roboblog)
-
-**Repo**: [Maciek-roboblog/Claude-Code-Usage-Monitor][claude-monitor] | **Stars**: 7.8K | **License**: MIT | **Version**: v3.1.0 | **Stack**: Python 3.9+
-
-Real-time terminal monitor for Claude Code with **predictions and warnings**, distinguishing it from after-the-fact analyzers like ccusage / CodeBurn ([README][claude-monitor]).
-
-### Plan Support
-
-Per the [README][claude-monitor]:
-
-| Plan | Token limit |
-|---|---|
-| Pro | ~19,000 |
-| Max5 | ~88,000 |
-| Max20 | ~220,000 |
-| **Custom** | P90 auto-detection over recent session blocks |
-
-The Custom plan analyzes recent session blocks and computes a personalized 90th-percentile limit — adapts to actual usage patterns without manual configuration.
-
-### Views
-
-- **Realtime** — live progress bars + burn rate (default)
-- **Daily** — aggregated table
-- **Monthly** — long-trend analysis
-
-### Methodology
-
-P90 percentile analysis across all available session blocks; multi-session burn-rate analytics; intelligent session-limit detection. Stack: `pytz`, `rich`, `pydantic`, `numpy`, `pyyaml`, `sentry-sdk`.
-
-### Installation
-
-```bash
-uv tool install claude-monitor       # recommended
-pip install claude-monitor
-```
-
-### Key Differentiator
-
-Only tool in this category that does **prediction** (not just retrospective measurement). ccusage and CodeBurn answer "what did I spend?"; claude-monitor answers "will I exhaust my window?" Useful pairing: claude-monitor for live discipline, ccusage for historical trend, CodeBurn for cross-agent comparison.
-
-Cross-ref: [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-analysis.md) — Anthropic plan limits and 5-hour windows
-
----
+- [CC-memory-tooling-landscape.md](CC-memory-tooling-landscape.md) — persistent memory: ByteRover, Claude-Mem, MemPalace, MemSearch
+- [CC-code-tooling-landscape.md](CC-code-tooling-landscape.md) — code analysis: Graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP, Repomix, code2prompt
+- [CC-usage-tooling-landscape.md](CC-usage-tooling-landscape.md) — usage observability: CodeBurn, ccusage, Claude-Code-Usage-Monitor
 
 ## Comparison
 
@@ -817,7 +320,7 @@ Cross-ref: [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-a
 | **ccusage** | Token-usage observability (CC/Codex) | CLI + MCP server + statusline | JSONL analyzer, cache-token split, offline mode | Stable (13.4K stars, v18.0.11) |
 | **Claude-Code-Usage-Monitor** | Predictive usage monitoring | Real-time TUI | P90-based limit prediction, burn-rate analytics, plan-aware | Active (7.8K stars, v3.1.0) |
 
-All twenty-two address different layers of the agent stack — complementary, not competing. The five code-analysis tools (graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP) split along precompute-a-graph vs. live-LSP vs. on-demand-structural-search; the two repo packers (Repomix, code2prompt) are one-shot context export rather than a live server.
+All twenty-two address different layers of the agent stack — complementary, not competing. The five code-analysis tools (graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP) split along precompute-a-graph vs. live-LSP vs. on-demand-structural-search; the two repo packers (Repomix, code2prompt) are one-shot context export rather than a live server. Full per-tool entries for the memory, code-analysis, and usage-observability rows are in the topic docs linked above.
 
 Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-extended-context-analysis.md) — CC's built-in context compaction
 
@@ -853,14 +356,11 @@ Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-exte
 [awesome-design-md]: https://github.com/VoltAgent/awesome-design-md
 [graphify]: https://github.com/safishamsi/graphify
 [mempalace]: https://github.com/MemPalace/mempalace
-[longmemeval]: https://github.com/xiaowu0162/LongMemEval
 [memsearch]: https://github.com/zilliztech/memsearch
-[memsearch-docs]: https://zilliztech.github.io/memsearch/platforms/claude-code/
 [code-review-graph]: https://github.com/tirth8205/code-review-graph
 [codebase-memory-mcp]: https://github.com/DeusData/codebase-memory-mcp
 [serena]: https://github.com/oraios/serena
 [ast-grep-mcp]: https://github.com/ast-grep/ast-grep-mcp
-[ast-grep]: https://github.com/ast-grep/ast-grep
 [repomix]: https://github.com/yamadashy/repomix
 [code2prompt]: https://github.com/mufeedvh/code2prompt
 [rtk-repo]: https://github.com/rtk-ai/rtk
@@ -879,7 +379,6 @@ Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-exte
 [byterover]: https://github.com/campfirein/byterover-cli
 [byterover-paper]: https://arxiv.org/abs/2604.01599
 [claude-mem]: https://github.com/thedotmack/claude-mem
-[claude-mem-docs]: https://docs.claude-mem.ai/introduction
 [cc-switch]: https://github.com/farion1231/cc-switch
 [opensrc]: https://github.com/vercel-labs/opensrc
 [codeburn]: https://github.com/getagentseal/codeburn

--- a/docs/cc-community/CC-memory-tooling-landscape.md
+++ b/docs/cc-community/CC-memory-tooling-landscape.md
@@ -1,0 +1,195 @@
+---
+title: CC Memory Tooling Landscape
+purpose: Persistent cross-session memory tools that integrate with Claude Code — ByteRover, Claude-Mem, MemPalace, MemSearch.
+category: landscape
+status: research
+created: 2026-06-14
+updated: 2026-06-14
+validated_links: 2026-06-14
+---
+
+**Status**: Research (informational)
+
+Persistent-memory tools for Claude Code. Split out of [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) (which keeps the cross-tool comparison table). For non-CC memory *infrastructure* (Mem0, Zep/Graphiti, Cognee, LangMem, A-MEM), see [agent-frameworks-infrastructure-landscape.md § Agent Memory Infrastructure](../non-cc/agent-frameworks-infrastructure-landscape.md#4-agent-memory-infrastructure). CC's native memory: [CC-memory-system-analysis.md](../cc-native/context-memory/CC-memory-system-analysis.md).
+
+## ByteRover CLI (campfirein)
+
+**Repo**: [campfirein/byterover-cli][byterover] | **Stars**: 4.1K | **License**: Elastic License 2.0 | **Paper**: [arXiv:2604.01599][byterover-paper]
+
+Portable memory layer for autonomous coding agents. Persistent hierarchical context trees (Domain→Topic→Subtopic→Entry) with cloud sync and sub-100ms retrieval without vector databases.
+
+### Architecture
+
+- **Context Tree**: LLM-curated hierarchical knowledge storage in human-readable markdown
+- **Adaptive Knowledge Lifecycle**: Importance scoring + recency decay
+- **5-tier progressive retrieval**: Escalates to LLM reasoning only for novel queries
+- **MCP integration**: `brv mcp` starts an MCP server for CC to access memory natively
+
+### CC Integration
+
+ByteRover integrates with Claude Code via MCP protocol. Run `brv mcp` to expose the memory layer as an MCP server, giving CC access to persistent cross-session knowledge, semantic search, and context tree operations.
+
+### Adoption Considerations
+
+**Strengths**: Research-backed ([arXiv:2604.01599][byterover-paper] — SOTA on LoCoMo benchmark), 20+ LLM provider support, cloud sync with SOC 2 Type II, active development (48 releases, 2,391 commits).
+
+**Risks**: Elastic License 2.0 (not OSS — requires commercial agreement for production). Cloud dependency for sync features. Overlaps with CC's built-in memory system (`~/.claude/memory/`). Standalone daemon CLI — install alongside CC via MCP, not embeddable in plugins.
+
+Cross-ref: [CC-memory-system-analysis.md](../cc-native/context-memory/CC-memory-system-analysis.md) — CC's native memory for comparison
+
+---
+
+## Claude-Mem (thedotmack / Alex Newman)
+
+**Repo**: [thedotmack/claude-mem][claude-mem] | **Stars**: 45.2K | **License**: AGPL-3.0 | **Version**: 6.5.0
+
+Persistent memory compression system for Claude Code. Automatically captures everything Claude does during coding sessions, compresses it with AI, and injects relevant context back into future sessions for continuity.
+
+### Architecture
+
+| Component | Purpose |
+|-----------|---------|
+| **Lifecycle Hooks** (5) | SessionStart, UserPromptSubmit, PostToolUse, Stop, SessionEnd |
+| **Worker Service** | Express API on port 37777, managed by Bun runtime, includes web viewer UI |
+| **SQLite Storage** | Sessions, observations, summaries with FTS5 full-text search |
+| **Chroma Vector DB** | Hybrid semantic/keyword search |
+| **MCP Tools** | 3-layer progressive disclosure workflow |
+
+### MCP Search Pattern (Token-Efficient)
+
+| Tool | Purpose | Cost |
+|------|---------|------|
+| `search` | Compact index retrieval with IDs | ~50–100 tokens/result |
+| `timeline` | Chronological context around observations | moderate |
+| `get_observations` | Full detail for filtered IDs | ~500–1,000 tokens/result |
+
+Progressive disclosure: start with index → assess via timeline → fetch full detail only for relevant matches. Estimated **10x token savings** over naive retrieval.
+
+### Installation
+
+```bash
+npx claude-mem install                          # CLI install
+/plugin marketplace add thedotmack/claude-mem   # marketplace install
+```
+
+**Note**: npm global install provides only the SDK library; proper plugin registration requires `npx claude-mem install`.
+
+### Key Features
+
+- AI-compressed semantic summaries of session activity
+- Automatic context injection into new sessions
+- `<private>` tags for content exclusion
+- Citation system referencing past observations by ID
+- Web viewer UI at localhost:37777
+- Notification integrations (Telegram, Discord, Slack)
+
+### Live Observer Architecture
+
+A dedicated observer AI watches each session in real-time, generating searchable observations with before-and-after context — capturing causality and decision chains, not just snapshots. Observations are auto-categorized by type (decisions, bugfixes, features, discoveries) and queryable by file path or semantic concept (e.g., "decisions about token refresh").
+
+### RAD Protocol (Coming Soon)
+
+**Real-Time Agent Data** — an open protocol standardizing how AI agents capture and retrieve working memory. Positioned as a counterpart to RAG (Retrieval Augmented Generation). Hook-based architecture for temporal awareness.
+
+### Adoption Considerations
+
+**Strengths**: Largest community memory solution (45.2K stars), progressive disclosure saves tokens, hybrid search (FTS5 + vector), multi-platform (CC + Gemini CLI), web UI for browsing history, [dedicated docs site][claude-mem-docs].
+
+**Risks**: AGPL-3.0 (copyleft — commercial use requires compliance). Ragtime subdirectory under separate PolyForm Noncommercial License. Heavy dependencies (Bun + uv + Chroma). Overlaps with CC's built-in memory system and ByteRover.
+
+Cross-ref: [CC-memory-system-analysis.md](../cc-native/context-memory/CC-memory-system-analysis.md) — CC's native memory for comparison
+
+---
+
+## MemPalace (milla-jovovich)
+
+**Repo**: [milla-jovovich/mempalace][mempalace] | **Stars**: 33.6K | **License**: MIT | **Version**: 3.0.0
+
+Local-first AI memory system storing conversation histories verbatim using a spatial "palace" metaphor. Achieved 96.6% R@5 on [LongMemEval benchmark][longmemeval] — the highest published result — without cloud dependencies.
+
+### Palace Architecture
+
+| Layer | Metaphor | Purpose |
+|-------|----------|---------|
+| **Wings** | Projects or people | Top-level partitioning |
+| **Rooms** | Topic categories | Within-wing organization |
+| **Halls** | Memory types | Cross-wing shared categories (facts, events, discoveries) |
+| **Closets** | Summaries | Pointers to original content |
+| **Drawers** | Verbatim files | Raw original data |
+| **Tunnels** | Cross-references | Links between rooms across wings |
+
+34% retrieval improvement over unstructured search from this hierarchical organization.
+
+### Memory Stack
+
+| Layer | Content | Size | Timing |
+|-------|---------|------|--------|
+| L0 | Identity/system prompt | ~50 tokens | Always loaded |
+| L1 | Critical facts | ~120 tokens (AAAK) | Always loaded |
+| L2 | Room recall (recent sessions) | On demand | When topic emerges |
+| L3 | Deep semantic search | On demand | When explicitly queried |
+
+### CC Integration
+
+```bash
+claude plugin marketplace add milla-jovovich/mempalace   # marketplace install
+claude mcp add mempalace -- python -m mempalace.mcp_server  # MCP install
+```
+
+19 MCP tools for search and memory operations. Also supports ChatGPT, Cursor, Gemini, and local models (Ollama, Mistral).
+
+### Adoption Considerations
+
+**Strengths**: Highest published LongMemEval score (96.6% raw mode, reproducible via `/benchmarks`). Free and fully local. ChromaDB + SQLite knowledge graph. Specialist agent support with per-agent memory wings.
+
+**Risks**: AAAK compression is lossy and regresses to 84.2% ([README candid note][mempalace]). Overlaps with CC's built-in memory, ByteRover, and Claude-Mem. ChromaDB dependency adds install complexity.
+
+Cross-ref: [CC-memory-system-analysis.md](../cc-native/context-memory/CC-memory-system-analysis.md) — CC's native memory for comparison
+
+---
+
+## MemSearch (zilliztech)
+
+**Repo**: [zilliztech/memsearch][memsearch] | **Stars**: ~2K | **License**: MIT | **Version**: v0.4.7
+
+Persistent, cross-session semantic memory for AI coding agents from the Milvus/Zilliz team. Stores conversation history as human-readable Markdown and indexes it with Milvus for hybrid vector + BM25 search. Unlike MCP-based memory tools, it ships as a **native Claude Code plugin** — "4 shell hooks + 1 skill + 1 watch process, no MCP, no sidecar service" ([CC plugin docs][memsearch-docs]).
+
+### Architecture
+
+- **Markdown is the source of truth** (`.memsearch/memory/*.md`); the Milvus index is a derived "shadow" cache, rebuildable at any time
+- **3-layer progressive retrieval**: search → expand → transcript
+- **Hybrid search**: dense vector embeddings + BM25 sparse + RRF reranking
+- **Local-first embeddings**: ONNX bge-m3 int8 by default (CPU, no API key); pluggable to OpenAI, Google, Voyage, Ollama
+- **SHA-256 dedup** avoids re-indexing unchanged content; a live file watcher auto-indexes edits
+- **Backend options**: Milvus Lite (embedded default), self-hosted Milvus, or Zilliz Cloud (free tier)
+
+### CC Integration
+
+```bash
+/plugin marketplace add zilliztech/memsearch
+/plugin install memsearch
+```
+
+The memory-recall skill runs in a `context: fork` subagent, so intermediate search results never pollute the main context — and because there is no MCP server, no tool definitions consume context tokens permanently. The same Markdown store is shared across Claude Code, OpenCode, Codex CLI, and OpenClaw.
+
+### Adoption Considerations
+
+**Strengths**: Zero permanent context overhead (no MCP tool defs); human-readable Markdown that survives index loss; local embeddings need no API key; one memory store across multiple agent CLIs.
+
+**Risks**: Overlaps with CC's built-in memory, Claude-Mem, MemPalace, and ByteRover — pick one. Milvus/Zilliz dependency for the index. Pre-1.0 (v0.4.7), active release cadence. Distinct from Zilliz's separate `claude-context` code-search MCP — do not conflate the two.
+
+Cross-ref: [CC-remote-access-landscape.md](../cc-native/ci-remote/CC-remote-access-landscape.md) — memsearch as a mobile/remote supporting tool
+
+## Cross-References
+
+- [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) — full cross-tool comparison + the rest of the CC tooling landscape
+- [agent-frameworks-infrastructure-landscape.md](../non-cc/agent-frameworks-infrastructure-landscape.md) — non-CC memory infrastructure (Mem0, Zep, Cognee, LangMem)
+
+[byterover]: https://github.com/campfirein/byterover-cli
+[byterover-paper]: https://arxiv.org/abs/2604.01599
+[claude-mem]: https://github.com/thedotmack/claude-mem
+[claude-mem-docs]: https://docs.claude-mem.ai/introduction
+[mempalace]: https://github.com/MemPalace/mempalace
+[longmemeval]: https://github.com/xiaowu0162/LongMemEval
+[memsearch]: https://github.com/zilliztech/memsearch
+[memsearch-docs]: https://zilliztech.github.io/memsearch/platforms/claude-code/

--- a/docs/cc-community/CC-usage-tooling-landscape.md
+++ b/docs/cc-community/CC-usage-tooling-landscape.md
@@ -1,0 +1,159 @@
+---
+title: CC Usage-Observability Tooling Landscape
+purpose: Token-usage and cost observability tools for Claude Code (and sibling agents) — CodeBurn, ccusage, Claude-Code-Usage-Monitor.
+category: landscape
+status: research
+created: 2026-06-14
+updated: 2026-06-14
+validated_links: 2026-06-14
+---
+
+**Status**: Research (informational)
+
+Tools that measure token usage and cost across coding-agent sessions. Split out of [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) (which keeps the cross-tool comparison table). They divide into **retrospective** measurement (CodeBurn cross-agent; ccusage CC/Codex-deep) and **predictive** monitoring (Claude-Code-Usage-Monitor). Where RTK reduces tokens *entering* context, these observe what was actually spent — optimization needs measurement.
+
+## CodeBurn (AgentSeal)
+
+**Repo**: [getagentseal/codeburn][codeburn] | **Stars**: 4K | **License**: MIT | **Latest**: Menubar v0.9.0 (2026-04-25) | **Stack**: TypeScript, Node.js 20+
+
+Local-first TUI dashboard that tracks AI coding token usage and cost across multiple coding agents. Reads session data directly from disk — no API keys, no proxy ([README][codeburn]).
+
+### Supported Agents
+
+Per the [README][codeburn]: Claude Code, Claude Desktop, Codex, Cursor, cursor-agent, OpenCode, Pi, OMP (Oh My Pi), GitHub Copilot.
+
+### Data Sources (Read-Only, On-Disk)
+
+| Agent | Path |
+|---|---|
+| Claude | `~/.claude/projects/` (JSONL) |
+| Cursor | `~/Library/Application Support/Cursor/` (SQLite, macOS) |
+| Codex | `~/.codex/sessions/` (JSONL with timestamped token events) |
+| OpenCode | `~/.local/share/opencode/` (SQLite) |
+| GitHub Copilot | `~/.copilot/session-state/` |
+
+### Features
+
+- **TUI dashboard** with gradient charts and responsive panels
+- **13 task categories** classified from tool patterns: Coding, Debugging, Feature Dev, Refactoring, Testing, Exploration, Planning, Delegation, Git Ops, Build/Deploy, Brainstorming, Conversation, General
+- **[`codeburn optimize`](https://github.com/getagentseal/codeburn#optimize)** — surfaces nine waste patterns (files re-read across sessions, low Read:Edit ratio, unused MCP servers, ghost agents/skills/slash commands, bloated `CLAUDE.md`, wasted bash output, cache-creation overhead, context-heavy and low-worth sessions) with copy-paste token/$ fixes ranked into an A–F health grade
+- **`codeburn compare`** — side-by-side model performance metrics
+- **`codeburn report -p 30days`** — rolling-window analysis
+- **`codeburn export`** — CSV/JSON across multiple time periods
+- **Subscription tracking** — Claude Pro/Max, Cursor Pro
+- **Currency conversion** — 162 ISO 4217 codes
+- **Pricing data** sourced from LiteLLM with 24h cached refresh; hardcoded fallbacks for Claude and GPT-5 to prevent fuzzy-match errors
+
+### Platform Support
+
+macOS (native menubar app via `codeburn menubar`), Linux (CLI), Windows (CLI; Cursor support requires `better-sqlite3`).
+
+### Installation
+
+```bash
+npm install -g codeburn
+# or run without installing:
+npx codeburn
+```
+
+### Key Differentiator
+
+Where RTK reduces tokens *entering* context and caveman compresses tokens *leaving* the assistant, **CodeBurn observes** what was actually spent — across agents, models, and projects. Complementary to both: optimization needs measurement. Local-first (no API keys, no telemetry) makes it usable in air-gapped or compliance-sensitive environments.
+
+Cross-ref: [CC-community-skills-landscape.md](CC-community-skills-landscape.md) — caveman (output compression skill); [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-analysis.md) — CC's native session-cost extraction via JSONL/jq
+
+---
+
+## ccusage (ryoppippi)
+
+**Repo**: [ryoppippi/ccusage][ccusage] | **Stars**: 13.4K | **License**: MIT | **Version**: v18.0.11 (2026-04-19) | **Stack**: TypeScript
+
+CLI tool that analyzes Claude Code / Codex CLI usage from local JSONL files. Established reference tool in the CC usage-tracking space — predates and is broader-adopted than CodeBurn ([README][ccusage]).
+
+### Reports
+
+- **Daily** — token usage and costs aggregated by date
+- **Monthly** — long-horizon aggregation
+- **Session** — usage grouped by conversation
+- **Blocks** — 5-hour billing windows (matches Anthropic's plan limits)
+- **Statusline** (Beta) — integration for hooks
+
+### Capabilities
+
+Per the [README][ccusage]:
+
+- **Model tracking** — per-model breakdown with `--breakdown`
+- **Cache token support** — tracks cache creation and cache read tokens separately (codeburn does not split these)
+- **Offline mode** — `--offline` uses pre-cached pricing (no network)
+- **MCP integration** — built-in MCP server for in-session queries
+- **Multi-instance** — group usage by project
+- **JSON export**
+
+### Installation
+
+```bash
+npx ccusage@latest          # recommended — always latest
+bunx ccusage
+pnpm dlx ccusage
+```
+
+Reads `~/.claude/projects/` JSONL by default; data path is configurable.
+
+### Key Differentiator
+
+Where CodeBurn is **multi-agent** (Claude/Codex/Cursor/OpenCode/Copilot in one TUI), ccusage is **CC/Codex-focused** with deeper CC-specific features (cache token split, MCP server, statusline hook). The two are complementary, not redundant: ccusage for CC-deep analysis and in-session queries via MCP; CodeBurn for cross-agent comparison.
+
+Cross-ref: [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-analysis.md) — manual JSONL/jq extraction patterns ccusage automates; [CC-hooks-system-analysis.md](../cc-native/configuration/CC-hooks-system-analysis.md) — statusline hook integration point
+
+---
+
+## Claude-Code-Usage-Monitor (Maciek-roboblog)
+
+**Repo**: [Maciek-roboblog/Claude-Code-Usage-Monitor][claude-monitor] | **Stars**: 7.8K | **License**: MIT | **Version**: v3.1.0 | **Stack**: Python 3.9+
+
+Real-time terminal monitor for Claude Code with **predictions and warnings**, distinguishing it from after-the-fact analyzers like ccusage / CodeBurn ([README][claude-monitor]).
+
+### Plan Support
+
+Per the [README][claude-monitor]:
+
+| Plan | Token limit |
+|---|---|
+| Pro | ~19,000 |
+| Max5 | ~88,000 |
+| Max20 | ~220,000 |
+| **Custom** | P90 auto-detection over recent session blocks |
+
+The Custom plan analyzes recent session blocks and computes a personalized 90th-percentile limit — adapts to actual usage patterns without manual configuration.
+
+### Views
+
+- **Realtime** — live progress bars + burn rate (default)
+- **Daily** — aggregated table
+- **Monthly** — long-trend analysis
+
+### Methodology
+
+P90 percentile analysis across all available session blocks; multi-session burn-rate analytics; intelligent session-limit detection. Stack: `pytz`, `rich`, `pydantic`, `numpy`, `pyyaml`, `sentry-sdk`.
+
+### Installation
+
+```bash
+uv tool install claude-monitor       # recommended
+pip install claude-monitor
+```
+
+### Key Differentiator
+
+Only tool in this category that does **prediction** (not just retrospective measurement). ccusage and CodeBurn answer "what did I spend?"; claude-monitor answers "will I exhaust my window?" Useful pairing: claude-monitor for live discipline, ccusage for historical trend, CodeBurn for cross-agent comparison.
+
+Cross-ref: [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-analysis.md) — Anthropic plan limits and 5-hour windows
+
+## Cross-References
+
+- [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) — full cross-tool comparison + the rest of the CC tooling landscape
+- [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-analysis.md) — CC's native session-cost extraction
+
+[codeburn]: https://github.com/getagentseal/codeburn
+[ccusage]: https://github.com/ryoppippi/ccusage
+[claude-monitor]: https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor

--- a/docs/cc-community/README.md
+++ b/docs/cc-community/README.md
@@ -8,7 +8,10 @@ Community-built skills, plugins, tooling, workflows, and patterns for Claude Cod
 |----------|----------|
 | [CC-community-skills-landscape.md](CC-community-skills-landscape.md) | Skill libraries: gstack, pm-skills, claude-code-best-practice, BHIL, claude-howto, dispatch, superpowers, agent-skills, caveman |
 | [CC-community-plugins-landscape.md](CC-community-plugins-landscape.md) | Plugin catalogs: awesome-claude-code, awesome-claude-code-plugins |
-| [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) | Dev tooling: RTK, GSD, everything-claude-code, Boucle, OpenHarness, ByteRover, claude-mem, CC Switch, opensrc, awesome-design-md, Graphify, MemPalace, Code-Review-Graph, CodeBurn, ccusage, Claude-Code-Usage-Monitor |
+| [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) | Dev tooling + cross-tool comparison: RTK, GSD, everything-claude-code, Boucle, OpenHarness, CC Switch, opensrc, awesome-design-md |
+| [CC-memory-tooling-landscape.md](CC-memory-tooling-landscape.md) | Persistent memory: ByteRover, Claude-Mem, MemPalace, MemSearch |
+| [CC-code-tooling-landscape.md](CC-code-tooling-landscape.md) | Code analysis: Graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP, Repomix, code2prompt |
+| [CC-usage-tooling-landscape.md](CC-usage-tooling-landscape.md) | Usage observability: CodeBurn, ccusage, Claude-Code-Usage-Monitor |
 | [CC-community-reimplementations-landscape.md](CC-community-reimplementations-landscape.md) | Reimplementations: claw-code, CLAURST (expanded), learn-claude-code, openclaude, zackautocracy/claude-code (with provenance classification) |
 | [CC-reverse-engineering-landscape.md](CC-reverse-engineering-landscape.md) | RE tools: system prompts, binary analysis, env vars, API interception, ccunpacked.dev |
 | [CC-office-worker-workflows.md](CC-office-worker-workflows.md) | Office workflows: invoices, documents, email, financial reporting + multi-agent orchestrators (Vibe Kanban, Conductor, tmux tools) |

--- a/docs/cc-native/ci-remote/CC-remote-access-landscape.md
+++ b/docs/cc-native/ci-remote/CC-remote-access-landscape.md
@@ -168,7 +168,7 @@ Tools that complement any remote access method ([source][zilliz]):
 | Tool | Purpose | Setup | Notes |
 | ---- | ------- | ----- | ----- |
 | **Typeless** | Voice-to-text for prompts | Mobile app | ~4x faster than phone typing; replaces keyboard for prompt input |
-| **memsearch** | Persistent searchable recall across sessions/devices | CC plugin (hooks + skill, no MCP) | Markdown store + Milvus hybrid vector+BM25 search; full entry in [CC-community-tooling-landscape.md](../../cc-community/CC-community-tooling-landscape.md#memsearch-zilliztech) |
+| **memsearch** | Persistent searchable recall across sessions/devices | CC plugin (hooks + skill, no MCP) | Markdown store + Milvus hybrid vector+BM25 search; full entry in [CC-memory-tooling-landscape.md](../../cc-community/CC-memory-tooling-landscape.md#memsearch-zilliztech) |
 | **cc-tmux-worktree-orchestration** | Parallel CC instances via git worktrees | CC plugin | `/tmux-worktree-split login signup dashboard` runs 3 agents simultaneously |
 
 ## See Also

--- a/docs/cc-native/configuration/CC-model-provider-configuration.md
+++ b/docs/cc-native/configuration/CC-model-provider-configuration.md
@@ -50,23 +50,9 @@ Opus 4.6 and Sonnet 4.6 support `low`/`medium`/`high`/`max` (no `xhigh`). Settin
 
 **Verified 2026-06-11.** Effort availability and defaults are model-generation-specific and shift over time; `xhigh` is gated on the `xhigh_effort` capability (CC v2.1.111+), and `xhigh`-capable models require recent CC builds (Opus 4.8 → v2.1.154+, Fable 5 → v2.1.170+) ([source][cc-effort]).
 
-### Claude Fable 5 (newest model)
+### Newest Model (Fable 5)
 
-Claude Fable 5 (`claude-fable-5`) — Anthropic's most capable widely released model, built for complex, long-running agentic work — is selectable in CC via `/model` or `ANTHROPIC_MODEL=claude-fable-5`. Generally available on the Claude API and major clouds since 2026-06-09 ([source][fable5-intro]).
-
-| Property | Value |
-| -------- | ----- |
-| Model ID | `claude-fable-5` |
-| Context / max output | 1M tokens (default) / 128K tokens ([source][models-overview]) |
-| Pricing | $10 / $50 per MTok (input / output) — above Opus-tier's $5 / $25 ([source][models-pricing]) |
-| Thinking | Adaptive only, always on (`thinking: disabled` unsupported); tune depth with `CLAUDE_CODE_EFFORT_LEVEL` / effort `low`–`xhigh`/`max` ([source][fable5-intro]) |
-
-CC-relevant caveats ([source][fable5-intro]):
-
-- **New tokenizer** (the one introduced with Opus 4.7): the same text is ~30% more tokens than on pre-4.7 models — re-baseline cost and `CLAUDE_CODE_MAX_OUTPUT_TOKENS` expectations.
-- **`refusal` stop reason**: safety classifiers may decline a request as a successful HTTP 200 (not an error); plan for refusal handling and fallback to another model.
-- **30-day data retention required** — not available to zero-data-retention orgs.
-- **CC plan access** (per the in-product `/model` notice, 2026-06): included in Claude plan limits until 2026-06-22, after which it continues via usage credits.
+Claude **Fable 5** (`claude-fable-5`) is the newest model, selectable in CC via `/model` or `ANTHROPIC_MODEL=claude-fable-5`. For its model card (context, pricing, tokenizer/refusal caveats, CC plan access) and a free-tier/OSS provider snapshot, see [CC-models-reference.md](CC-models-reference.md).
 
 ## API Key & Endpoint
 
@@ -333,36 +319,9 @@ When routing through gateways, additionally set ([source][cc-settings]):
 | **Per-task local routing / cost control** | Claude Code Router (CCR) | Medium (npm + `ccr start`) |
 | **EU / Swiss data sovereignty, OSS models** | Infomaniak AI (+ proxy for CC; native in OpenCode) | Medium (OpenAI→Anthropic proxy) |
 
-## Free-Tier & OSS Provider Reference
-
-Snapshot of inference providers with free or trial tiers — useful when routing CC (via proxy) or sibling agents (OpenCode, n8n, PydanticAI) to non-Anthropic models. Free-tier terms and model ids change frequently: **the rows below are a February 2026 snapshot** (except Infomaniak, verified June 2026); confirm current offerings on each provider's site before relying on them.
-
-| Provider | Free Tier | Example Model (API ID) | Context | Output | Tools | Notes / Limit |
-| --- | --- | --- | --- | --- | --- | --- |
-| **infomaniak** | 1M credits, 1-mo trial | OSS via OpenAI API: `qwen3`, `mistral3`, `gemma3`, `llama3` | model-dependent | — | Yes | EU/Swiss-hosted; OpenAI-compatible (proxy for CC) |
-| **gemini** | Truly free | `gemini-2.0-flash` | 1M | 8K | Yes | 15 RPM, ~1.5K RPD |
-| **github** | Truly free | `gpt-4.1-mini` | 1M | 32K | Yes | 15 RPM, ~150 RPD |
-| **cerebras** | Truly free | `gpt-oss-120b` | 128K | 8K | Yes | 30 RPM, 1M TPD |
-| **groq** | Truly free | `llama-3.3-70b-versatile` | 131K | 32K | Yes | 30 RPM, 1K RPD |
-| **mistral** | Truly free | `open-mistral-nemo` | 128K | 4K | Yes | 1 RPS, 1B tokens/mo |
-| **openrouter** | Truly free | `qwen/qwen3-next-80b-a3b-instruct:free` | 262K | 8K | Yes | 20 RPM, 50 RPD |
-| **cohere** | Truly free | `command-a-03-2025` | 256K | 8K | Yes | 20 RPM, 1K calls/mo |
-| **deepseek** | 5M free tokens | `deepseek-chat` | 128K | 8K | Yes | Spend-limited |
-| **grok** | $25 trial credit | `grok-3-mini` | 131K | 32K | Yes | Spend-limited |
-| **sambanova** | $5 trial + limited free | `Meta-Llama-3.3-70B-Instruct` | 128K | 8K | Yes | Free: 40 RPD |
-| **nebius** | $1 trial credit | `meta-llama/Meta-Llama-3.1-70B-Instruct` | 128K | 8K | Yes | $1 credit |
-| **fireworks** | $1 trial credit | `accounts/fireworks/models/llama-v3p3-70b-instruct` | 131K | 8K | Yes | $1 credit |
-| **together** | No free tier | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | 128K | 8K | Yes | $5 min purchase |
-| **perplexity** | No free API tier | `sonar` | 127K | 4K | Limited | Credits required |
-| **huggingface** | ~$0.10/mo | `meta-llama/Meta-Llama-3.3-70B-Instruct` | 128K | 8K | Yes | ~10 calls on free |
-| **ollama** | Always free (local) | `llama3.3:70b` | 128K | 8K | Yes | Hardware-bound (see Local Models above) |
-
-> **OpenAI-compatible tool calling**: some providers reject strict tool-definition schemas — `groq`, `cerebras`, `fireworks`, `together`, `sambanova`. With PydanticAI, set `OpenAIModelProfile(openai_supports_strict_tool_definition=False)` for these.
-
-(`restack`, which appears on some provider lists, is a workflow-orchestration platform — not an inference provider; it proxies to others.)
-
 ## Cross-References
 
+- [CC-models-reference.md](CC-models-reference.md) — Fable 5 model card + free-tier/OSS provider reference table
 - [CC-cli-reference.md](CC-cli-reference.md) — canonical flag definitions (`--model`, `--effort`, `--fallback-model`, `--betas`)
 - [CC-env-vars-reference.md](CC-env-vars-reference.md) — env var reference for `ANTHROPIC_MODEL`, `CLAUDE_CODE_EFFORT_LEVEL`, etc.
 
@@ -371,8 +330,6 @@ Snapshot of inference providers with free or trial tiers — useful when routing
 - [CC Settings — Environment Variables][cc-settings]
 - [CC Model Configuration — Effort Levels][cc-effort]
 - [CC Model Configuration — ultrathink][cc-ultrathink]
-- [Anthropic — Introducing Claude Fable 5 & Mythos 5][fable5-intro]
-- [Anthropic — Models Overview][models-overview]
 - [Anthropic — Pricing][models-pricing]
 - [OpenRouter — Claude Code Integration][openrouter]
 - [Ollama — Claude Code with Anthropic API Compatibility][ollama-claude]
@@ -400,8 +357,6 @@ Snapshot of inference providers with free or trial tiers — useful when routing
 [bifrost]: https://www.getmaxim.ai/articles/running-non-anthropic-models-in-claude-code-via-an-enterprise-ai-gateway/
 [cc-router]: https://github.com/musistudio/claude-code-router
 [local-setup]: https://medium.com/@luongnv89/run-claude-code-on-local-cloud-models-in-5-minutes-ollama-openrouter-llama-cpp-6dfeaee03cda
-[fable5-intro]: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
-[models-overview]: https://platform.claude.com/docs/en/about-claude/models/overview
 [models-pricing]: https://platform.claude.com/docs/en/about-claude/pricing
 [infomaniak-ai]: https://www.infomaniak.com/en/hosting/ai-services/open-source-models
 [infomaniak-translategemma]: https://huggingface.co/Infomaniak-AI/vllm-translategemma-27b-it

--- a/docs/cc-native/configuration/CC-models-reference.md
+++ b/docs/cc-native/configuration/CC-models-reference.md
@@ -1,0 +1,70 @@
+---
+title: CC Models & Free-Tier Provider Reference
+source: https://platform.claude.com/docs/en/about-claude/models/overview, https://platform.claude.com/docs/en/about-claude/pricing
+purpose: Descriptive reference for the newest Claude model (Fable 5) and a snapshot of free-tier / OSS inference providers — the model/provider facts behind CC-model-provider-configuration.md.
+created: 2026-06-14
+updated: 2026-06-14
+validated_links: 2026-06-14
+---
+
+**Status**: Reference (descriptive). For *how to configure* CC against these models/providers (env vars, endpoints, gateways), see [CC-model-provider-configuration.md](CC-model-provider-configuration.md).
+
+## Claude Fable 5 (newest model)
+
+Claude Fable 5 (`claude-fable-5`) — Anthropic's most capable widely released model, built for complex, long-running agentic work — is selectable in CC via `/model` or `ANTHROPIC_MODEL=claude-fable-5`. Generally available on the Claude API and major clouds since 2026-06-09 ([source][fable5-intro]).
+
+| Property | Value |
+| -------- | ----- |
+| Model ID | `claude-fable-5` |
+| Context / max output | 1M tokens (default) / 128K tokens ([source][models-overview]) |
+| Pricing | $10 / $50 per MTok (input / output) — above Opus-tier's $5 / $25 ([source][models-pricing]) |
+| Thinking | Adaptive only, always on (`thinking: disabled` unsupported); tune depth with `CLAUDE_CODE_EFFORT_LEVEL` / effort `low`–`xhigh`/`max` ([source][fable5-intro]) |
+
+CC-relevant caveats ([source][fable5-intro]):
+
+- **New tokenizer** (the one introduced with Opus 4.7): the same text is ~30% more tokens than on pre-4.7 models — re-baseline cost and `CLAUDE_CODE_MAX_OUTPUT_TOKENS` expectations.
+- **`refusal` stop reason**: safety classifiers may decline a request as a successful HTTP 200 (not an error); plan for refusal handling and fallback to another model.
+- **30-day data retention required** — not available to zero-data-retention orgs.
+- **CC plan access** (per the in-product `/model` notice, 2026-06): included in Claude plan limits until 2026-06-22, after which it continues via usage credits.
+
+## Free-Tier & OSS Provider Reference
+
+Snapshot of inference providers with free or trial tiers — useful when routing CC (via proxy) or sibling agents (OpenCode, n8n, PydanticAI) to non-Anthropic models. Free-tier terms and model ids change frequently: **the rows below are a February 2026 snapshot** (except Infomaniak, verified June 2026); confirm current offerings on each provider's site before relying on them.
+
+| Provider | Free Tier | Example Model (API ID) | Context | Output | Tools | Notes / Limit |
+| --- | --- | --- | --- | --- | --- | --- |
+| **infomaniak** | 1M credits, 1-mo trial | OSS via OpenAI API: `qwen3`, `mistral3`, `gemma3`, `llama3` | model-dependent | — | Yes | EU/Swiss-hosted; OpenAI-compatible (proxy for CC) |
+| **gemini** | Truly free | `gemini-2.0-flash` | 1M | 8K | Yes | 15 RPM, ~1.5K RPD |
+| **github** | Truly free | `gpt-4.1-mini` | 1M | 32K | Yes | 15 RPM, ~150 RPD |
+| **cerebras** | Truly free | `gpt-oss-120b` | 128K | 8K | Yes | 30 RPM, 1M TPD |
+| **groq** | Truly free | `llama-3.3-70b-versatile` | 131K | 32K | Yes | 30 RPM, 1K RPD |
+| **mistral** | Truly free | `open-mistral-nemo` | 128K | 4K | Yes | 1 RPS, 1B tokens/mo |
+| **openrouter** | Truly free | `qwen/qwen3-next-80b-a3b-instruct:free` | 262K | 8K | Yes | 20 RPM, 50 RPD |
+| **cohere** | Truly free | `command-a-03-2025` | 256K | 8K | Yes | 20 RPM, 1K calls/mo |
+| **deepseek** | 5M free tokens | `deepseek-chat` | 128K | 8K | Yes | Spend-limited |
+| **grok** | $25 trial credit | `grok-3-mini` | 131K | 32K | Yes | Spend-limited |
+| **sambanova** | $5 trial + limited free | `Meta-Llama-3.3-70B-Instruct` | 128K | 8K | Yes | Free: 40 RPD |
+| **nebius** | $1 trial credit | `meta-llama/Meta-Llama-3.1-70B-Instruct` | 128K | 8K | Yes | $1 credit |
+| **fireworks** | $1 trial credit | `accounts/fireworks/models/llama-v3p3-70b-instruct` | 131K | 8K | Yes | $1 credit |
+| **together** | No free tier | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | 128K | 8K | Yes | $5 min purchase |
+| **perplexity** | No free API tier | `sonar` | 127K | 4K | Limited | Credits required |
+| **huggingface** | ~$0.10/mo | `meta-llama/Meta-Llama-3.3-70B-Instruct` | 128K | 8K | Yes | ~10 calls on free |
+| **ollama** | Always free (local) | `llama3.3:70b` | 128K | 8K | Yes | Hardware-bound (local) |
+
+> **OpenAI-compatible tool calling**: some providers reject strict tool-definition schemas — `groq`, `cerebras`, `fireworks`, `together`, `sambanova`. With PydanticAI, set `OpenAIModelProfile(openai_supports_strict_tool_definition=False)` for these.
+
+(`restack`, which appears on some provider lists, is a workflow-orchestration platform — not an inference provider; it proxies to others.)
+
+## Cross-References
+
+- [CC-model-provider-configuration.md](CC-model-provider-configuration.md) — how to point CC at these models/providers (env vars, endpoints, gateways, decision matrix)
+
+## References
+
+- [Anthropic — Introducing Claude Fable 5 & Mythos 5][fable5-intro]
+- [Anthropic — Models Overview][models-overview]
+- [Anthropic — Pricing][models-pricing]
+
+[fable5-intro]: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
+[models-overview]: https://platform.claude.com/docs/en/about-claude/models/overview
+[models-pricing]: https://platform.claude.com/docs/en/about-claude/pricing


### PR DESCRIPTION
## Summary

Implements the two doc-split advisories from #237 — breaking up files that mixed multiple topics into focused, scannable docs.

**Model/provider split** (`docs(config)`)
- Extracted descriptive model facts out of `CC-model-provider-configuration.md` (which keeps CC-specific config: env vars, endpoints, gateways, effort levels, decision matrix)
- New `CC-models-reference.md` = Fable 5 model card + free-tier/OSS provider reference table
- Pruned now-unused link refs (kept `models-pricing`, still used)

**Tooling-landscape split** (`docs(tooling)`)
- `CC-community-tooling-landscape.md` held 22 tools across distinct categories. Detailed per-tool entries split into three focused docs; the index keeps the cross-tool **Comparison + Sources** tables plus the context/harness/provider tools (RTK, GSD, everything-claude-code, Boucle, OpenHarness, CC Switch, opensrc, awesome-design-md):
  - `CC-memory-tooling-landscape.md` — ByteRover, Claude-Mem, MemPalace, MemSearch
  - `CC-code-tooling-landscape.md` — Graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP, Repomix, code2prompt
  - `CC-usage-tooling-landscape.md` — CodeBurn, ccusage, Claude-Code-Usage-Monitor
- Repointed inbound anchors (`#memsearch-zilliztech`, `#codeburn-agentseal`); added README index rows

## Verification
- `make check_docs` (markdownlint): **0 errors / 140 files** (no unused/missing link-defs)
- `make check_links` (lychee): **no broken internal links/anchors**; the only failure is a transient pre-existing external 500 (`opentools.ai`, in an untouched doc)

## Commits (by topic)
1. docs(config): extract general model/provider reference from config doc
2. docs(tooling): split memory/code/usage tools into topic landscapes

Generated with Claude <noreply@anthropic.com>