### PR TITLE
docs(research): map deep-research agents to CC /deep-research harness

### DIFF
--- a/docs/cc-community/CC-research-agents-landscape.md
+++ b/docs/cc-community/CC-research-agents-landscape.md
@@ -1,11 +1,11 @@
 ---
 title: Research Agents & Discovery Platforms Landscape
-purpose: Catalog of autonomous research agents, scientific-domain models, and literature discovery/analysis platforms for research automation — restored and refreshed from the archived research-agents landscape.
+purpose: Catalog of autonomous research agents, scientific-domain models, and literature discovery/analysis platforms for research automation, with a mapping of deep-research agents to Claude Code's bundled /deep-research harness.
 category: landscape
 status: research
 created: 2026-06-14
 updated: 2026-06-14
-validated_links: 2026-03-12
+validated_links: 2026-06-14
 ---
 
 **Status**: Research (informational)
@@ -30,6 +30,8 @@ Agents that conduct multi-step research and generate research outputs.
 - [CMBAgent](https://github.com/CMBAgents/cmbagent) — AG2-based autonomous "Planning & Control" multi-agent system; 1st place, NeurIPS 2025 Fair Universe Competition.
 - [OpenAI Deep Research](https://openai.com/index/introducing-deep-research/) — agentic ChatGPT capability; API as `o3-deep-research` ($10/$40 per MTok, 200K ctx, MCP connectors), led HLE at launch.
 - [Gemini Deep Research](https://blog.google/technology/developers/deep-research-agent-gemini-api/) — Gemini 3 Pro long-horizon agent via the Interactions API (`deep-research-pro-preview-12-2025`); 46.4% HLE, 66.1% DeepSearchQA, background execution + remote MCP.
+- [AutoScientists (mims-harvard)](https://github.com/mims-harvard/AutoScientists) — decentralized team of AI agents for long-running computational-science experiments, self-organizing around promising hypotheses; **packaged as Claude Code subagents** coordinating via a local ClawInstitute server (no central planner). BioML-Bench 74.4% mean leaderboard percentile (629★, Python) — the most direct CC-harness tie-in here.
+- [local-deep-research (LearningCircuit)](https://github.com/LearningCircuit/local-deep-research) — LLM-agnostic deep-research assistant: local (Ollama/LM Studio/llama.cpp) + cloud (Claude, OpenAI, Gemini, OpenRouter), LangGraph agent strategies, 20+ search sources (arXiv/PubMed/SearXNG/…), cited reports; 95.7% SimpleQA. MIT, 8.5k★, v1.7.0 (2026-06) — a close OSS parallel to CC's `/deep-research`.
 
 **Domain-specific science agents**: [Coscientist (CMU, Nature)](https://www.nature.com/articles/s41586-023-06792-0) — GPT-4 chemistry agent driving cloud-lab experiments; [ChemCrow](https://arxiv.org/abs/2304.05376) — GPT-4 + 18 chemistry tools; [BioPlanner](https://arxiv.org/abs/2310.10632) — biology protocol generation (BIOPROT, 9K+ protocols); [BioChatter](https://biochatter.org/) — privacy-preserving biomedical conversational-AI framework.
 
@@ -65,8 +67,25 @@ Literature search, paper analysis, and discovery (assistive, not autonomous cond
 - [Paper2Agent](https://arxiv.org/abs/2509.06917) — converts a paper + codebase into an interactive **MCP-server agent** (auto-generated, test-refined); integrates with Claude Code. Cross-ref: [CC-ai-security-governance-analysis.md § MCP Ecosystem Security](CC-ai-security-governance-analysis.md#mcp-ecosystem-security) for MCP-server hardening.
 - [PaperQA2](https://github.com/Future-House/paper-qa) — superhuman scientific-literature RAG (beats PhD/postdoc on LitQA2); powers WikiCrow and ContraCrow ([paper](https://arxiv.org/abs/2312.07559)).
 
+## Mapping to the CC `/deep-research` Harness
+
+Claude Code ships one bundled workflow, [`/deep-research`](../cc-native/agents-skills/CC-dynamic-workflows-analysis.md#bundled-workflow-deep-research): fan-out web searches across angles → fetch + cross-check sources → vote per claim → cited report (unsupported claims dropped). How the deep-research-style agents above relate to that pattern:
+
+| Agent | Overlap with `/deep-research` | Beyond / gap vs the CC workflow | CC-based? |
+|---|---|---|---|
+| **local-deep-research** | Same fan-out → search → cross-check → cited-report loop | Local/offline LLMs, 20+ specialized sources (PubMed/arXiv/SearXNG), persistence + encryption | No (LangGraph; runs Claude as a model option) |
+| **AutoScientists** | Multi-agent fan-out + peer-critique ≈ cross-check/vote | Runs *experiments* (code/compute), not just literature; computational-science domain | **Yes** — built on CC subagents |
+| **GPT-Researcher** | Multi-agent web+local research → cited long-form report | Self-hosted LangGraph with explicit planner/executor roles | No |
+| **OpenAI Deep Research** | Agentic multi-step browse → cited analyst report | Hosted `o3`-tuned browsing model, RL-trained; API-gated, not local | No |
+| **Gemini Deep Research** | Iterative plan → search → synthesize cited report | Gemini-3-Pro hosted, server-side background runs | No |
+| **STORM / Co-STORM** | Multi-perspective fan-out → cited synthesis | Perspective-simulation step; tuned for Wikipedia-style articles | No |
+| **FutureHouse / PaperQA2** | Retrieval + cross-check, citation-grounded | Scientific-literature RAG (not open web); benchmarked superhuman retrieval | No |
+
+**Takeaway**: CC's `/deep-research` is a general open-web harness; the third-party agents specialize it — local/private (local-deep-research), scientific-corpus (PaperQA2/FutureHouse), or autonomous experimentation (AutoScientists, the one actually built on CC). AutoScientists is the clearest reference design for extending CC's harness toward long-running scientific work.
+
 ## Cross-References
 
 - [agent-frameworks-infrastructure-landscape.md](../non-cc/agent-frameworks-infrastructure-landscape.md) — agent frameworks, orchestration, memory infrastructure
 - [CC-evaluation-data-resources-landscape.md](CC-evaluation-data-resources-landscape.md) — evaluation frameworks, benchmarks, datasets
 - [rxiv-agentic-papers.md](../research/rxiv-agentic-papers.md) — agentic-AI research papers (auto-generated pipeline)
+- [CC-dynamic-workflows-analysis.md § Bundled Workflow: /deep-research](../cc-native/agents-skills/CC-dynamic-workflows-analysis.md#bundled-workflow-deep-research) — CC's first-party deep-research harness these agents map to

--- a/docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md
+++ b/docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md
@@ -64,6 +64,8 @@ The one built-in workflow Claude Code ships ([bundled workflows][cc-bundled]):
 
 **Workflow vs harness**: `/deep-research` is the **only** bundled workflow Claude Code currently ships, and it is a *workflow* — not a skill. "Harness" describes its *pattern* (fan-out → cross-check → vote → synthesize), not its mechanism; the mechanism is a dynamic workflow. A project may also define a same-named custom `deep-research` **skill** that labels itself a "harness" and mirrors the behavior, but the first-party artifact is the bundled workflow.
 
+**Third-party equivalents**: for deep-research agents outside CC (local-deep-research, GPT-Researcher, OpenAI/Gemini Deep Research, AutoScientists — the last built *on* CC subagents) mapped to this fan-out → cross-check → synthesize pattern, see [CC-research-agents-landscape.md § Mapping to the CC /deep-research Harness](../../cc-community/CC-research-agents-landscape.md#mapping-to-the-cc-deep-research-harness).
+
 ## Managing Runs (`/workflows`)
 
 Runs execute in the background, so the session stays responsive. Run `/workflows` to **list running and completed runs** and open a progress view showing each phase with its agent count, token total, and elapsed time; a one-line summary also appears in the task panel below the input box ([watch the run][cc-watch]).


### PR DESCRIPTION
Closes the remaining gap in **#219** on the merged `CC-research-agents-landscape.md` (the catalog half was already done):

- **Seed agents added**: AutoScientists (mims-harvard — *packaged as Claude Code subagents* via a local ClawInstitute server; BioML-Bench 74.4%) and local-deep-research (LearningCircuit — LLM-agnostic incl. Claude, LangGraph, 20+ sources, 95.7% SimpleQA, MIT).
- **New "Mapping to the CC `/deep-research` Harness" section**: a table relating the deep-research agents (local-deep-research, AutoScientists, GPT-Researcher, OpenAI/Gemini Deep Research, STORM, FutureHouse/PaperQA2) to CC's bundled `/deep-research` workflow (fan-out → cross-check → vote → synthesize): overlap / gap / is-it-CC-based.
- **Bidirectional cross-ref** with `CC-dynamic-workflows-analysis.md § Bundled Workflow: /deep-research`.

## Verification
- markdownlint: 0 errors / 140 files
- lychee: 0 errors (both cross-file anchors + new GitHub URLs resolve)

Closes #219

Generated with Claude <noreply@anthropic.com>