### PR TITLE
refactor(ci): extract changelog + native-sources logic to lib (+tests)

### DIFF
--- a/.github/scripts/changelog-compare.py
+++ b/.github/scripts/changelog-compare.py
@@ -2,337 +2,84 @@
 """Compare CC CHANGELOG.md against the scanned version range in CC-changelog-feature-scan.md.
 
 Identifies versions newer than the last scanned version and checks whether
-existing docs cover those features.
+existing docs cover those features. Pure parsing/coverage/report logic lives in
+lib/changelog.py; this entry point handles file IO and exit codes.
 
 Usage:
-    python changelog-compare.py \\
-        --changelog PATH \\
-        --scan-doc PATH \\
-        --docs-dir PATH \\
-        [--update-scan-doc]
+    python changelog-compare.py --changelog PATH --scan-doc PATH --docs-dir PATH [--update-scan-doc]
 
 Exit codes:
     0 = no new uncovered features
     1 = new features found (workflow should open a PR)
-    2 = fatal error (bad input / parse failure) — distinct from 1 so the
-        workflow fails loudly instead of treating an error as "new features"
+    2 = fatal error (bad input / parse failure) — distinct from 1 so the workflow
+        fails loudly instead of treating an error as "new features"
 """
 
 import argparse
-import re
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from lib.monitor_utils import DEFAULT_NOISE, extract_keywords
-
-
-def _fatal(message: str) -> None:
-    """Print an error to stderr and exit 2.
-
-    Exit 2 is distinct from the exit-1 "new features found" signal, so the
-    workflow can fail loudly on a real error instead of mistaking it for a PR-worthy result.
-    """
-    print(message, file=sys.stderr)
-    sys.exit(2)
-
-
-# ---------------------------------------------------------------------------
-# Parsing helpers
-# ---------------------------------------------------------------------------
-
-def parse_scanned_version(scan_doc_path: Path) -> str:
-    """Extract the last scanned version from the scan doc frontmatter.
-
-    Looks for a ``purpose:`` field containing a version range like
-    ``v2.1.0-2.1.71`` or ``v2.1.0–2.1.71`` (en-dash or hyphen).
-
-    Returns the end version string, e.g. ``"2.1.71"``.
-    Raises ``SystemExit`` if not found.
-    """
-    text = scan_doc_path.read_text(encoding="utf-8")
-    # Match frontmatter block between --- markers
-    fm_match = re.search(r"^---\s*\n(.*?)\n---", text, re.DOTALL | re.MULTILINE)
-    if not fm_match:
-        _fatal(f"ERROR: No frontmatter found in {scan_doc_path}")
-
-    frontmatter = fm_match.group(1)
-    # purpose: ... (v2.1.0–2.1.71) ...
-    # Capture range after 'v' with either hyphen or en-dash separator
-    purpose_match = re.search(
-        r"purpose:.*?v(\d+\.\d+\.\d+)[–\-](\d+\.\d+\.\d+)", frontmatter
-    )
-    if not purpose_match:
-        _fatal(
-            f"ERROR: Could not find version range in purpose field of {scan_doc_path}"
-        )
-
-    return purpose_match.group(2)  # end of range
-
-
-def update_scanned_version(scan_doc_path: Path, new_end_version: str) -> None:
-    """Bump the end version in the scan doc frontmatter.
-
-    Replaces the version range end in the ``purpose:`` field, e.g.
-    ``v2.1.0–2.1.71`` becomes ``v2.1.0–2.1.85``.
-    """
-    text = scan_doc_path.read_text(encoding="utf-8")
-    updated = re.sub(
-        r"(purpose:.*?v\d+\.\d+\.\d+[–\-])\d+\.\d+\.\d+",
-        rf"\g<1>{new_end_version}",
-        text,
-        count=1,
-    )
-    if updated == text:
-        print(
-            f"WARNING: Could not update version in {scan_doc_path}", file=sys.stderr
-        )
-        return
-    scan_doc_path.write_text(updated, encoding="utf-8")
-    print(f"Updated scan doc version range end to {new_end_version}", file=sys.stderr)
-
-
-def version_tuple(v: str) -> tuple[int, ...]:
-    """Convert a version string like '2.1.71' to a comparable tuple."""
-    return tuple(int(x) for x in v.split("."))
-
-
-def parse_changelog_versions(changelog_path: Path) -> list[tuple[str, list[str]]]:
-    """Parse CHANGELOG.md into a list of (version, feature_lines) pairs.
-
-    Expects section headers like ``## 2.1.72`` or ``## [2.1.72]``.
-    Returns list sorted descending (newest first).
-    """
-    text = changelog_path.read_text(encoding="utf-8")
-    # Split on version section headers
-    # Format: ## x.y.z  or  ## [x.y.z]
-    section_pattern = re.compile(
-        r"^##\s+\[?(\d+\.\d+\.\d+)\]?", re.MULTILINE
-    )
-    matches = list(section_pattern.finditer(text))
-    if not matches:
-        _fatal(f"ERROR: No version sections found in {changelog_path}")
-
-    versions: list[tuple[str, list[str]]] = []
-    for i, match in enumerate(matches):
-        version = match.group(1)
-        start = match.end()
-        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
-        section_text = text[start:end]
-
-        # Extract non-empty, non-header lines as feature lines
-        feature_lines = [
-            line.strip()
-            for line in section_text.splitlines()
-            if line.strip() and not line.strip().startswith("#")
-        ]
-        versions.append((version, feature_lines))
-
-    # Sort descending
-    versions.sort(key=lambda t: version_tuple(t[0]), reverse=True)
-    return versions
-
-
-def collect_doc_index(docs_dir: Path) -> dict[str, list[str]]:
-    """Build an index of doc file paths to list of H2/H3 headings.
-
-    Only scans ``*.md`` files under ``docs_dir`` recursively.
-    Returns ``{relative_path: [heading_text, ...]}``.
-    """
-    index: dict[str, list[str]] = {}
-    for md_file in sorted(docs_dir.rglob("*.md")):
-        rel = str(md_file.relative_to(docs_dir.parent))
-        headings: list[str] = []
-        for line in md_file.read_text(encoding="utf-8", errors="replace").splitlines():
-            h_match = re.match(r"^#{2,3}\s+(.*)", line)
-            if h_match:
-                headings.append(h_match.group(1).strip())
-        index[rel] = headings
-    return index
-
-
-# ---------------------------------------------------------------------------
-# Coverage checking
-# ---------------------------------------------------------------------------
-
-_NOISE_ONLY_PATTERNS = re.compile(
-    r"^[-\s]*bug fixes and reliability improvements\.?\s*$",
-    re.IGNORECASE,
+from lib.changelog import (
+    bump_scanned_version,
+    classify_versions,
+    collect_doc_keyword_index,
+    extract_scanned_version,
+    parse_changelog_versions,
+    render_changelog_report,
+    version_tuple,
 )
+from lib.monitor_utils import fatal
 
-_COVERAGE_THRESHOLD = 0.4
-
-
-def find_covering_docs(
-    feature_line: str, doc_index: dict[str, list[str]]
-) -> list[str]:
-    """Return list of doc paths that meaningfully cover the feature.
-
-    Uses a keyword-overlap threshold (>= 0.4 of non-noise feature keywords)
-    against each doc's filename + headings, matching the approach used by the
-    native-sources monitor.  Pure "Bug fixes and reliability improvements" lines
-    are treated as non-actionable and return an empty list (caller marks them
-    skipped rather than covered).
-    """
-    if _NOISE_ONLY_PATTERNS.match(feature_line.strip("- ")):
-        return []
-
-    feature_kw = extract_keywords(feature_line) - DEFAULT_NOISE
-    if not feature_kw:
-        return []
-
-    covering: list[str] = []
-    for path, headings in doc_index.items():
-        doc_kw: set[str] = extract_keywords(Path(path).name)
-        for heading in headings:
-            doc_kw.update(extract_keywords(heading))
-
-        overlap = feature_kw & doc_kw
-        if len(overlap) / len(feature_kw) > _COVERAGE_THRESHOLD:
-            covering.append(path)
-
-    return covering
-
-
-# ---------------------------------------------------------------------------
-# Report generation
-# ---------------------------------------------------------------------------
-
-def build_report(
-    new_versions: list[tuple[str, list[str]]],
-    doc_index: dict[str, list[str]],
-    last_scanned: str,
-) -> tuple[str, bool]:
-    """Build a markdown report and return (report_text, has_uncovered).
-
-    ``has_uncovered`` is True when at least one feature line has no covering doc.
-    """
-    lines: list[str] = [
-        "## Changelog Monitor Report",
-        "",
-        f"Last scanned version: **{last_scanned}**",
-        f"New versions detected: **{len(new_versions)}**",
-        "",
-    ]
-
-    has_uncovered = False
-
-    if not new_versions:
-        lines += [
-            "No new versions found beyond the scanned range. Nothing to review.",
-        ]
-        return "\n".join(lines).rstrip("\n"), False
-
-    # Summary table
-    lines += [
-        "### New Versions Summary",
-        "",
-        "| Version | Features | Covered | Uncovered |",
-        "|---------|----------|---------|-----------|",
-    ]
-
-    per_version: list[tuple[str, list[tuple[str, list[str]]]]] = []
-
-    for version, feature_lines in new_versions:
-        covered: list[tuple[str, list[str]]] = []
-        uncovered: list[tuple[str, list[str]]] = []
-        for feat in feature_lines:
-            docs = find_covering_docs(feat, doc_index)
-            if docs:
-                covered.append((feat, docs))
-            else:
-                uncovered.append((feat, []))
-        per_version.append((version, covered + uncovered))
-
-        if uncovered:
-            has_uncovered = True
-
-        lines.append(
-            f"| {version} | {len(feature_lines)} "
-            f"| {len(covered)} | {len(uncovered)} |"
-        )
-
-    lines.append("")
-
-    # Detailed breakdown
-    lines += ["### Feature Coverage Details", ""]
-
-    for version, features in per_version:
-        lines += [f"#### v{version}", ""]
-        for feat, docs in features:
-            if docs:
-                doc_links = ", ".join(f"`{d}`" for d in docs[:3])
-                lines.append(f"- **[covered]** {feat}")
-                lines.append(f"  - Covered by: {doc_links}")
-            else:
-                lines.append(f"- **[UNCOVERED]** {feat}")
-        lines.append("")
-
-    lines += [
-        "---",
-        "_Generated by `.github/scripts/changelog-compare.py`_",
-    ]
-
-    return "\n".join(lines).rstrip("\n"), has_uncovered
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
 
 def main() -> None:
     """Entry point for the changelog comparison script."""
     parser = argparse.ArgumentParser(
         description="Compare CC CHANGELOG.md against scanned version range."
     )
-    parser.add_argument(
-        "--changelog", required=True, type=Path,
-        help="Path to fetched CHANGELOG.md"
-    )
-    parser.add_argument(
-        "--scan-doc", required=True, type=Path,
-        help="Path to CC-changelog-feature-scan.md (contains frontmatter with version range)"
-    )
-    parser.add_argument(
-        "--docs-dir", required=True, type=Path,
-        help="Path to docs/ directory to search for coverage"
-    )
-    parser.add_argument(
-        "--update-scan-doc", action="store_true",
-        help="Bump the scan doc frontmatter to the newest changelog version"
-    )
+    parser.add_argument("--changelog", required=True, type=Path,
+                        help="Path to fetched CHANGELOG.md")
+    parser.add_argument("--scan-doc", required=True, type=Path,
+                        help="Path to CC-changelog-feature-scan.md (frontmatter version range)")
+    parser.add_argument("--docs-dir", required=True, type=Path,
+                        help="Path to docs/ directory to search for coverage")
+    parser.add_argument("--update-scan-doc", action="store_true",
+                        help="Bump the scan doc frontmatter to the newest changelog version")
     args = parser.parse_args()
 
-    # Validate inputs
     for p in (args.changelog, args.scan_doc, args.docs_dir):
         if not p.exists():
-            _fatal(f"ERROR: Path does not exist: {p}")
+            fatal(f"ERROR: Path does not exist: {p}")
 
-    last_scanned = parse_scanned_version(args.scan_doc)
+    scan_text = args.scan_doc.read_text(encoding="utf-8")
+    last_scanned = extract_scanned_version(scan_text)
+    if last_scanned is None:
+        fatal(f"ERROR: Could not parse scanned version range from {args.scan_doc}")
     print(f"Last scanned version: {last_scanned}", file=sys.stderr)
 
-    all_versions = parse_changelog_versions(args.changelog)
+    all_versions = parse_changelog_versions(args.changelog.read_text(encoding="utf-8"))
+    if not all_versions:
+        fatal(f"ERROR: No version sections found in {args.changelog}")
     cutoff = version_tuple(last_scanned)
-    new_versions = [
-        (v, feats)
-        for v, feats in all_versions
-        if version_tuple(v) > cutoff
-    ]
+    new_versions = [(v, feats) for v, feats in all_versions if version_tuple(v) > cutoff]
     print(f"New versions found: {len(new_versions)}", file=sys.stderr)
 
-    doc_index = collect_doc_index(args.docs_dir)
-    print(f"Docs indexed: {len(doc_index)}", file=sys.stderr)
+    keyword_index = collect_doc_keyword_index(args.docs_dir)
+    print(f"Docs indexed: {len(keyword_index)}", file=sys.stderr)
 
-    report, has_uncovered = build_report(new_versions, doc_index, last_scanned)
+    results = classify_versions(new_versions, keyword_index)
+    report, has_uncovered = render_changelog_report(results, last_scanned)
 
-    # Bump scan doc version if requested and there are new versions
     if args.update_scan_doc and new_versions:
-        newest_version = new_versions[0][0]  # already sorted descending
-        update_scanned_version(args.scan_doc, newest_version)
+        newest = new_versions[0][0]  # already sorted descending
+        updated = bump_scanned_version(scan_text, newest)
+        if updated is not None:
+            args.scan_doc.write_text(updated, encoding="utf-8")
+            print(f"Updated scan doc version range end to {newest}", file=sys.stderr)
+        else:
+            print(f"WARNING: Could not update version in {args.scan_doc}", file=sys.stderr)
 
-    # Output report to stdout (captured by workflow)
     print(report)
-
     sys.exit(1 if has_uncovered else 0)
 
 

--- a/.github/scripts/lib/changelog.py
+++ b/.github/scripts/lib/changelog.py
@@ -1,0 +1,169 @@
+"""Pure changelog-vs-docs comparison logic for changelog-compare.py.
+
+No file IO / argparse / sys.exit here (the entry script reads files and handles
+exit codes), so the parsing, coverage, and report logic is unit-testable.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from .monitor_utils import DEFAULT_NOISE, extract_keywords
+
+_NOISE_ONLY = re.compile(
+    r"^[-\s]*bug fixes and reliability improvements\.?\s*$", re.IGNORECASE
+)
+_COVERAGE_THRESHOLD = 0.4
+_VERSION_SECTION = re.compile(r"^##\s+\[?(\d+\.\d+\.\d+)\]?", re.MULTILINE)
+
+
+def version_tuple(v: str) -> tuple[int, ...]:
+    """Convert a version string like '2.1.71' to a comparable tuple."""
+    return tuple(int(x) for x in v.split("."))
+
+
+def extract_scanned_version(scan_doc_text: str) -> str | None:
+    """End of the version range in the scan-doc frontmatter purpose field, or None.
+
+    Looks for ``purpose: ... vX.Y.Z–A.B.C ...`` (en-dash or hyphen) and returns
+    the end version (``A.B.C``).
+    """
+    fm = re.search(r"^---\s*\n(.*?)\n---", scan_doc_text, re.DOTALL | re.MULTILINE)
+    if not fm:
+        return None
+    m = re.search(r"purpose:.*?v(\d+\.\d+\.\d+)[–\-](\d+\.\d+\.\d+)", fm.group(1))
+    return m.group(2) if m else None
+
+
+def bump_scanned_version(scan_doc_text: str, new_end_version: str) -> str | None:
+    """Return scan-doc text with the range end bumped, or None if nothing changed."""
+    updated = re.sub(
+        r"(purpose:.*?v\d+\.\d+\.\d+[–\-])\d+\.\d+\.\d+",
+        rf"\g<1>{new_end_version}",
+        scan_doc_text,
+        count=1,
+    )
+    return updated if updated != scan_doc_text else None
+
+
+def parse_changelog_versions(text: str) -> list[tuple[str, list[str]]]:
+    """Parse CHANGELOG text into ``[(version, feature_lines)]``, newest first.
+
+    Section headers look like ``## 2.1.72`` or ``## [2.1.72]``. Feature lines are
+    the non-empty, non-heading lines within each section.
+    """
+    matches = list(_VERSION_SECTION.finditer(text))
+    versions: list[tuple[str, list[str]]] = []
+    for match, nxt in zip(matches, matches[1:] + [None]):
+        section = text[match.end():(nxt.start() if nxt else len(text))]
+        feature_lines = [
+            line.strip()
+            for line in section.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        versions.append((match.group(1), feature_lines))
+    versions.sort(key=lambda t: version_tuple(t[0]), reverse=True)
+    return versions
+
+
+def collect_doc_keyword_index(docs_dir: Path) -> dict[str, frozenset[str]]:
+    """Map each ``*.md`` doc's relative path to its keyword set (filename + H2/H3).
+
+    Pre-computing keywords once here avoids rebuilding them per feature line in
+    find_covering_docs.
+    """
+    heading_re = re.compile(r"^#{2,3}\s+(.*)")
+    index: dict[str, frozenset[str]] = {}
+    for md in sorted(docs_dir.rglob("*.md")):
+        rel = str(md.relative_to(docs_dir.parent))
+        kw = set(extract_keywords(md.name))
+        for line in md.read_text(encoding="utf-8", errors="replace").splitlines():
+            m = heading_re.match(line)
+            if m:
+                kw.update(extract_keywords(m.group(1).strip()))
+        index[rel] = frozenset(kw)
+    return index
+
+
+def find_covering_docs(
+    feature_line: str, keyword_index: dict[str, frozenset[str]]
+) -> list[str]:
+    """Doc paths whose keywords overlap the feature's keywords past the threshold.
+
+    Pure "Bug fixes and reliability improvements" lines and keyword-empty lines
+    return ``[]`` (the caller then marks them uncovered).
+    """
+    if _NOISE_ONLY.match(feature_line.strip("- ")):
+        return []
+    feature_kw = extract_keywords(feature_line) - DEFAULT_NOISE
+    if not feature_kw:
+        return []
+    return [
+        path for path, doc_kw in keyword_index.items()
+        if len(feature_kw & doc_kw) / len(feature_kw) > _COVERAGE_THRESHOLD
+    ]
+
+
+@dataclass
+class VersionCoverage:
+    """Coverage breakdown for one changelog version."""
+    version: str
+    covered: list[tuple[str, list[str]]]  # (feature_line, covering_doc_paths)
+    uncovered: list[str]                   # feature_lines with no covering doc
+
+
+def classify_versions(
+    new_versions: list[tuple[str, list[str]]],
+    keyword_index: dict[str, frozenset[str]],
+) -> list[VersionCoverage]:
+    """Split each version's feature lines into covered / uncovered."""
+    results: list[VersionCoverage] = []
+    for version, feature_lines in new_versions:
+        covered: list[tuple[str, list[str]]] = []
+        uncovered: list[str] = []
+        for feat in feature_lines:
+            docs = find_covering_docs(feat, keyword_index)
+            if docs:
+                covered.append((feat, docs))
+            else:
+                uncovered.append(feat)
+        results.append(VersionCoverage(version, covered, uncovered))
+    return results
+
+
+def render_changelog_report(
+    results: list[VersionCoverage], last_scanned: str
+) -> tuple[str, bool]:
+    """Render the markdown report; returns ``(report_text, has_uncovered)``."""
+    lines: list[str] = [
+        "## Changelog Monitor Report", "",
+        f"Last scanned version: **{last_scanned}**",
+        f"New versions detected: **{len(results)}**", "",
+    ]
+    if not results:
+        lines.append("No new versions found beyond the scanned range. Nothing to review.")
+        return "\n".join(lines).rstrip("\n"), False
+
+    lines += ["### New Versions Summary", "",
+              "| Version | Features | Covered | Uncovered |",
+              "|---------|----------|---------|-----------|"]
+    for r in results:
+        lines.append(
+            f"| {r.version} | {len(r.covered) + len(r.uncovered)} "
+            f"| {len(r.covered)} | {len(r.uncovered)} |"
+        )
+    lines.append("")
+
+    lines += ["### Feature Coverage Details", ""]
+    for r in results:
+        lines += [f"#### v{r.version}", ""]
+        for feat, docs in r.covered:
+            lines.append(f"- **[covered]** {feat}")
+            lines.append(f"  - Covered by: {', '.join(f'`{d}`' for d in docs[:3])}")
+        for feat in r.uncovered:
+            lines.append(f"- **[UNCOVERED]** {feat}")
+        lines.append("")
+
+    lines += ["---", "_Generated by `.github/scripts/changelog-compare.py`_"]
+    return "\n".join(lines).rstrip("\n"), any(r.uncovered for r in results)

--- a/.github/scripts/lib/native_sources.py
+++ b/.github/scripts/lib/native_sources.py
@@ -1,0 +1,77 @@
+"""Pure extractors + GraphQL-response navigation for native-sources-monitor.py.
+
+No HTTP / os.environ / sys.exit here (the entry script does the fetching), so the
+HTML/JSON parsing is unit-testable.
+"""
+from __future__ import annotations
+
+import re
+
+from .monitor_utils import strip_html_noise
+
+
+def extract_blog_entries(html: str) -> list[dict[str, str]]:
+    """Extract Anthropic /news blog links from HTML (deduped by URL, single pass)."""
+    clean = strip_html_noise(html)
+    seen: set[str] = set()
+    entries: list[dict[str, str]] = []
+    for match in re.finditer(r'<a[^>]+href="(/news/[^"]+)"[^>]*>(.*?)</a>', clean, re.DOTALL):
+        title = re.sub(r"<[^>]+>", "", match.group(2)).strip()
+        url = f"https://www.anthropic.com{match.group(1)}"
+        if not title or len(title) < 5 or url in seen:
+            continue
+        seen.add(url)
+        entries.append({"name": title, "url": url, "description": title, "heading": "Anthropic Blog"})
+    return entries
+
+
+def extract_issues(json_pages: list[list[dict]]) -> list[dict[str, str]]:
+    """Extract entries from GitHub REST Issues API response pages (skipping PRs)."""
+    return [
+        {
+            "name": issue.get("title", ""),
+            "url": issue.get("html_url", ""),
+            "description": (issue.get("body") or "")[:200],
+            "heading": "GitHub Issues (enhancement)",
+        }
+        for page in json_pages
+        for issue in page
+        if "pull_request" not in issue
+    ]
+
+
+def extract_discussions(nodes: list[dict]) -> list[dict[str, str]]:
+    """Extract entries from GitHub GraphQL Discussions response nodes."""
+    return [
+        {
+            "name": node.get("title", ""),
+            "url": node.get("url", ""),
+            "description": (node.get("body") or "")[:200],
+            "heading": f"GitHub Discussions ({node.get('category', {}).get('name', 'feature-request')})",
+        }
+        for node in nodes
+    ]
+
+
+def feature_category_id(graphql_data: dict | None) -> str | None:
+    """Pick the 'feature' discussion category id from a categories GraphQL response."""
+    if graphql_data is None:
+        return None
+    categories = (
+        graphql_data.get("data", {}).get("repository", {})
+        .get("discussionCategories", {}).get("nodes", [])
+    )
+    for cat in categories:
+        if "feature" in cat.get("name", "").lower():
+            return cat["id"]
+    return None
+
+
+def discussion_page(graphql_data: dict | None) -> tuple[list[dict], dict]:
+    """Extract ``(nodes, pageInfo)`` from a discussions GraphQL response."""
+    if graphql_data is None:
+        return [], {}
+    discussions = (
+        graphql_data.get("data", {}).get("repository", {}).get("discussions", {})
+    )
+    return discussions.get("nodes", []), discussions.get("pageInfo", {})

--- a/.github/scripts/native-sources-monitor.py
+++ b/.github/scripts/native-sources-monitor.py
@@ -3,11 +3,10 @@
 
 Polls Anthropic Blog, GitHub Issues (enhancement), and GitHub Discussions
 (feature-request) for new entries not yet covered by existing native docs.
+Pure HTML/JSON parsing lives in lib/native_sources.py.
 
 Usage:
-    python native-sources-monitor.py \\
-        --native-docs-dir PATH \\
-        [--state-file PATH]
+    python native-sources-monitor.py --native-docs-dir PATH [--state-file PATH]
 
 Exit codes:
     0 = no new uncovered content
@@ -19,21 +18,23 @@ import json
 import os
 import re
 import sys
+import urllib.error
 import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from lib.monitor_utils import (
-    fetch_text,
-    run_monitor,
+from lib.monitor_utils import fetch_text, run_monitor
+from lib.native_sources import (
+    discussion_page,
+    extract_blog_entries,
+    extract_discussions,
+    extract_issues,
+    feature_category_id,
 )
-
-# ---------------------------------------------------------------------------
-# Source definitions
-# ---------------------------------------------------------------------------
 
 CC_REPO_OWNER = "anthropics"
 CC_REPO_NAME = "claude-code"
+MAX_PAGES = 3
 
 SOURCES: list[dict[str, str]] = [
     {
@@ -61,81 +62,6 @@ SOURCES: list[dict[str, str]] = [
     },
 ]
 
-MAX_PAGES = 3
-
-
-# ---------------------------------------------------------------------------
-# Extractors
-# ---------------------------------------------------------------------------
-
-def extract_blog_entries(html: str) -> list[dict[str, str]]:
-    """Extract blog post entries from Anthropic /news HTML.
-
-    Looks for link+text patterns that mention Claude Code or related features.
-    """
-    entries: list[dict[str, str]] = []
-
-    # Strip script/style
-    clean = re.sub(r"<script[^>]*>.*?</script[^>]*>", "", html, flags=re.DOTALL | re.IGNORECASE)
-    clean = re.sub(r"<style[^>]*>.*?</style[^>]*>", "", clean, flags=re.DOTALL | re.IGNORECASE)
-
-    # Extract links with text: <a href="...">Title</a>
-    for match in re.finditer(r'<a[^>]+href="(/news/[^"]+)"[^>]*>(.*?)</a>', clean, re.DOTALL):
-        href = match.group(1)
-        title = re.sub(r"<[^>]+>", "", match.group(2)).strip()
-        if not title or len(title) < 5:
-            continue
-        entries.append({
-            "name": title,
-            "url": f"https://www.anthropic.com{href}",
-            "description": title,
-            "heading": "Anthropic Blog",
-        })
-
-    # Deduplicate by URL
-    seen_urls: set[str] = set()
-    deduped: list[dict[str, str]] = []
-    for entry in entries:
-        if entry["url"] not in seen_urls:
-            seen_urls.add(entry["url"])
-            deduped.append(entry)
-
-    return deduped
-
-
-def extract_issues(json_pages: list[list[dict]]) -> list[dict[str, str]]:
-    """Extract entries from GitHub REST Issues API response pages."""
-    entries: list[dict[str, str]] = []
-    for page in json_pages:
-        for issue in page:
-            # Skip pull requests (they have a pull_request key)
-            if "pull_request" in issue:
-                continue
-            entries.append({
-                "name": issue.get("title", ""),
-                "url": issue.get("html_url", ""),
-                "description": (issue.get("body") or "")[:200],
-                "heading": "GitHub Issues (enhancement)",
-            })
-    return entries
-
-
-def extract_discussions(nodes: list[dict]) -> list[dict[str, str]]:
-    """Extract entries from GitHub GraphQL Discussions response nodes."""
-    entries: list[dict[str, str]] = []
-    for node in nodes:
-        entries.append({
-            "name": node.get("title", ""),
-            "url": node.get("url", ""),
-            "description": (node.get("body") or "")[:200],
-            "heading": f"GitHub Discussions ({node.get('category', {}).get('name', 'feature-request')})",
-        })
-    return entries
-
-
-# ---------------------------------------------------------------------------
-# GitHub API helpers
-# ---------------------------------------------------------------------------
 
 def github_headers(token: str) -> dict[str, str]:
     """Build GitHub API request headers."""
@@ -150,21 +76,31 @@ def fetch_github_rest_pages(url: str, token: str) -> list[list[dict]]:
     """Fetch paginated GitHub REST API results (up to MAX_PAGES)."""
     pages: list[list[dict]] = []
     current_url: str | None = url
-
     for _ in range(MAX_PAGES):
         if current_url is None:
             break
-        headers = github_headers(token)
-        req = urllib.request.Request(current_url, headers=headers)
+        req = urllib.request.Request(current_url, headers=github_headers(token))
         with urllib.request.urlopen(req, timeout=30) as resp:
             pages.append(json.loads(resp.read().decode("utf-8")))
-
-            # Parse Link header for next page
-            link_header = resp.headers.get("Link", "")
-            next_match = re.search(r'<([^>]+)>;\s*rel="next"', link_header)
+            next_match = re.search(r'<([^>]+)>;\s*rel="next"', resp.headers.get("Link", ""))
             current_url = next_match.group(1) if next_match else None
-
     return pages
+
+
+def graphql_request(query: str, variables: dict, token: str) -> dict | None:
+    """Execute a GitHub GraphQL request (None on network failure)."""
+    payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+    headers = github_headers(token)
+    headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        "https://api.github.com/graphql", data=payload, headers=headers, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.URLError as e:
+        print(f"WARNING: GraphQL request failed: {e}", file=sys.stderr)
+        return None
 
 
 def resolve_discussion_category_id(token: str) -> str | None:
@@ -178,28 +114,14 @@ def resolve_discussion_category_id(token: str) -> str | None:
       }
     }
     """
-    variables = {"owner": CC_REPO_OWNER, "name": CC_REPO_NAME}
-    data = graphql_request(query, variables, token)
-    if data is None:
-        return None
-
-    categories = (
-        data.get("data", {})
-        .get("repository", {})
-        .get("discussionCategories", {})
-        .get("nodes", [])
-    )
-    for cat in categories:
-        if "feature" in cat.get("name", "").lower():
-            return cat["id"]
-    return None
+    data = graphql_request(query, {"owner": CC_REPO_OWNER, "name": CC_REPO_NAME}, token)
+    return feature_category_id(data)
 
 
 def fetch_discussions_graphql(token: str, category_id: str | None) -> list[dict]:
     """Fetch discussions via GraphQL with cursor pagination (up to MAX_PAGES)."""
     all_nodes: list[dict] = []
     cursor: str | None = None
-
     query = """
     query($owner: String!, $name: String!, $categoryId: ID, $after: String) {
       repository(owner: $owner, name: $name) {
@@ -210,116 +132,51 @@ def fetch_discussions_graphql(token: str, category_id: str | None) -> list[dict]
       }
     }
     """
-
     for _ in range(MAX_PAGES):
-        variables: dict = {
-            "owner": CC_REPO_OWNER,
-            "name": CC_REPO_NAME,
-            "after": cursor,
-        }
+        variables: dict = {"owner": CC_REPO_OWNER, "name": CC_REPO_NAME, "after": cursor}
         if category_id:
             variables["categoryId"] = category_id
-
-        data = graphql_request(query, variables, token)
-        if data is None:
-            break
-
-        discussions = (
-            data.get("data", {})
-            .get("repository", {})
-            .get("discussions", {})
-        )
-        nodes = discussions.get("nodes", [])
+        nodes, page_info = discussion_page(graphql_request(query, variables, token))
         all_nodes.extend(nodes)
-
-        page_info = discussions.get("pageInfo", {})
         if not page_info.get("hasNextPage"):
             break
         cursor = page_info.get("endCursor")
-
     return all_nodes
 
-
-def graphql_request(
-    query: str, variables: dict, token: str
-) -> dict | None:
-    """Execute a GitHub GraphQL request."""
-    payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
-    headers = github_headers(token)
-    headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(
-        "https://api.github.com/graphql",
-        data=payload,
-        headers=headers,
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return json.loads(resp.read().decode("utf-8"))
-    except urllib.error.URLError as e:
-        print(f"WARNING: GraphQL request failed: {e}", file=sys.stderr)
-        return None
-
-
-# ---------------------------------------------------------------------------
-# Source dispatching
-# ---------------------------------------------------------------------------
 
 def fetch_and_extract(source: dict[str, str]) -> list[dict[str, str]]:
     """Fetch a source and extract entries based on its type and auth.
 
-    Returns extracted entries. Skips with WARNING on auth/network failures.
+    Skips github-token sources (returning []) when no token is set.
     """
     source_type = source["type"]
-    auth = source["auth"]
-
-    # Check auth requirements
-    if auth == "github_token":
-        token = os.environ.get("GITHUB_TOKEN", "")
-        if not token:
-            print(
-                f"WARNING: Skipping {source['name']} — GITHUB_TOKEN not set",
-                file=sys.stderr,
-            )
-            return []
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if source["auth"] == "github_token" and not token:
+        print(f"WARNING: Skipping {source['name']} — GITHUB_TOKEN not set", file=sys.stderr)
+        return []
 
     if source_type == "html":
-        html = fetch_text(source["url"])
-        return extract_blog_entries(html)
-
+        return extract_blog_entries(fetch_text(source["url"]))
     if source_type == "github_rest":
-        token = os.environ["GITHUB_TOKEN"]
-        pages = fetch_github_rest_pages(source["url"], token)
-        return extract_issues(pages)
-
+        return extract_issues(fetch_github_rest_pages(source["url"], token))
     if source_type == "github_graphql":
-        token = os.environ["GITHUB_TOKEN"]
         category_id = resolve_discussion_category_id(token)
-        nodes = fetch_discussions_graphql(token, category_id)
-        return extract_discussions(nodes)
+        return extract_discussions(fetch_discussions_graphql(token, category_id))
 
     print(f"WARNING: Unknown source type '{source_type}'", file=sys.stderr)
     return []
 
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
 
 def main() -> None:
     """Entry point for the native sources monitor script."""
     parser = argparse.ArgumentParser(
         description="Monitor native/Anthropic sources for CC updates."
     )
-    parser.add_argument(
-        "--native-docs-dir", required=True, type=Path,
-        help="Path to docs/cc-native/ directory",
-    )
-    parser.add_argument(
-        "--state-file", type=Path,
-        default=Path(".github/state/native-monitor-state.json"),
-        help="Path to state file tracking previously seen entries",
-    )
+    parser.add_argument("--native-docs-dir", required=True, type=Path,
+                        help="Path to docs/cc-native/ directory")
+    parser.add_argument("--state-file", type=Path,
+                        default=Path(".github/state/native-monitor-state.json"),
+                        help="Path to state file tracking previously seen entries")
     args = parser.parse_args()
 
     if not args.native_docs_dir.exists():

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,77 @@
+"""Unit tests for lib/changelog.py (pure changelog-vs-docs comparison logic)."""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".github" / "scripts"))
+
+from lib import changelog as cl  # noqa: E402
+
+IDX = {"docs/sandbox.md": frozenset({"sandboxing", "controls", "bash"})}
+
+
+class VersionTupleTests(unittest.TestCase):
+    def test_compares(self):
+        self.assertTrue(cl.version_tuple("2.1.80") > cl.version_tuple("2.1.71"))
+
+
+class ScannedVersionTests(unittest.TestCase):
+    def test_extracts_range_end(self):
+        self.assertEqual(
+            cl.extract_scanned_version("---\npurpose: scan (v2.1.0-2.1.71) here\n---\n"),
+            "2.1.71",
+        )
+
+    def test_none_without_frontmatter_or_range(self):
+        self.assertIsNone(cl.extract_scanned_version("no frontmatter"))
+        self.assertIsNone(cl.extract_scanned_version("---\npurpose: no range\n---\n"))
+
+    def test_bump(self):
+        out = cl.bump_scanned_version("---\npurpose: (v2.1.0-2.1.71)\n---\n", "2.1.85")
+        self.assertIn("v2.1.0-2.1.85", out)
+        self.assertIsNone(cl.bump_scanned_version("no version", "2.1.85"))
+
+
+class ParseChangelogTests(unittest.TestCase):
+    def test_sections_newest_first_and_feature_lines(self):
+        text = "# CL\n\n## 2.1.71\n- Old\n\n## 2.1.80\n- Feature A\n- Feature B\n"
+        versions = cl.parse_changelog_versions(text)
+        self.assertEqual([v for v, _ in versions], ["2.1.80", "2.1.71"])
+        self.assertEqual(versions[0][1], ["- Feature A", "- Feature B"])
+
+
+class FindCoveringDocsTests(unittest.TestCase):
+    def test_covered_uncovered_and_noise(self):
+        self.assertEqual(
+            cl.find_covering_docs("New sandboxing controls for the bash tool", IDX),
+            ["docs/sandbox.md"],
+        )
+        self.assertEqual(cl.find_covering_docs("Totally unrelated xyzzy widget", IDX), [])
+        self.assertEqual(cl.find_covering_docs("- Bug fixes and reliability improvements", IDX), [])
+
+
+class ReportTests(unittest.TestCase):
+    def test_covered(self):
+        results = cl.classify_versions(
+            [("2.1.80", ["- New sandboxing controls for the bash tool"])], IDX
+        )
+        report, has_unc = cl.render_changelog_report(results, "2.1.71")
+        self.assertIn("## Changelog Monitor Report", report)
+        self.assertIn("Last scanned version: **2.1.71**", report)
+        self.assertIn("- **[covered]** - New sandboxing controls for the bash tool", report)
+        self.assertFalse(has_unc)
+
+    def test_uncovered(self):
+        results = cl.classify_versions([("2.2.0", ["- novel xyzzy thing"])], IDX)
+        report, has_unc = cl.render_changelog_report(results, "2.1.71")
+        self.assertIn("- **[UNCOVERED]** - novel xyzzy thing", report)
+        self.assertTrue(has_unc)
+
+    def test_empty(self):
+        report, has_unc = cl.render_changelog_report([], "2.1.71")
+        self.assertIn("No new versions found", report)
+        self.assertFalse(has_unc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_sources.py
+++ b/tests/test_native_sources.py
@@ -1,0 +1,71 @@
+"""Unit tests for lib/native_sources.py (pure extractors + GraphQL navigation)."""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".github" / "scripts"))
+
+from lib import native_sources as ns  # noqa: E402
+
+
+class ExtractBlogEntriesTests(unittest.TestCase):
+    def test_extracts_dedups_and_skips_short_and_strips_noise(self):
+        html = (
+            "<script>x</script>"
+            '<a href="/news/claude-code-update">Claude Code Update</a>'
+            '<a href="/news/claude-code-update">Claude Code Update</a>'  # dup URL
+            '<a href="/news/short">hi</a>'                                # title < 5
+            '<a href="/news/agents">New <b>agent</b> teams</a>'           # inner tags stripped
+        )
+        entries = ns.extract_blog_entries(html)
+        urls = [e["url"] for e in entries]
+        self.assertEqual(urls, [
+            "https://www.anthropic.com/news/claude-code-update",
+            "https://www.anthropic.com/news/agents",
+        ])
+        self.assertEqual(entries[1]["name"], "New agent teams")
+        self.assertEqual(entries[0]["heading"], "Anthropic Blog")
+
+
+class ExtractIssuesTests(unittest.TestCase):
+    def test_skips_prs_and_truncates_body(self):
+        pages = [[
+            {"title": "Feature X", "html_url": "u1", "body": "b" * 300},
+            {"title": "A PR", "html_url": "u2", "pull_request": {}},
+        ]]
+        entries = ns.extract_issues(pages)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "Feature X")
+        self.assertEqual(len(entries[0]["description"]), 200)
+
+
+class ExtractDiscussionsTests(unittest.TestCase):
+    def test_maps_fields_and_category(self):
+        nodes = [{"title": "T", "url": "u", "body": None, "category": {"name": "Feature Requests"}}]
+        entries = ns.extract_discussions(nodes)
+        self.assertEqual(entries[0]["name"], "T")
+        self.assertEqual(entries[0]["description"], "")
+        self.assertEqual(entries[0]["heading"], "GitHub Discussions (Feature Requests)")
+
+
+class GraphQLNavigationTests(unittest.TestCase):
+    def test_feature_category_id(self):
+        data = {"data": {"repository": {"discussionCategories": {"nodes": [
+            {"id": "c1", "name": "General"}, {"id": "c2", "name": "Feature Requests"},
+        ]}}}}
+        self.assertEqual(ns.feature_category_id(data), "c2")
+        self.assertIsNone(ns.feature_category_id(None))
+        self.assertIsNone(ns.feature_category_id({"data": {"repository": {"discussionCategories": {"nodes": []}}}}))
+
+    def test_discussion_page(self):
+        data = {"data": {"repository": {"discussions": {
+            "nodes": [{"title": "D"}], "pageInfo": {"hasNextPage": True, "endCursor": "X"},
+        }}}}
+        nodes, page = ns.discussion_page(data)
+        self.assertEqual(nodes, [{"title": "D"}])
+        self.assertTrue(page["hasNextPage"])
+        self.assertEqual(ns.discussion_page(None), ([], {}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**PR 3 of 4** in the `.github/scripts/` complexity cleanup.

The two changelog-monitor scripts become thin IO entry points; pure logic moves to importable `lib/` modules:
- `lib/changelog.py` — parse/coverage/report logic; `collect_doc_keyword_index` pre-computes per-doc keyword sets (kills the O(features×docs×headings) rebuild); `build_report` split into `classify_versions` + `render_changelog_report`.
- `lib/native_sources.py` — `extract_blog_entries` (single-pass dedup, `strip_html_noise`), `extract_issues`, `extract_discussions`, and pure GraphQL navigation (`feature_category_id`, `discussion_page`).
- Scripts use `monitor_utils.fatal`; native reads `GITHUB_TOKEN` once + imports `urllib.error` explicitly.

**Behavior-preserving**: changelog-compare output byte-identical on a synthetic fixture. 14 new tests; full suite green (65).

Generated with Claude <noreply@anthropic.com>