### PR TITLE
refactor(ci): consolidate shared primitives into monitor_utils + add tests

### DIFF
--- a/.github/scripts/lib/monitor_utils.py
+++ b/.github/scripts/lib/monitor_utils.py
@@ -11,7 +11,9 @@ import re
 import sys
 import urllib.request
 from collections.abc import Callable
+from datetime import datetime
 from pathlib import Path
+from typing import NoReturn
 
 # Noise words that match too broadly across docs.
 # Changelog verbs (added, fixed, improved, removed, renamed) are included so
@@ -22,6 +24,48 @@ DEFAULT_NOISE: set[str] = {
     "github", "added", "fixed", "improved", "removed", "renamed",
     "support", "feature",
 }
+
+
+def fatal(message: str, code: int = 2) -> NoReturn:
+    """Print an error to stderr and exit with ``code`` (default 2)."""
+    print(message, file=sys.stderr)
+    sys.exit(code)
+
+
+def strip_html_noise(html: str) -> str:
+    """Remove <script>/<style> blocks from HTML.
+
+    Tolerant of case and whitespace/junk in tags (e.g. ``</script >``) so the
+    regex can't be trivially defeated (CodeQL py/bad-tag-filter).
+    """
+    clean = re.sub(r"<script[^>]*>.*?</script[^>]*>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    clean = re.sub(r"<style[^>]*>.*?</style[^>]*>", "", clean, flags=re.DOTALL | re.IGNORECASE)
+    return clean
+
+
+def parse_iso(s: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp (tolerating a trailing ``Z``); None on failure."""
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    """Load a JSONL file into a list of dicts, skipping blank lines.
+
+    Returns ``[]`` when the file does not exist.
+    """
+    if not path.exists():
+        return []
+    records: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            records.append(json.loads(line))
+    return records
 
 
 def extract_keywords(text: str, min_len: int = 4) -> set[str]:
@@ -106,34 +150,9 @@ def build_report(
     ]
 
     total_new = 0
-
     for result in source_results:
-        name = result["name"]
-        new_entries = result["new_entries"]
-        total_new += len(new_entries)
-
-        lines += [
-            f"### {name}",
-            "",
-            f"- Source: {result['description']}",
-            f"- Entries fetched: {result['total']}",
-            f"- New uncovered: {len(new_entries)}",
-            "",
-        ]
-
-        if new_entries:
-            lines.append("| Entry | Section | Description |")
-            lines.append("|-------|---------|-------------|")
-            for entry in new_entries[:30]:
-                name_col = _clean_table_cell(entry.get("name", ""), 60)
-                heading = _clean_table_cell(entry.get("heading", ""), 40)
-                desc = _clean_table_cell(entry.get("description", ""), 80)
-                lines.append(f"| {name_col} | {heading} | {desc} |")
-            lines.append("")
-
-            if len(new_entries) > 30:
-                lines.append(f"_... and {len(new_entries) - 30} more entries._")
-                lines.append("")
+        total_new += len(result["new_entries"])
+        lines += _render_source_section(result)
 
     lines += [
         "---",
@@ -143,6 +162,32 @@ def build_report(
     ]
 
     return "\n".join(lines).rstrip("\n"), total_new > 0
+
+
+def _render_source_section(result: dict) -> list[str]:
+    """Render one source's markdown section (header, counts, optional table)."""
+    new_entries = result["new_entries"]
+    lines = [
+        f"### {result['name']}",
+        "",
+        f"- Source: {result['description']}",
+        f"- Entries fetched: {result['total']}",
+        f"- New uncovered: {len(new_entries)}",
+        "",
+    ]
+    if new_entries:
+        lines.append("| Entry | Section | Description |")
+        lines.append("|-------|---------|-------------|")
+        for entry in new_entries[:30]:
+            name_col = _clean_table_cell(entry.get("name", ""), 60)
+            heading = _clean_table_cell(entry.get("heading", ""), 40)
+            desc = _clean_table_cell(entry.get("description", ""), 80)
+            lines.append(f"| {name_col} | {heading} | {desc} |")
+        lines.append("")
+        if len(new_entries) > 30:
+            lines.append(f"_... and {len(new_entries) - 30} more entries._")
+            lines.append("")
+    return lines
 
 
 def _clean_table_cell(text: str, max_len: int) -> str:
@@ -155,6 +200,31 @@ def _clean_table_cell(text: str, max_len: int) -> str:
     text = text.replace("\n", " ").replace("|", "\\|")
     text = re.sub(r"\s+", " ", text).strip()
     return text[:max_len]
+
+
+def _process_source(
+    source: dict[str, str],
+    fetch_fn: Callable[[dict[str, str]], list[dict[str, str]]],
+    seen: set[str],
+    doc_keywords: set[str],
+) -> tuple[dict, list[str]]:
+    """Fetch + filter one source.
+
+    Returns ``(result_dict, fingerprints_of_all_fetched)``. Pure except for the
+    injected ``fetch_fn`` (whose exceptions propagate to the caller).
+    """
+    entries = fetch_fn(source)
+    new_entries = [
+        e for e in entries
+        if entry_fingerprint(e) not in seen and not is_covered(e, doc_keywords)
+    ]
+    result = {
+        "name": source["name"],
+        "description": source["description"],
+        "total": len(entries),
+        "new_entries": new_entries,
+    }
+    return result, [entry_fingerprint(e) for e in entries]
 
 
 def run_monitor(
@@ -186,7 +256,9 @@ def run_monitor(
         print(f"Fetching {name}...", file=sys.stderr)
 
         try:
-            entries = fetch_fn(source)
+            result, fingerprints = _process_source(
+                source, fetch_fn, set(state.get(name, [])), doc_keywords
+            )
         except Exception as e:
             print(f"WARNING: Failed to fetch {name}: {e}", file=sys.stderr)
             source_results.append({
@@ -197,28 +269,10 @@ def run_monitor(
             })
             continue
 
-        print(f"  Extracted {len(entries)} entries", file=sys.stderr)
-
-        seen = set(state.get(name, []))
-        new_entries: list[dict[str, str]] = []
-
-        for entry in entries:
-            fp = entry_fingerprint(entry)
-            if fp in seen:
-                continue
-            if not is_covered(entry, doc_keywords):
-                new_entries.append(entry)
-
-        print(f"  New uncovered: {len(new_entries)}", file=sys.stderr)
-
-        state[name] = [entry_fingerprint(e) for e in entries]
-
-        source_results.append({
-            "name": name,
-            "description": source["description"],
-            "total": len(entries),
-            "new_entries": new_entries,
-        })
+        print(f"  Extracted {result['total']} entries", file=sys.stderr)
+        print(f"  New uncovered: {len(result['new_entries'])}", file=sys.stderr)
+        state[name] = fingerprints
+        source_results.append(result)
 
     save_state(state_file, state)
     print(f"State saved to {state_file}", file=sys.stderr)

--- a/tests/test_monitor_utils.py
+++ b/tests/test_monitor_utils.py
@@ -1,0 +1,147 @@
+"""Unit tests for the shared monitor lib (.github/scripts/lib/monitor_utils.py).
+
+Tests the module's pure logic only (the hyphenated entry scripts are thin IO
+wrappers and are not imported here). Stdlib `unittest`, no deps.
+
+Run: python3 -m unittest discover -s tests
+"""
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".github" / "scripts" / "lib"))
+
+import monitor_utils as mu  # noqa: E402
+
+
+class ExtractKeywordsTests(unittest.TestCase):
+    def test_lowercases_and_filters_short(self):
+        kw = mu.extract_keywords("Hello Foo subagent x ab")
+        self.assertIn("hello", kw)
+        self.assertIn("subagent", kw)
+        self.assertNotIn("foo", kw)  # 3 chars < min_len 4
+        self.assertNotIn("ab", kw)
+
+    def test_keeps_slash_hyphen_tokens(self):
+        self.assertIn("a/b-c", mu.extract_keywords("token a/b-c here"))
+
+
+class IsCoveredTests(unittest.TestCase):
+    def test_covered_when_overlap_exceeds_threshold(self):
+        docs = {"subagent", "orchestration", "spawning"}
+        entry = {"name": "Subagent orchestration", "description": "spawning"}
+        self.assertTrue(mu.is_covered(entry, docs))
+
+    def test_uncovered_when_below_threshold(self):
+        docs = {"unrelated", "words"}
+        entry = {"name": "Subagent orchestration spawning", "description": ""}
+        self.assertFalse(mu.is_covered(entry, docs))
+
+    def test_empty_keywords_treated_as_covered(self):
+        # Only noise words -> no meaningful keywords -> covered (skip).
+        self.assertTrue(mu.is_covered({"name": "claude code", "description": ""}, set()))
+
+
+class EntryFingerprintTests(unittest.TestCase):
+    def test_stable_and_16_hex(self):
+        fp = mu.entry_fingerprint({"name": "X", "url": "http://a"})
+        self.assertEqual(len(fp), 16)
+        self.assertEqual(fp, mu.entry_fingerprint({"name": "x", "url": "HTTP://A"}))  # case-insensitive
+
+    def test_distinct_entries_differ(self):
+        self.assertNotEqual(
+            mu.entry_fingerprint({"name": "A", "url": "u"}),
+            mu.entry_fingerprint({"name": "B", "url": "u"}),
+        )
+
+
+class CleanTableCellTests(unittest.TestCase):
+    def test_strips_url_escapes_pipe_collapses_ws_and_truncates(self):
+        out = mu._clean_table_cell("see https://x.com/y  a|b\nc   d", 6)
+        self.assertNotIn("http", out)
+        self.assertNotIn("\n", out)
+        self.assertEqual(out, "see a\\")  # pipe escaped, ws collapsed, clipped to 6
+
+
+class StripHtmlNoiseTests(unittest.TestCase):
+    def test_strips_script_style_case_and_whitespace_insensitive(self):
+        html = "<script>a</script >B<STYLE x>c</STYLE>D<script\n>e</script\t bar>F"
+        self.assertEqual(mu.strip_html_noise(html), "BDF")
+
+
+class LoadJsonlTests(unittest.TestCase):
+    def test_reads_skipping_blank_lines(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "x.jsonl"
+            p.write_text('{"a": 1}\n\n  \n{"a": 2}\n', encoding="utf-8")
+            self.assertEqual(mu.load_jsonl(p), [{"a": 1}, {"a": 2}])
+
+    def test_missing_file_returns_empty(self):
+        self.assertEqual(mu.load_jsonl(Path("/nonexistent/x.jsonl")), [])
+
+
+class ParseIsoTests(unittest.TestCase):
+    def test_parses_trailing_z_as_utc(self):
+        self.assertEqual(
+            mu.parse_iso("2026-06-18T12:00:00Z"),
+            datetime(2026, 6, 18, 12, 0, tzinfo=timezone.utc),
+        )
+
+    def test_empty_and_invalid_return_none(self):
+        self.assertIsNone(mu.parse_iso(""))
+        self.assertIsNone(mu.parse_iso("not-a-date"))
+
+
+class FatalTests(unittest.TestCase):
+    def test_exits_with_code(self):
+        with self.assertRaises(SystemExit) as cm:
+            mu.fatal("boom", code=2)
+        self.assertEqual(cm.exception.code, 2)
+
+
+class ProcessSourceTests(unittest.TestCase):
+    def test_filters_seen_and_covered(self):
+        source = {"name": "s", "description": "d"}
+        entries = [
+            {"name": "Fresh subagent topic", "url": "u1", "description": ""},  # new
+            {"name": "Already seen", "url": "u2", "description": ""},          # seen
+            {"name": "covered thing", "url": "u3", "description": ""},         # covered
+        ]
+        seen = {mu.entry_fingerprint(entries[1])}
+        doc_keywords = {"covered", "thing"}
+        result, fingerprints = mu._process_source(
+            source, lambda _s: entries, seen, doc_keywords
+        )
+        self.assertEqual(result["total"], 3)
+        self.assertEqual([e["name"] for e in result["new_entries"]], ["Fresh subagent topic"])
+        self.assertEqual(len(fingerprints), 3)
+
+
+class BuildReportTests(unittest.TestCase):
+    def _result(self, new_entries):
+        return {"name": "Src", "description": "desc", "total": len(new_entries), "new_entries": new_entries}
+
+    def test_has_new_and_renders_table(self):
+        results = [self._result([{"name": "E1", "heading": "H", "description": "about subagents"}])]
+        report, has_new = mu.build_report(results, "My Report", "x.py")
+        self.assertTrue(has_new)
+        self.assertIn("## My Report", report)
+        self.assertIn("### Src", report)
+        self.assertIn("| E1 | H | about subagents |", report)
+        self.assertIn("Total new uncovered entries: **1**", report)
+        self.assertIn("_Generated by `.github/scripts/x.py`_", report)
+
+    def test_no_new_content(self):
+        _, has_new = mu.build_report([self._result([])], "T", "x.py")
+        self.assertFalse(has_new)
+
+    def test_truncates_over_30(self):
+        entries = [{"name": f"E{i}", "heading": "", "description": ""} for i in range(35)]
+        report, _ = mu.build_report([self._result(entries)], "T", "x.py")
+        self.assertIn("_... and 5 more entries._", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**PR 1 of 4** in the `.github/scripts/` complexity-reduction effort (foundation).

Adds reusable helpers to `lib/monitor_utils.py` that the monitor/status/changelog scripts currently duplicate inline — `strip_html_noise`, `fatal`, `load_jsonl`, `parse_iso` — and splits the two heaviest functions behavior-preservingly: `run_monitor` → `_process_source`, `build_report` → `_render_source_section`.

New `tests/test_monitor_utils.py` (stdlib `unittest`) locks the pure logic **before** any entry script adopts the helpers (PRs 2–4). No entry-script changes here (additive + internal).

Verification: `python3 -m unittest discover -s tests` → green (33 tests); lib + all importers `py_compile` clean.

Generated with Claude <noreply@anthropic.com>