### PR TITLE
docs: doc-hierarchy audit fixes (post-#248)

### DIFF
--- a/docs/cc-community/CC-repo-to-docs-tools-landscape.md
+++ b/docs/cc-community/CC-repo-to-docs-tools-landscape.md
@@ -5,7 +5,7 @@ purpose: Survey of AI-powered tools that generate documentation from GitHub repo
 category: landscape
 status: research
 created: 2026-04-06
-updated: 2026-06-11
+updated: 2026-06-16
 validated_links: 2026-04-06
 ---
 
@@ -37,6 +37,7 @@ A fourth tool, **Understand Anything** (Egonex-AI, 57.4k stars), sits at the gra
 
 **URL**: [deepwiki.com](https://deepwiki.com)
 **Maker**: [Cognition Labs](https://cognition.ai) (the company behind Devin AI)
+**Full analysis**: [deepwiki-analysis.md](../non-cc/deepwiki-analysis.md)
 
 AI indexes an entire GitHub repository and generates hierarchical wiki-style documentation with:
 

--- a/docs/non-cc/README.md
+++ b/docs/non-cc/README.md
@@ -99,7 +99,7 @@ Terminal/CLI agents and agentic IDEs beyond Claude Code — the former "Planned"
 | [ag-ui-protocol-landscape.md](ag-ui-protocol-landscape.md) | AG-UI (Agent-User Interaction protocol), A2UI (Google declarative generative-UI spec), OpenGenerativeUI (CopilotKit reference framework); 2026 ecosystem adoption + Salesforce non-adoption note |
 | [agentcanvas-analysis.md](agentcanvas-analysis.md) | AgentCanvas — renders Pydantic AI + Logfire execution traces as interactive HTML diagrams (OTel agent observability) |
 
-## Planned
+## Backlog status
 
 The former coding-agent backlog — Cline, opencode, Codebuff, Gemini CLI, Cursor,
 Antigravity, Kiro, Codex CLI, VS Code Copilot Chat, Devin CLI, Windsurf, Aider,

--- a/docs/non-cc/gemini-cli-analysis.md
+++ b/docs/non-cc/gemini-cli-analysis.md
@@ -22,7 +22,7 @@ that Gemini CLI would stop serving requests for free-tier users, Google AI Pro
 subscribers, and Google AI Ultra subscribers on **June 18, 2026** — one day after
 this analysis was written. Only Gemini Code Assist Standard and Enterprise
 subscribers retain access. Non-enterprise users are directed to migrate to
-[Antigravity CLI][antigravity-discussion], Google's closed-source replacement.
+[Antigravity CLI][antigravity-discussion], Google's closed-source replacement (full analysis: [antigravity-analysis.md](antigravity-analysis.md)).
 This renders the project effectively an archive for the vast majority of its
 100,000+ GitHub-star community.
 

--- a/docs/non-cc/windsurf-analysis.md
+++ b/docs/non-cc/windsurf-analysis.md
@@ -20,7 +20,7 @@ December 2025 for approximately $250 million (accessed 2026-06-16, first-party v
 
 The product retains backward compatibility with VS Code extensions and continues
 under active development. Pricing, plans, and extensions carried over without
-change at the rebrand date ([Devin Desktop launch post][devin-desktop-blog]).
+change at the rebrand date ([Devin Desktop launch post][devin-desktop-blog]). See also [devin-cli-analysis.md](devin-cli-analysis.md) — Cognition's terminal Devin CLI in the same product family.
 
 **Ownership chain** (as of 2026-06-16, via [cognition.ai][cognition-windsurf-blog]):
 


### PR DESCRIPTION
Follow-up to #248 — fixes from the enforcing-doc-hierarchy audit.

- DeepWiki: forward-link from the repo-to-docs landscape to the new deepwiki-analysis.md (resolves the two-write-ups SSOT divergence).
- Rename stale Planned heading to Backlog status in non-cc README (backlog now covered by the Coding Agents & IDEs section).
- Discovery back-links: gemini-cli to antigravity, windsurf to devin-cli.

Audit result: 0 orphans, all 31 docs from #248 indexed, SSOT clean (SearXNG / OpenRouter / LiteLLM complementary). Skipped by design: frameworks-to-scraping back-link (tangential) and the architecture.md anchor (false positive — valid).

Generated with Claude <noreply@anthropic.com>