### PR TITLE
docs(learnings): record subagent ref-sweep false-negative pattern

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -26,3 +26,10 @@ description: Non-obvious patterns that prevent repeated mistakes across sprints
 - **Problem**: Git operations fail with `error: unable to unlink old '<file>': Device or resource busy` on project-root config files (varies by project: `CHANGELOG.md`, `README.md`, `pyproject.toml`, `Makefile`, `.claude/settings.json`). Server-side merges succeed but local FF fails; working tree desyncs from HEAD.
 - **Solution**: `git update-ref` + `git reset HEAD` to move branch pointer without checkout; `git restore` for unlocked files; Claude Code Edit/Write tool for busy ones (overwrites via `O_TRUNC`, bypasses `unlink(2)`).
 - **References**: [docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md](docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md) (canonical, Friction 3), [anthropics/claude-code#17727](https://github.com/anthropics/claude-code/issues/17727).
+
+### Subagent reference sweeps can return false negatives — verify before deleting
+
+- **Context**: Before deleting or moving docs, dispatching a subagent (Explore / general-purpose) to grep the repo for inbound references.
+- **Problem**: A subagent sweep confidently reported "no live-doc references" to files queued for deletion. In fact ~28 inbound links existed (a metrics doc deferred to the archive landscapes at ~22 lines; the observability doc linked one too). Acting on the sweep alone would have shipped broken links — and because `lychee.toml` excludes `docs/archive/`, links *into* the archive were never CI-checked, so the breakage would have surfaced only after deletion made them dangle elsewhere.
+- **Solution**: Treat subagent ref-sweeps as advisory, not authoritative. Cross-check the result against references you have already read directly; calibrate the sweep by naming known hits and confirming it finds them. Repoint inbound refs to their new homes, then run `make check_links` (lychee) — it is the backstop that catches anything the sweep missed before the change merges.
+- **References**: [lychee.toml](lychee.toml) (excludes `docs/archive/` — repoint archive-bound links to live homes before deleting), [PR #237](https://github.com/qte77/ai-agents-research/pull/237).


### PR DESCRIPTION
## Summary

Promotes a learning from the archive-integration work (PR #237) to `AGENT_LEARNINGS.md` per the compound-learning rule.

**Pattern**: a subagent reference-sweep reported "no inbound references" to files queued for deletion when ~28 actually existed. Cross-checking against directly-read refs caught it. The entry records the verify-before-delete approach and the gotcha that `lychee.toml` excludes `docs/archive/` (so archive-bound links aren't CI-checked — repoint before deleting).

## Verification
- markdownlint: clean (note: AGENT_LEARNINGS.md is outside the `check_docs` glob; entry follows the file's existing format)
- lychee: the two added links (`lychee.toml`, PR #237) resolve

Generated with Claude <noreply@anthropic.com>