### PR TITLE
fix(ci): make monitor HTML tag-stripping case-insensitive (CodeQL py/bad-tag-filter)

### DIFF
--- a/.github/scripts/community-monitor.py
+++ b/.github/scripts/community-monitor.py
@@ -137,8 +137,8 @@ def extract_html_entries(text: str) -> list[dict[str, str]]:
     entries: list[dict[str, str]] = []
 
     # Extract text from HTML by stripping tags (simple approach)
-    clean = re.sub(r"<script[^>]*>.*?</script>", "", text, flags=re.DOTALL)
-    clean = re.sub(r"<style[^>]*>.*?</style>", "", clean, flags=re.DOTALL)
+    clean = re.sub(r"<script[^>]*>.*?</script[^>]*>", "", text, flags=re.DOTALL | re.IGNORECASE)
+    clean = re.sub(r"<style[^>]*>.*?</style[^>]*>", "", clean, flags=re.DOTALL | re.IGNORECASE)
     clean = re.sub(r"<[^>]+>", "\n", clean)
     clean = re.sub(r"\n{3,}", "\n\n", clean)
 

--- a/.github/scripts/native-sources-monitor.py
+++ b/.github/scripts/native-sources-monitor.py
@@ -76,8 +76,8 @@ def extract_blog_entries(html: str) -> list[dict[str, str]]:
     entries: list[dict[str, str]] = []
 
     # Strip script/style
-    clean = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL)
-    clean = re.sub(r"<style[^>]*>.*?</style>", "", clean, flags=re.DOTALL)
+    clean = re.sub(r"<script[^>]*>.*?</script[^>]*>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    clean = re.sub(r"<style[^>]*>.*?</style[^>]*>", "", clean, flags=re.DOTALL | re.IGNORECASE)
 
     # Extract links with text: <a href="...">Title</a>
     for match in re.finditer(r'<a[^>]+href="(/news/[^"]+)"[^>]*>(.*?)</a>', clean, re.DOTALL):


### PR DESCRIPTION
Resolves the 2 open CodeQL `py/bad-tag-filter` alerts (high security-severity) in the cron-monitor scripts.

The `<script>`/`<style>` strip regexes in `community-monitor.py` and `native-sources-monitor.py` matched lowercase only — a mixed-case tag could slip through. Real risk is negligible (the stripped text feeds keyword/coverage comparison, never rendered as HTML; sources are trusted), but `re.IGNORECASE` clears both alerts and removes the ambiguity.

4 lines across 2 files; behavior otherwise unchanged.

Generated with Claude <noreply@anthropic.com>