### PR TITLE
docs(plans): establish docs/plans/ convention + triage open tasks to issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,7 @@ ai-agents-research/
     cc-community/                      # Community skills, plugins, tooling, CLAUDE.md patterns
     sdlc-lcm/                          # SDLC/lifecycle management specs
     research/                          # Auto-generated cumulative rxiv agentic-AI paper index
+    plans/                             # Plan/design docs (durable plan-mode output; backlog = GitHub Issues)
     todo/                              # Agents-eval era docs pending review (analysis, landscape, best-practices, research)
   triage/                              # Auto-generated monitor outputs
   .github/                             # CI automation (monitors, scripts, templates)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Currency is maintained by four cron-driven monitors — see [How it stays curren
 | [`docs/archive/`](docs/archive/) | Agents-eval era docs retained for reference (frameworks/infrastructure, evaluation/data resources, further reading, adoption plans) |
 | [`docs/learnings/`](docs/learnings/) | Cross-repo compound learnings hub — recurring patterns from live development across the qte77 ecosystem |
 | [`docs/research/`](docs/research/) | Auto-generated cumulative index of agentic-AI papers from the rxiv eval pipeline |
+| [`docs/plans/`](docs/plans/) | Plan/design docs (durable plan-mode output); backlog/roadmap lives in GitHub Issues |
 | [`triage/`](triage/) | Auto-generated monitor outputs: outage archive, changelog triage, community triage, rxiv paper triage |
 | [`.github/`](.github/) | Monitor workflows, scripts, composite actions, state files |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ ai-agents-research/
 │   ├── learnings/             # Cross-repo compound learnings hub (CRLA write-back target)
 │   │   └── per-repo/          # Per-repo pattern distillations
 │   ├── research/              # Auto-generated cumulative agentic-AI paper index (rxiv eval)
+│   ├── plans/                 # Plan/design docs (durable plan-mode output; backlog = GitHub Issues)
 │   └── archive/               # Retired Agents-eval era docs
 ├── triage/                    # Auto-generated monitor outputs (at repo root)
 │   ├── cc-changelog/          # CC changelog + native-sources triage
@@ -45,6 +46,12 @@ ai-agents-research/
     ├── scripts/               # Monitor scripts + shared lib/monitor_utils.py
     └── state/                 # Per-monitor fingerprint files (committed)
 ```
+
+## Planning & Roadmap
+
+- **Backlog / roadmap** — [GitHub Issues](https://github.com/qte77/ai-agents-research/issues) are the single source of truth for planned and deferred work (per #191; the former static `docs/TODO.md` was retired to avoid CHANGELOG/issue duplication).
+- **Design docs** — `docs/plans/` holds durable plan/design docs (the saved output of plan-mode work); each links its tracking issue. See [docs/plans/README.md](plans/README.md).
+- **Landed work** — `CHANGELOG.md` `[Unreleased]` records what has merged.
 
 ## Analysis Format Convention
 

--- a/docs/plans/2026-06-14-planning-workflow-and-open-task-triage.md
+++ b/docs/plans/2026-06-14-planning-workflow-and-open-task-triage.md
@@ -1,0 +1,35 @@
+---
+title: Planning Workflow + Open-Task Triage
+status: done
+issue: "#242, #243"
+created: 2026-06-14
+updated: 2026-06-14
+---
+
+**Status**: Done — establishes the `docs/plans/` convention and triages the session's untracked open tasks into GitHub Issues.
+
+## Context
+
+A 2026-06-14 working session (research integration + archive sweep + doc splits + PR-backlog cleanup) produced several deferred items and raised the question of where to durably record plans. Recon found the repo had **already** made **GitHub Issues the authoritative backlog/roadmap** ([#191](https://github.com/qte77/ai-agents-research/issues/191), 2026-05-26 — which deleted the static `docs/TODO.md` to stop CHANGELOG/issue duplication). There was no `docs/plans/`, no roadmap doc, and no "plans" slot in the doc hierarchy.
+
+## Decision
+
+- `docs/plans/` = home for **plan/design docs** (this is the first). It is **not** a task list.
+- **GitHub Issues stay the authoritative backlog/roadmap.** Untracked deferrals become tracker issues.
+- Plan docs ↔ issues cross-link. See [README.md](README.md) for the convention.
+- Registered `docs/plans/` in [docs/architecture.md](../architecture.md) (hierarchy + "Planning & Roadmap"), `CONTRIBUTING.md`, and `README.md` so it isn't mistaken for `docs/todo/`-style staging.
+
+## Open tasks triaged → issues
+
+| Task | Issue |
+|---|---|
+| Langtrace URL relocated (404) — update the entry in `CC-agent-observability-methods-analysis.md` + drop the `lychee.toml` exclude added in #237 | [#242](https://github.com/qte77/ai-agents-research/issues/242) |
+| Re-apply un-merged PR #206 content (CodeBurn optimize-rules → `CC-usage-tooling-landscape.md`; GitHub-App provenance → `CC-github-actions-analysis.md`; HuggingScience `llms-full.txt` example → `CC-llms-txt-analysis.md`; `BASH_MAX_OUTPUT_LENGTH` → `.claude/settings.json`) | [#243](https://github.com/qte77/ai-agents-research/issues/243) |
+
+Already tracked (no new issue needed): #232, #217, #191, #189, #188, #185.
+
+## Verification
+
+- `make check_docs` and `make check_links` pass.
+- `docs/plans/` registered in `docs/architecture.md` / `CONTRIBUTING.md` / `README.md`.
+- #242 and #243 open and cross-linked to this doc.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,32 @@
+---
+title: Plans — Design & Decision Docs
+purpose: Convention for docs/plans/ — durable plan/design docs (the saved output of plan-mode work). GitHub Issues remain the authoritative backlog/roadmap; each plan doc links its tracking issue.
+created: 2026-06-14
+updated: 2026-06-14
+---
+
+**Status**: Reference (convention)
+
+`docs/plans/` holds **plan / design / decision docs** — the durable output of a plan-mode (or design) session for a non-trivial effort. It is **not** a task list or a roadmap.
+
+## What goes where
+
+| Need | Home |
+|---|---|
+| Backlog / roadmap / "what to do next" | **GitHub Issues** — the single source of truth ([#191](https://github.com/qte77/ai-agents-research/issues/191) retired the static `docs/TODO.md` to stop CHANGELOG/issue duplication) |
+| Detailed plan / design for a specific effort | **`docs/plans/`** (here) — one doc per effort, linked from its tracking issue |
+| What has already landed | `CHANGELOG.md` `[Unreleased]` |
+| Escalations / blockers needing a human decision | `AGENT_REQUESTS.md` |
+
+## Convention
+
+- **One doc per effort**, named `YYYY-MM-DD-<slug>.md`.
+- **Link the tracking issue both ways**: the plan doc names its issue in frontmatter (`issue:`) and body; the issue links back to the plan doc.
+- **Plans are not the backlog.** A plan doc explains *how* a tracked task will be done; the issue tracks *whether/when*. Don't list untracked tasks here — open an issue.
+- Frontmatter: `title / status / issue / created / updated`. `status` ∈ `draft` | `approved` | `done` | `superseded`.
+
+## Index
+
+| Plan | Status | Issue(s) |
+|---|---|---|
+| [2026-06-14-planning-workflow-and-open-task-triage.md](2026-06-14-planning-workflow-and-open-task-triage.md) | done | #242, #243 |


### PR DESCRIPTION
Establishes `docs/plans/` as the durable home for plan/design docs — the saved output of plan-mode/design work — while keeping **GitHub Issues as the authoritative backlog/roadmap** (per #191; no static task-list, no duplication).

- `docs/plans/README.md` — the convention: plans = design docs, issues = backlog, cross-link both ways.
- `docs/plans/2026-06-14-planning-workflow-and-open-task-triage.md` — inaugural plan doc + decision record (the #191 reconciliation); links the tracker issues.
- Registered `docs/plans/` in `docs/architecture.md` (hierarchy + new **Planning & Roadmap** pointer), `CONTRIBUTING.md`, `README.md`.

Untracked session deferrals were opened as **tracker issues**, not listed in a doc: **#242** (Langtrace URL relocated) and **#243** (re-apply un-merged PR #206 content).

## Verification
- markdownlint: 0 errors / 142 files
- lychee: 0 errors

Generated with Claude <noreply@anthropic.com>