### PR TITLE
refactor(ci): extract status-pair logic to lib + thin the scripts (+tests)

### DIFF
--- a/.github/scripts/lib/status_incidents.py
+++ b/.github/scripts/lib/status_incidents.py
@@ -1,0 +1,67 @@
+"""Pure incident-normalization logic for status-collector.py.
+
+Transforms raw Statuspage incidents into archive records and decides upserts.
+Kept import-clean (no HTTP / argparse / sys.exit) so it is unit-testable; the
+status-collector.py entry script does the IO and wires these together.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from .monitor_utils import parse_iso
+
+STATUSPAGE_BASE = "https://status.anthropic.com"
+
+
+def compute_duration(started_at: str, resolved_at: str | None) -> int | None:
+    """Incident duration in minutes; None if unresolved or unparseable."""
+    if not resolved_at or not started_at:
+        return None
+    start, end = parse_iso(started_at), parse_iso(resolved_at)
+    if start is None or end is None:
+        return None
+    return max(0, int((end - start).total_seconds() / 60))
+
+
+def normalize_incident(raw: dict) -> dict:
+    """Normalize a Statuspage incident into an archive record."""
+    started_at = raw.get("started_at") or raw.get("created_at", "")
+    resolved_at = raw.get("resolved_at")
+    components = [c["name"] for c in raw.get("components", []) if c.get("name")]
+    return {
+        "id": raw["id"],
+        "name": raw.get("name", ""),
+        "status": raw.get("status", ""),
+        "impact": raw.get("impact", ""),
+        "started_at": started_at,
+        "resolved_at": resolved_at or "",
+        "duration_minutes": compute_duration(started_at, resolved_at),
+        "affected_components": components,
+        "updates_count": len(raw.get("incident_updates", [])),
+        "url": raw.get("shortlink", f"{STATUSPAGE_BASE}/incidents/{raw['id']}"),
+        "collected_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+def normalize_webhook_incident(payload: dict) -> dict | None:
+    """Extract + normalize the incident from a webhook payload (None if absent)."""
+    incident = payload.get("incident")
+    return normalize_incident(incident) if incident else None
+
+
+def record_changed(old: dict, new: dict) -> bool:
+    """True if a record meaningfully changed (ignoring the collected_at stamp)."""
+    return any(
+        old.get(key) != new.get(key)
+        for key in ("status", "resolved_at", "duration_minutes", "updates_count",
+                    "affected_components", "impact", "name")
+    )
+
+
+def upsert_record(archive: dict[str, dict], record: dict) -> bool:
+    """Insert or update ``record`` in ``archive`` by id; True if it changed."""
+    existing = archive.get(record["id"])
+    if not existing or record_changed(existing, record):
+        archive[record["id"]] = record
+        return True
+    return False

--- a/.github/scripts/lib/status_report.py
+++ b/.github/scripts/lib/status_report.py
@@ -1,0 +1,225 @@
+"""Pure markdown-report generation for status-stats.py.
+
+All functions are deterministic given their inputs (except the generated-at
+timestamp in the report header), so the logic is unit-testable; the
+status-stats.py entry script only loads the archive and prints the report.
+Stdlib only (no pandas/numpy).
+"""
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from statistics import mean, median
+
+from .monitor_utils import parse_iso
+
+
+def format_duration(minutes: float) -> str:
+    """Format minutes as a human-readable duration."""
+    if minutes < 60:
+        return f"{minutes:.0f}m"
+    hours = minutes / 60
+    if hours < 24:
+        return f"{hours:.1f}h"
+    return f"{hours / 24:.1f}d"
+
+
+def _extract_timing(records: list[dict]) -> tuple[list[dict], list[datetime], list[int]]:
+    """Extract resolved records, start times, and durations from records."""
+    resolved: list[dict] = []
+    all_starts: list[datetime] = []
+    durations: list[int] = []
+    for r in records:
+        start = parse_iso(r.get("started_at", ""))
+        if start:
+            all_starts.append(start)
+        dur = r.get("duration_minutes")
+        if isinstance(dur, (int, float)):
+            durations.append(int(dur))
+            resolved.append(r)
+    return resolved, all_starts, durations
+
+
+def _section_summary(
+    records: list[dict], resolved: list[dict], all_starts: list[datetime],
+) -> list[str]:
+    """Build the Summary section."""
+    lines = ["## Summary", ""]
+    unresolved = sum(1 for r in records if r.get("status") != "resolved")
+    lines.append(f"- **Total incidents**: {len(records)}")
+    lines.append(f"- **Resolved**: {len(resolved)}")
+    lines.append(f"- **Unresolved/ongoing**: {unresolved}")
+    if all_starts:
+        earliest, latest = min(all_starts), max(all_starts)
+        span_days = max(1, (latest - earliest).days)
+        lines.append(f"- **Date range**: {earliest.strftime('%Y-%m-%d')} to {latest.strftime('%Y-%m-%d')}")
+        lines.append(f"- **Span**: {span_days} days")
+        lines.append(f"- **Rate**: {len(records) / (span_days / 7):.1f} incidents/week")
+    lines.append("")
+    return lines
+
+
+def _section_resolution_time(durations: list[int]) -> list[str]:
+    """Build the Resolution Time section."""
+    if not durations:
+        return []
+    return [
+        "## Resolution Time", "",
+        "| Metric | Value |", "|--------|-------|",
+        f"| Min | {format_duration(min(durations))} |",
+        f"| Max | {format_duration(max(durations))} |",
+        f"| Median | {format_duration(median(durations))} |",
+        f"| Mean | {format_duration(mean(durations))} |",
+        f"| Total downtime | {format_duration(sum(durations))} |",
+        "",
+    ]
+
+
+def _section_severity(records: list[dict]) -> list[str]:
+    """Build the Severity Distribution section."""
+    impact_counts = Counter(r.get("impact", "unknown") for r in records)
+    lines = ["## Severity Distribution", "", "| Impact | Count | % |", "|--------|-------|---|"]
+    for impact, count in impact_counts.most_common():
+        pct = count / len(records) * 100
+        lines.append(f"| {impact} | {count} | {pct:.0f}% |")
+    lines.append("")
+    return lines
+
+
+def _section_mttr(resolved: list[dict]) -> list[str]:
+    """Build the MTTR by Severity section."""
+    severity_durations: dict[str, list[int]] = defaultdict(list)
+    for r in resolved:
+        dur = r.get("duration_minutes")
+        if dur is not None:
+            severity_durations[r.get("impact", "unknown")].append(int(dur))
+    if not severity_durations:
+        return []
+    lines = ["## MTTR by Severity", "",
+             "| Impact | MTTR (mean) | MTTR (median) | Count |",
+             "|--------|-------------|---------------|-------|"]
+    for impact in sorted(severity_durations.keys()):
+        durs = severity_durations[impact]
+        lines.append(
+            f"| {impact} | {format_duration(mean(durs))} "
+            f"| {format_duration(median(durs))} | {len(durs)} |"
+        )
+    lines.append("")
+    return lines
+
+
+def _build_component_data(
+    records: list[dict],
+) -> tuple[Counter[str], dict[str, list[int]]]:
+    """Aggregate component incident counts and durations."""
+    comp_counts: Counter[str] = Counter()
+    comp_durations: dict[str, list[int]] = defaultdict(list)
+    for r in records:
+        dur = r.get("duration_minutes")
+        for comp in r.get("affected_components", []):
+            comp_counts[comp] += 1
+            if dur is not None:
+                comp_durations[comp].append(int(dur))
+    return comp_counts, comp_durations
+
+
+def _section_components(
+    comp_counts: Counter[str], comp_durations: dict[str, list[int]],
+) -> list[str]:
+    """Build the Component Frequency section."""
+    if not comp_counts:
+        return []
+    lines = ["## Component Frequency", "",
+             "| Component | Incidents | Total Downtime | Avg Duration |",
+             "|-----------|-----------|----------------|--------------|"]
+    for comp, count in comp_counts.most_common():
+        durs = comp_durations.get(comp, [])
+        total = format_duration(sum(durs)) if durs else "—"
+        avg = format_duration(mean(durs)) if durs else "—"
+        lines.append(f"| {comp} | {count} | {total} | {avg} |")
+    lines.append("")
+    return lines
+
+
+def _render_bar_table(title: str, label_header: str, rows: list[tuple[str, int]]) -> list[str]:
+    """Render a titled ``| label | Incidents | Bar |`` table; bars scale to the max count."""
+    max_count = max((count for _, count in rows), default=0)
+    sep = "-" * (len(label_header) + 2)
+    lines = [f"## {title}", "",
+             f"| {label_header} | Incidents | Bar |", f"|{sep}|-----------|-----|"]
+    for label, count in rows:
+        bar = "#" * int(count / max_count * 20) if count > 0 else ""
+        lines.append(f"| {label} | {count} | {bar} |")
+    lines.append("")
+    return lines
+
+
+def _section_time_distributions(all_starts: list[datetime]) -> list[str]:
+    """Build Time-of-Day, Day-of-Week, and Monthly Trend sections."""
+    if not all_starts:
+        return []
+    hour_counts = Counter(dt.hour for dt in all_starts)
+    dow_names = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+    dow_counts = Counter(dt.weekday() for dt in all_starts)
+    month_counts = Counter(dt.strftime("%Y-%m") for dt in all_starts)
+    return (
+        _render_bar_table("Time-of-Day Distribution (UTC)", "Hour",
+                          [(f"{hour:02d}:00", hour_counts.get(hour, 0)) for hour in range(24)])
+        + _render_bar_table("Day-of-Week Distribution", "Day",
+                            [(name, dow_counts.get(i, 0)) for i, name in enumerate(dow_names)])
+        + _render_bar_table("Monthly Trend", "Month",
+                            [(month, month_counts[month]) for month in sorted(month_counts)])
+    )
+
+
+def _section_uptime(
+    all_starts: list[datetime], durations: list[int],
+    comp_durations: dict[str, list[int]],
+) -> list[str]:
+    """Build the Uptime Estimate section."""
+    if not all_starts or not durations:
+        return []
+    span_minutes = max(1, (max(all_starts) - min(all_starts)).total_seconds() / 60)
+    total_down = sum(durations)
+    uptime_pct = (1 - total_down / span_minutes) * 100
+    lines = [
+        "## Uptime Estimate", "",
+        f"- **Overall uptime**: {uptime_pct:.3f}%",
+        f"- **Total downtime**: {format_duration(total_down)}",
+        f"- **Measurement period**: {format_duration(span_minutes)}",
+        "",
+    ]
+    if comp_durations:
+        lines += ["| Component | Uptime % | Downtime |",
+                   "|-----------|----------|----------|"]
+        for comp, durs in sorted(comp_durations.items(), key=lambda x: -sum(x[1])):
+            comp_down = sum(durs)
+            comp_up = (1 - comp_down / span_minutes) * 100
+            lines.append(f"| {comp} | {comp_up:.3f}% | {format_duration(comp_down)} |")
+        lines.append("")
+    return lines
+
+
+def generate_report(records: list[dict]) -> str:
+    """Generate a markdown statistical report from outage records."""
+    lines: list[str] = [
+        "# Claude Platform Outage Statistics", "",
+        f"*Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} "
+        f"| {len(records)} incidents in archive*", "",
+    ]
+    if not records:
+        lines.append("No incidents recorded yet.")
+        return "\n".join(lines).rstrip("\n")
+
+    resolved, all_starts, durations = _extract_timing(records)
+    comp_counts, comp_durations = _build_component_data(records)
+
+    lines += _section_summary(records, resolved, all_starts)
+    lines += _section_resolution_time(durations)
+    lines += _section_severity(records)
+    lines += _section_mttr(resolved)
+    lines += _section_components(comp_counts, comp_durations)
+    lines += _section_time_distributions(all_starts)
+    lines += _section_uptime(all_starts, durations, comp_durations)
+
+    return "\n".join(lines).rstrip("\n")

--- a/.github/scripts/status-collector.py
+++ b/.github/scripts/status-collector.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
-"""Collect Claude platform incidents from Statuspage API into a JSONL archive.
+"""Collect Claude platform incidents from the Statuspage API into a JSONL archive.
 
-Fetches all incidents (resolved + unresolved) from the Anthropic Statuspage
-and upserts them into a local JSONL archive. Can also process webhook payloads
-from repository_dispatch events.
+Fetches incidents from the Anthropic Statuspage and upserts them into a local
+JSONL archive; can also process webhook payloads from repository_dispatch
+events. Pure normalization logic lives in lib/status_incidents.py.
 
 Usage:
     # Fetch from API (weekly cron)
     python status-collector.py --archive triage/status-monitor/outages.jsonl
 
     # Process webhook payload (repository_dispatch)
-    python status-collector.py --archive triage/status-monitor/outages.jsonl --webhook-payload /tmp/payload.json
+    python status-collector.py --archive ... --webhook-payload /tmp/payload.json
 
 Exit codes:
     0 = no new or updated incidents
@@ -22,10 +22,16 @@ import json
 import sys
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
 from pathlib import Path
 
-STATUSPAGE_BASE = "https://status.anthropic.com"
+sys.path.insert(0, str(Path(__file__).parent))
+from lib.monitor_utils import fatal, load_jsonl
+from lib.status_incidents import (
+    STATUSPAGE_BASE,
+    normalize_incident,
+    normalize_webhook_incident,
+    upsert_record,
+)
 
 
 def fetch_incidents(base_url: str) -> list[dict]:
@@ -36,73 +42,8 @@ def fetch_incidents(base_url: str) -> list[dict]:
         with urllib.request.urlopen(req, timeout=30) as resp:
             data = json.loads(resp.read().decode("utf-8"))
     except urllib.error.URLError as e:
-        print(f"ERROR: Failed to fetch incidents: {e}", file=sys.stderr)
-        sys.exit(2)
+        fatal(f"ERROR: Failed to fetch incidents: {e}")
     return data.get("incidents", [])
-
-
-def normalize_incident(raw: dict) -> dict:
-    """Normalize a Statuspage incident into an archive record."""
-    started_at = raw.get("started_at") or raw.get("created_at", "")
-    resolved_at = raw.get("resolved_at")
-    duration = compute_duration(started_at, resolved_at)
-
-    components = []
-    for comp in raw.get("components", []):
-        name = comp.get("name", "")
-        if name:
-            components.append(name)
-
-    updates = raw.get("incident_updates", [])
-
-    return {
-        "id": raw["id"],
-        "name": raw.get("name", ""),
-        "status": raw.get("status", ""),
-        "impact": raw.get("impact", ""),
-        "started_at": started_at,
-        "resolved_at": resolved_at or "",
-        "duration_minutes": duration,
-        "affected_components": components,
-        "updates_count": len(updates),
-        "url": raw.get("shortlink", f"{STATUSPAGE_BASE}/incidents/{raw['id']}"),
-        "collected_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    }
-
-
-def compute_duration(started_at: str, resolved_at: str | None) -> int | None:
-    """Compute incident duration in minutes. Returns None if unresolved."""
-    if not resolved_at or not started_at:
-        return None
-    try:
-        start = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
-        end = datetime.fromisoformat(resolved_at.replace("Z", "+00:00"))
-        return max(0, int((end - start).total_seconds() / 60))
-    except (ValueError, TypeError):
-        return None
-
-
-def normalize_webhook_incident(payload: dict) -> dict | None:
-    """Extract and normalize incident from a webhook payload."""
-    incident = payload.get("incident")
-    if not incident:
-        return None
-    return normalize_incident(incident)
-
-
-def load_archive(path: Path) -> dict[str, dict]:
-    """Load existing archive as a dict keyed by incident ID."""
-    archive: dict[str, dict] = {}
-    if not path.exists():
-        return archive
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            record = json.loads(line)
-            archive[record["id"]] = record
-    return archive
 
 
 def save_archive(path: Path, archive: dict[str, dict]) -> None:
@@ -114,13 +55,33 @@ def save_archive(path: Path, archive: dict[str, dict]) -> None:
             f.write(json.dumps(record, separators=(",", ":")) + "\n")
 
 
-def record_changed(old: dict, new: dict) -> bool:
-    """Check if a record has meaningfully changed (ignoring collected_at)."""
-    for key in ("status", "resolved_at", "duration_minutes", "updates_count",
-                "affected_components", "impact", "name"):
-        if old.get(key) != new.get(key):
-            return True
+def _process_webhook(archive: dict[str, dict], payload_path: Path) -> bool:
+    """Upsert one incident from a webhook payload; True if the archive changed."""
+    with open(payload_path) as f:
+        payload = json.load(f)
+    record = normalize_webhook_incident(payload)
+    if not record:
+        return False
+    is_new = record["id"] not in archive
+    if upsert_record(archive, record):
+        print(f"Webhook: {'new' if is_new else 'updated'} incident {record['id']}: {record['name']}")
+        return True
+    print(f"Webhook: no changes for incident {record['id']}")
     return False
+
+
+def _process_api(archive: dict[str, dict], base_url: str) -> bool:
+    """Fetch + upsert all API incidents; True if the archive changed."""
+    incidents = fetch_incidents(base_url)
+    print(f"Fetched {len(incidents)} incidents from API")
+    changed = False
+    for raw in incidents:
+        record = normalize_incident(raw)
+        is_new = record["id"] not in archive
+        if upsert_record(archive, record):
+            changed = True
+            print(f"  {'NEW' if is_new else 'UPDATED'}: {record['id']} — {record['name']}")
+    return changed
 
 
 def main() -> None:
@@ -142,46 +103,19 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    archive = load_archive(args.archive)
-    changed = False
-
-    if args.webhook_payload:
-        # Process webhook payload
-        with open(args.webhook_payload) as f:
-            payload = json.load(f)
-        record = normalize_webhook_incident(payload)
-        if record:
-            existing = archive.get(record["id"])
-            if not existing or record_changed(existing, record):
-                archive[record["id"]] = record
-                changed = True
-                print(f"Webhook: {'updated' if existing else 'new'} incident {record['id']}: {record['name']}")
-            else:
-                print(f"Webhook: no changes for incident {record['id']}")
-    else:
-        # Fetch all incidents from API
-        incidents = fetch_incidents(args.statuspage_base)
-        print(f"Fetched {len(incidents)} incidents from API")
-
-        for raw in incidents:
-            record = normalize_incident(raw)
-            existing = archive.get(record["id"])
-            if not existing:
-                archive[record["id"]] = record
-                changed = True
-                print(f"  NEW: {record['id']} — {record['name']}")
-            elif record_changed(existing, record):
-                archive[record["id"]] = record
-                changed = True
-                print(f"  UPDATED: {record['id']} — {record['name']}")
+    archive = {r["id"]: r for r in load_jsonl(args.archive)}
+    changed = (
+        _process_webhook(archive, args.webhook_payload)
+        if args.webhook_payload
+        else _process_api(archive, args.statuspage_base)
+    )
 
     if changed:
         save_archive(args.archive, archive)
         print(f"Archive updated: {len(archive)} total incidents in {args.archive}")
         sys.exit(1)
-    else:
-        print(f"No changes. Archive has {len(archive)} incidents.")
-        sys.exit(0)
+    print(f"No changes. Archive has {len(archive)} incidents.")
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/status-stats.py
+++ b/.github/scripts/status-stats.py
@@ -1,289 +1,21 @@
 #!/usr/bin/env python3
-"""Generate statistical analysis of Claude platform outages from JSONL archive.
+"""Generate statistical analysis of Claude platform outages from a JSONL archive.
 
-Reads the outage archive and produces a markdown report with frequency,
-duration, severity, component, and time-of-day analysis.
+Reads the outage archive and prints a markdown report (frequency, duration,
+severity, component, and time-of-day analysis). The pure report logic lives in
+lib/status_report.py; this entry point only loads the archive and prints.
 
 Usage:
     python status-stats.py --archive triage/status-monitor/outages.jsonl > triage/status-monitor/outage-stats.md
-
-All calculations use stdlib only (no pandas/numpy).
 """
 
 import argparse
-import json
 import sys
-from collections import Counter, defaultdict
-from datetime import datetime, timezone
 from pathlib import Path
 
-
-def load_archive(path: Path) -> list[dict]:
-    """Load all records from the JSONL archive."""
-    records: list[dict] = []
-    if not path.exists():
-        print(f"ERROR: Archive not found: {path}", file=sys.stderr)
-        sys.exit(2)
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            records.append(json.loads(line))
-    return records
-
-
-def parse_dt(s: str) -> datetime | None:
-    """Parse an ISO 8601 datetime string."""
-    if not s:
-        return None
-    try:
-        return datetime.fromisoformat(s.replace("Z", "+00:00"))
-    except (ValueError, TypeError):
-        return None
-
-
-def median(values: list[int | float]) -> float:
-    """Compute median of a sorted list."""
-    if not values:
-        return 0.0
-    s = sorted(values)
-    n = len(s)
-    if n % 2 == 1:
-        return float(s[n // 2])
-    return (s[n // 2 - 1] + s[n // 2]) / 2.0
-
-
-def mean(values: list[int | float]) -> float:
-    """Compute mean of a list."""
-    if not values:
-        return 0.0
-    return sum(values) / len(values)
-
-
-def format_duration(minutes: float) -> str:
-    """Format minutes as human-readable duration."""
-    if minutes < 60:
-        return f"{minutes:.0f}m"
-    hours = minutes / 60
-    if hours < 24:
-        return f"{hours:.1f}h"
-    days = hours / 24
-    return f"{days:.1f}d"
-
-
-def _extract_timing(records: list[dict]) -> tuple[list[dict], list[datetime], list[int]]:
-    """Extract resolved records, start times, and durations from records."""
-    resolved = []
-    all_starts: list[datetime] = []
-    durations: list[int] = []
-    for r in records:
-        start = parse_dt(r.get("started_at", ""))
-        if start:
-            all_starts.append(start)
-        dur = r.get("duration_minutes")
-        if dur is not None and isinstance(dur, (int, float)):
-            durations.append(int(dur))
-            resolved.append(r)
-    return resolved, all_starts, durations
-
-
-def _section_summary(
-    records: list[dict], resolved: list[dict], all_starts: list[datetime],
-) -> list[str]:
-    """Build the Summary section."""
-    lines = ["## Summary", ""]
-    unresolved = sum(1 for r in records if r.get("status") != "resolved")
-    lines.append(f"- **Total incidents**: {len(records)}")
-    lines.append(f"- **Resolved**: {len(resolved)}")
-    lines.append(f"- **Unresolved/ongoing**: {unresolved}")
-    if all_starts:
-        earliest, latest = min(all_starts), max(all_starts)
-        span_days = max(1, (latest - earliest).days)
-        lines.append(f"- **Date range**: {earliest.strftime('%Y-%m-%d')} to {latest.strftime('%Y-%m-%d')}")
-        lines.append(f"- **Span**: {span_days} days")
-        lines.append(f"- **Rate**: {len(records) / (span_days / 7):.1f} incidents/week")
-    lines.append("")
-    return lines
-
-
-def _section_resolution_time(durations: list[int]) -> list[str]:
-    """Build the Resolution Time section."""
-    if not durations:
-        return []
-    return [
-        "## Resolution Time", "",
-        "| Metric | Value |", "|--------|-------|",
-        f"| Min | {format_duration(min(durations))} |",
-        f"| Max | {format_duration(max(durations))} |",
-        f"| Median | {format_duration(median(durations))} |",
-        f"| Mean | {format_duration(mean(durations))} |",
-        f"| Total downtime | {format_duration(sum(durations))} |",
-        "",
-    ]
-
-
-def _section_severity(records: list[dict]) -> list[str]:
-    """Build the Severity Distribution section."""
-    impact_counts = Counter(r.get("impact", "unknown") for r in records)
-    lines = ["## Severity Distribution", "", "| Impact | Count | % |", "|--------|-------|---|"]
-    for impact, count in impact_counts.most_common():
-        pct = count / len(records) * 100
-        lines.append(f"| {impact} | {count} | {pct:.0f}% |")
-    lines.append("")
-    return lines
-
-
-def _section_mttr(resolved: list[dict]) -> list[str]:
-    """Build the MTTR by Severity section."""
-    severity_durations: dict[str, list[int]] = defaultdict(list)
-    for r in resolved:
-        dur = r.get("duration_minutes")
-        if dur is not None:
-            severity_durations[r.get("impact", "unknown")].append(int(dur))
-    if not severity_durations:
-        return []
-    lines = ["## MTTR by Severity", "",
-             "| Impact | MTTR (mean) | MTTR (median) | Count |",
-             "|--------|-------------|---------------|-------|"]
-    for impact in sorted(severity_durations.keys()):
-        durs = severity_durations[impact]
-        lines.append(
-            f"| {impact} | {format_duration(mean(durs))} "
-            f"| {format_duration(median(durs))} | {len(durs)} |"
-        )
-    lines.append("")
-    return lines
-
-
-def _build_component_data(
-    records: list[dict],
-) -> tuple[Counter[str], dict[str, list[int]]]:
-    """Aggregate component incident counts and durations."""
-    comp_counts: Counter[str] = Counter()
-    comp_durations: dict[str, list[int]] = defaultdict(list)
-    for r in records:
-        dur = r.get("duration_minutes")
-        for comp in r.get("affected_components", []):
-            comp_counts[comp] += 1
-            if dur is not None:
-                comp_durations[comp].append(int(dur))
-    return comp_counts, comp_durations
-
-
-def _section_components(
-    comp_counts: Counter[str], comp_durations: dict[str, list[int]],
-) -> list[str]:
-    """Build the Component Frequency section."""
-    if not comp_counts:
-        return []
-    lines = ["## Component Frequency", "",
-             "| Component | Incidents | Total Downtime | Avg Duration |",
-             "|-----------|-----------|----------------|--------------|"]
-    for comp, count in comp_counts.most_common():
-        durs = comp_durations.get(comp, [])
-        total = format_duration(sum(durs)) if durs else "—"
-        avg = format_duration(mean(durs)) if durs else "—"
-        lines.append(f"| {comp} | {count} | {total} | {avg} |")
-    lines.append("")
-    return lines
-
-
-def _section_time_distributions(all_starts: list[datetime]) -> list[str]:
-    """Build Time-of-Day, Day-of-Week, and Monthly Trend sections."""
-    if not all_starts:
-        return []
-    lines: list[str] = []
-
-    # Time-of-Day
-    hour_counts = Counter(dt.hour for dt in all_starts)
-    max_hour = max(hour_counts.values())
-    lines += ["## Time-of-Day Distribution (UTC)", "",
-              "| Hour | Incidents | Bar |", "|------|-----------|-----|"]
-    for hour in range(24):
-        count = hour_counts.get(hour, 0)
-        bar = "#" * int(count / max_hour * 20) if count > 0 else ""
-        lines.append(f"| {hour:02d}:00 | {count} | {bar} |")
-    lines.append("")
-
-    # Day-of-Week
-    dow_names = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-    dow_counts = Counter(dt.weekday() for dt in all_starts)
-    max_dow = max(dow_counts.values())
-    lines += ["## Day-of-Week Distribution", "",
-              "| Day | Incidents | Bar |", "|-----|-----------|-----|"]
-    for day_idx, day_name in enumerate(dow_names):
-        count = dow_counts.get(day_idx, 0)
-        bar = "#" * int(count / max_dow * 20) if count > 0 else ""
-        lines.append(f"| {day_name} | {count} | {bar} |")
-    lines.append("")
-
-    # Monthly Trend
-    month_counts: Counter[str] = Counter(dt.strftime("%Y-%m") for dt in all_starts)
-    max_month = max(month_counts.values())
-    lines += ["## Monthly Trend", "",
-              "| Month | Incidents | Bar |", "|-------|-----------|-----|"]
-    for month in sorted(month_counts.keys()):
-        count = month_counts[month]
-        bar = "#" * int(count / max_month * 20) if count > 0 else ""
-        lines.append(f"| {month} | {count} | {bar} |")
-    lines.append("")
-
-    return lines
-
-
-def _section_uptime(
-    all_starts: list[datetime], durations: list[int],
-    comp_durations: dict[str, list[int]],
-) -> list[str]:
-    """Build the Uptime Estimate section."""
-    if not all_starts or not durations:
-        return []
-    span_minutes = max(1, (max(all_starts) - min(all_starts)).total_seconds() / 60)
-    total_down = sum(durations)
-    uptime_pct = (1 - total_down / span_minutes) * 100
-    lines = [
-        "## Uptime Estimate", "",
-        f"- **Overall uptime**: {uptime_pct:.3f}%",
-        f"- **Total downtime**: {format_duration(total_down)}",
-        f"- **Measurement period**: {format_duration(span_minutes)}",
-        "",
-    ]
-    if comp_durations:
-        lines += ["| Component | Uptime % | Downtime |",
-                   "|-----------|----------|----------|"]
-        for comp, durs in sorted(comp_durations.items(), key=lambda x: -sum(x[1])):
-            comp_down = sum(durs)
-            comp_up = (1 - comp_down / span_minutes) * 100
-            lines.append(f"| {comp} | {comp_up:.3f}% | {format_duration(comp_down)} |")
-        lines.append("")
-    return lines
-
-
-def generate_report(records: list[dict]) -> str:
-    """Generate a markdown statistical report from outage records."""
-    lines: list[str] = [
-        "# Claude Platform Outage Statistics", "",
-        f"*Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} "
-        f"| {len(records)} incidents in archive*", "",
-    ]
-
-    if not records:
-        lines.append("No incidents recorded yet.")
-        return "\n".join(lines).rstrip("\n")
-
-    resolved, all_starts, durations = _extract_timing(records)
-    comp_counts, comp_durations = _build_component_data(records)
-
-    lines += _section_summary(records, resolved, all_starts)
-    lines += _section_resolution_time(durations)
-    lines += _section_severity(records)
-    lines += _section_mttr(resolved)
-    lines += _section_components(comp_counts, comp_durations)
-    lines += _section_time_distributions(all_starts)
-    lines += _section_uptime(all_starts, durations, comp_durations)
-
-    return "\n".join(lines).rstrip("\n")
+sys.path.insert(0, str(Path(__file__).parent))
+from lib.monitor_utils import fatal, load_jsonl
+from lib.status_report import generate_report
 
 
 def main() -> None:
@@ -297,9 +29,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    records = load_archive(args.archive)
-    report = generate_report(records)
-    print(report)
+    if not args.archive.exists():
+        fatal(f"ERROR: Archive not found: {args.archive}")
+    print(generate_report(load_jsonl(args.archive)))
 
 
 if __name__ == "__main__":

--- a/tests/test_status_incidents.py
+++ b/tests/test_status_incidents.py
@@ -1,0 +1,82 @@
+"""Unit tests for lib/status_incidents.py (pure incident-normalization logic)."""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".github" / "scripts"))
+
+from lib import status_incidents as si  # noqa: E402
+
+
+class ComputeDurationTests(unittest.TestCase):
+    def test_resolved_minutes(self):
+        self.assertEqual(si.compute_duration("2026-01-01T00:00:00Z", "2026-01-01T01:30:00Z"), 90)
+
+    def test_unresolved_returns_none(self):
+        self.assertIsNone(si.compute_duration("2026-01-01T00:00:00Z", None))
+        self.assertIsNone(si.compute_duration("", "2026-01-01T01:00:00Z"))
+
+    def test_unparseable_returns_none(self):
+        self.assertIsNone(si.compute_duration("nope", "also-nope"))
+
+    def test_negative_clamped_to_zero(self):
+        self.assertEqual(si.compute_duration("2026-01-01T01:00:00Z", "2026-01-01T00:00:00Z"), 0)
+
+
+class NormalizeIncidentTests(unittest.TestCase):
+    def test_maps_fields_and_drops_blank_components(self):
+        rec = si.normalize_incident({
+            "id": "abc", "name": "Outage", "status": "resolved", "impact": "major",
+            "started_at": "2026-01-01T00:00:00Z", "resolved_at": "2026-01-01T00:30:00Z",
+            "components": [{"name": "API"}, {"name": ""}, {"foo": "x"}],
+            "incident_updates": [{}, {}], "shortlink": "http://s/abc",
+        })
+        self.assertEqual(rec["duration_minutes"], 30)
+        self.assertEqual(rec["affected_components"], ["API"])
+        self.assertEqual(rec["updates_count"], 2)
+        self.assertEqual(rec["url"], "http://s/abc")
+        self.assertIn("collected_at", rec)
+
+    def test_started_at_falls_back_and_url_default(self):
+        rec = si.normalize_incident({"id": "x", "created_at": "2026-01-01T00:00:00Z"})
+        self.assertEqual(rec["started_at"], "2026-01-01T00:00:00Z")
+        self.assertEqual(rec["url"], "https://status.anthropic.com/incidents/x")
+
+
+class NormalizeWebhookTests(unittest.TestCase):
+    def test_none_when_no_incident(self):
+        self.assertIsNone(si.normalize_webhook_incident({}))
+
+    def test_normalizes_incident(self):
+        self.assertEqual(si.normalize_webhook_incident({"incident": {"id": "w1"}})["id"], "w1")
+
+
+class RecordChangedTests(unittest.TestCase):
+    def test_collected_at_ignored(self):
+        self.assertFalse(si.record_changed(
+            {"status": "resolved", "collected_at": "t1"},
+            {"status": "resolved", "collected_at": "t2"},
+        ))
+
+    def test_status_change_detected(self):
+        self.assertTrue(si.record_changed({"status": "investigating"}, {"status": "resolved"}))
+
+
+class UpsertRecordTests(unittest.TestCase):
+    def test_new_added(self):
+        arc: dict = {}
+        self.assertTrue(si.upsert_record(arc, {"id": "a", "status": "x"}))
+        self.assertIn("a", arc)
+
+    def test_changed_updated(self):
+        arc = {"a": {"id": "a", "status": "x"}}
+        self.assertTrue(si.upsert_record(arc, {"id": "a", "status": "y"}))
+        self.assertEqual(arc["a"]["status"], "y")
+
+    def test_unchanged_is_noop(self):
+        arc = {"a": {"id": "a", "status": "x", "name": "n"}}
+        self.assertFalse(si.upsert_record(arc, {"id": "a", "status": "x", "name": "n", "collected_at": "diff"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status_report.py
+++ b/tests/test_status_report.py
@@ -1,0 +1,67 @@
+"""Unit tests for lib/status_report.py (pure markdown-report generation)."""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".github" / "scripts"))
+
+from lib import status_report as sr  # noqa: E402
+
+SAMPLE = [
+    {"id": "1", "status": "resolved", "impact": "major",
+     "started_at": "2026-01-05T03:00:00Z", "resolved_at": "2026-01-05T04:00:00Z",
+     "duration_minutes": 60, "affected_components": ["API"]},
+    {"id": "2", "status": "resolved", "impact": "minor",
+     "started_at": "2026-01-06T10:00:00Z", "resolved_at": "2026-01-06T10:30:00Z",
+     "duration_minutes": 30, "affected_components": ["API", "Console"]},
+    {"id": "3", "status": "investigating", "impact": "major",
+     "started_at": "2026-01-07T12:00:00Z", "duration_minutes": None,
+     "affected_components": ["Console"]},
+]
+
+
+class FormatDurationTests(unittest.TestCase):
+    def test_minutes_hours_days(self):
+        self.assertEqual(sr.format_duration(45), "45m")
+        self.assertEqual(sr.format_duration(90), "1.5h")
+        self.assertEqual(sr.format_duration(60 * 24 * 2), "2.0d")
+
+
+class ExtractTimingTests(unittest.TestCase):
+    def test_splits_resolved_and_durations(self):
+        resolved, starts, durations = sr._extract_timing(SAMPLE)
+        self.assertEqual(len(resolved), 2)
+        self.assertEqual(sorted(durations), [30, 60])
+        self.assertEqual(len(starts), 3)
+
+
+class RenderBarTableTests(unittest.TestCase):
+    def test_exact_output_with_scaled_bar_and_separator(self):
+        out = sr._render_bar_table("My Title", "Hour", [("00:00", 2), ("01:00", 0)])
+        self.assertEqual(out, [
+            "## My Title", "",
+            "| Hour | Incidents | Bar |", "|------|-----------|-----|",
+            f"| 00:00 | 2 | {'#' * 20} |",
+            "| 01:00 | 0 |  |",
+            "",
+        ])
+
+
+class GenerateReportTests(unittest.TestCase):
+    def test_sections_and_counts(self):
+        rep = sr.generate_report(SAMPLE)
+        self.assertIn("# Claude Platform Outage Statistics", rep)
+        self.assertIn("- **Total incidents**: 3", rep)
+        self.assertIn("- **Resolved**: 2", rep)
+        self.assertIn("- **Unresolved/ongoing**: 1", rep)
+        self.assertIn("| Median | 45m |", rep)  # median([60,30]) = 45
+        self.assertIn("## Severity Distribution", rep)
+        self.assertIn("## Time-of-Day Distribution (UTC)", rep)
+        self.assertIn("## Uptime Estimate", rep)
+
+    def test_empty_archive(self):
+        self.assertIn("No incidents recorded yet.", sr.generate_report([]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**PR 2 of 4** in the `.github/scripts/` complexity cleanup.

`status-stats.py` and `status-collector.py` become thin IO entry points; pure logic moves to importable `lib/` modules:
- `lib/status_report.py` — report builders; `_render_bar_table()` collapses the triple bar-chart loop; `statistics.median/mean` replace hand-rolled versions.
- `lib/status_incidents.py` — `normalize_incident`/`compute_duration`/`record_changed` + a new `upsert_record()` that dedupes the if/elif.
- Scripts use `monitor_utils.load_jsonl/parse_iso/fatal`; collector `main` split into `_process_webhook`/`_process_api`.

**Behavior-preserving**: `status-stats` output is byte-identical on the 175-incident fixture (timestamp aside); collector webhook path smoke-tested (new→exit 1, unchanged→exit 0). 18 new unit tests; full suite green (51).

Generated with Claude <noreply@anthropic.com>