### PR TITLE
refactor(ci): extract community-monitor extractors to lib + thin the script (+tests)

### DIFF
--- a/.github/scripts/community-monitor.py
+++ b/.github/scripts/community-monitor.py
@@ -2,13 +2,11 @@
 """Monitor community sources for Claude Code features, tips, and tricks.
 
 Fetches content from community sources (claudelog.com, awesome-claude-code,
-awesome-claude-code-plugins, Reddit, X) and identifies entries not yet
-covered by existing community docs.
+awesome-claude-code-plugins, Reddit, X) and identifies entries not yet covered
+by existing community docs. Pure parsing lives in lib/community_sources.py.
 
 Usage:
-    python community-monitor.py \\
-        --community-docs-dir PATH \\
-        [--state-file PATH]
+    python community-monitor.py --community-docs-dir PATH [--state-file PATH]
 
 Exit codes:
     0 = no new uncovered content
@@ -21,31 +19,14 @@ import argparse
 import base64
 import json
 import os
-import re
 import sys
 import urllib.parse
 import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from lib.monitor_utils import (
-    fetch_text,
-    run_monitor,
-)
-
-
-def _fatal(message: str) -> None:
-    """Print an error to stderr and exit 2.
-
-    Exit 2 is distinct from the exit-1 "new content found" signal, so the
-    workflow can fail loudly on a real error instead of opening an empty triage PR.
-    """
-    print(message, file=sys.stderr)
-    sys.exit(2)
-
-# ---------------------------------------------------------------------------
-# Source definitions
-# ---------------------------------------------------------------------------
+from lib.community_sources import extract_html_entries, extract_markdown_entries
+from lib.monitor_utils import fatal, fetch_text, run_monitor
 
 SOURCES: list[dict[str, str]] = [
     {
@@ -82,252 +63,105 @@ SOURCES: list[dict[str, str]] = [
     },
 ]
 
-
-# ---------------------------------------------------------------------------
-# Extraction
-# ---------------------------------------------------------------------------
-
-def extract_markdown_entries(text: str) -> list[dict[str, str]]:
-    """Extract list entries and headings from markdown content.
-
-    Returns list of {heading, entry} dicts representing notable items.
-    """
-    entries: list[dict[str, str]] = []
-    current_heading = ""
-
-    for line in text.splitlines():
-        h_match = re.match(r"^(#{1,4})\s+(.*)", line)
-        if h_match:
-            current_heading = h_match.group(2).strip()
-            continue
-
-        # Match markdown list items with links: - [Name](url) - description
-        # or plain list items: - **Name** - description
-        link_match = re.match(
-            r"^\s*[-*]\s+\[([^\]]+)\]\(([^)]+)\)\s*[-–—:]?\s*(.*)", line
-        )
-        if link_match:
-            entries.append({
-                "heading": current_heading,
-                "name": link_match.group(1).strip(),
-                "url": link_match.group(2).strip(),
-                "description": link_match.group(3).strip(),
-            })
-            continue
-
-        bold_match = re.match(
-            r"^\s*[-*]\s+\*\*([^*]+)\*\*\s*[-–—:]?\s*(.*)", line
-        )
-        if bold_match:
-            entries.append({
-                "heading": current_heading,
-                "name": bold_match.group(1).strip(),
-                "url": "",
-                "description": bold_match.group(2).strip(),
-            })
-
-    return entries
+_USER_AGENT = "cc-community-monitor/1.0"
 
 
-def extract_html_entries(text: str) -> list[dict[str, str]]:
-    """Extract notable entries from HTML content (claudelog).
-
-    Looks for headings and list-like content patterns.
-    """
-    entries: list[dict[str, str]] = []
-
-    # Extract text from HTML by stripping tags (simple approach)
-    clean = re.sub(r"<script[^>]*>.*?</script[^>]*>", "", text, flags=re.DOTALL | re.IGNORECASE)
-    clean = re.sub(r"<style[^>]*>.*?</style[^>]*>", "", clean, flags=re.DOTALL | re.IGNORECASE)
-    clean = re.sub(r"<[^>]+>", "\n", clean)
-    clean = re.sub(r"\n{3,}", "\n\n", clean)
-
-    # Extract lines that look like feature descriptions
-    current_heading = ""
-    for line in clean.splitlines():
-        line = line.strip()
-        if not line or len(line) < 10:
-            continue
-
-        # Lines that look like version headers or feature titles
-        version_match = re.match(r"^v?(\d+\.\d+\.\d+)", line)
-        if version_match:
-            current_heading = line
-            continue
-
-        # Lines with feature-like keywords
-        feature_keywords = {
-            "added", "new", "feature", "support", "improved", "fix",
-            "hook", "plugin", "skill", "agent", "team", "command",
-            "tool", "mode", "config", "memory", "context", "remote",
-        }
-        line_words = set(line.lower().split())
-        if line_words & feature_keywords and len(line) > 20:
-            entries.append({
-                "heading": current_heading,
-                "name": line[:80],
-                "url": "",
-                "description": line,
-            })
-
-    return entries
+def _require_env(source_name: str, *names: str) -> list[str] | None:
+    """Return the env values for ``names``, or None (with a WARNING) if any is unset."""
+    values = [os.environ.get(n, "") for n in names]
+    if all(values):
+        return values
+    print(f"WARNING: Skipping {source_name} — {'/'.join(names)} not set", file=sys.stderr)
+    return None
 
 
-# ---------------------------------------------------------------------------
-# Reddit / X fetching and extraction
-# ---------------------------------------------------------------------------
-
-def fetch_reddit(url: str, client_id: str, client_secret: str) -> list[dict[str, str]]:
-    """Fetch Reddit search results using OAuth2 client_credentials grant.
-
-    Args:
-        url: Reddit OAuth API search URL.
-        client_id: Reddit app client ID.
-        client_secret: Reddit app client secret.
-
-    Returns:
-        List of entry dicts extracted from search results.
-    """
-    # Obtain access token
-    token_url = "https://www.reddit.com/api/v1/access_token"
-    credentials = base64.b64encode(
-        f"{client_id}:{client_secret}".encode()
-    ).decode()
-    token_data = urllib.parse.urlencode(
-        {"grant_type": "client_credentials"}
-    ).encode()
-    token_req = urllib.request.Request(
-        token_url,
-        data=token_data,
-        headers={
-            "Authorization": f"Basic {credentials}",
-            "User-Agent": "cc-community-monitor/1.0",
-        },
+def _reddit_access_token(client_id: str, client_secret: str) -> str:
+    """Obtain a Reddit OAuth2 client_credentials access token."""
+    credentials = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+    data = urllib.parse.urlencode({"grant_type": "client_credentials"}).encode()
+    req = urllib.request.Request(
+        "https://www.reddit.com/api/v1/access_token", data=data,
+        headers={"Authorization": f"Basic {credentials}", "User-Agent": _USER_AGENT},
     )
-    with urllib.request.urlopen(token_req, timeout=15) as resp:
-        token_resp = json.loads(resp.read().decode("utf-8"))
-    access_token = token_resp["access_token"]
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read().decode("utf-8"))["access_token"]
 
-    # Fetch search results
-    search_req = urllib.request.Request(
-        url,
-        headers={
-            "Authorization": f"Bearer {access_token}",
-            "User-Agent": "cc-community-monitor/1.0",
-        },
+
+def _fetch_reddit_search(url: str, token: str) -> list[dict[str, str]]:
+    """Fetch + extract Reddit search results given an access token."""
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Bearer {token}", "User-Agent": _USER_AGENT},
     )
-    with urllib.request.urlopen(search_req, timeout=30) as resp:
+    with urllib.request.urlopen(req, timeout=30) as resp:
         data = json.loads(resp.read().decode("utf-8"))
-
-    entries: list[dict[str, str]] = []
-    for child in data.get("data", {}).get("children", []):
-        post = child.get("data", {})
-        entries.append({
+    return [
+        {
             "name": post.get("title", ""),
             "url": f"https://reddit.com{post.get('permalink', '')}",
             "description": (post.get("selftext") or "")[:200],
             "heading": "r/ClaudeAI",
-        })
-    return entries
+        }
+        for child in data.get("data", {}).get("children", [])
+        for post in [child.get("data", {})]
+    ]
+
+
+def fetch_reddit(url: str, client_id: str, client_secret: str) -> list[dict[str, str]]:
+    """Fetch Reddit search results via OAuth2 client_credentials grant."""
+    return _fetch_reddit_search(url, _reddit_access_token(client_id, client_secret))
 
 
 def fetch_x_tweets(url: str, bearer_token: str) -> list[dict[str, str]]:
-    """Fetch recent tweets from X API v2.
-
-    Args:
-        url: X API search/recent endpoint URL with query params.
-        bearer_token: X API bearer token.
-
-    Returns:
-        List of entry dicts extracted from tweet results.
-    """
+    """Fetch recent tweets from X API v2."""
     req = urllib.request.Request(
-        url,
-        headers={
-            "Authorization": f"Bearer {bearer_token}",
-            "User-Agent": "cc-community-monitor/1.0",
-        },
+        url, headers={"Authorization": f"Bearer {bearer_token}", "User-Agent": _USER_AGENT},
     )
     with urllib.request.urlopen(req, timeout=30) as resp:
         data = json.loads(resp.read().decode("utf-8"))
-
-    entries: list[dict[str, str]] = []
-    for tweet in data.get("data", []):
-        text = tweet.get("text", "")
-        tweet_id = tweet.get("id", "")
-        entries.append({
-            "name": text[:80],
-            "url": f"https://x.com/i/status/{tweet_id}" if tweet_id else "",
-            "description": text[:200],
+    return [
+        {
+            "name": tweet.get("text", "")[:80],
+            "url": f"https://x.com/i/status/{tweet['id']}" if tweet.get("id") else "",
+            "description": tweet.get("text", "")[:200],
             "heading": "#ClaudeCode",
-        })
-    return entries
+        }
+        for tweet in data.get("data", [])
+    ]
 
-
-# ---------------------------------------------------------------------------
-# Auth-aware fetch dispatcher
-# ---------------------------------------------------------------------------
 
 def fetch_and_extract_source(source: dict[str, str]) -> list[dict[str, str]]:
     """Fetch and extract entries from a source, handling auth requirements.
 
-    Returns extracted entries. Skips with WARNING on missing auth or errors.
+    Skips with a WARNING (returning []) when required credentials are unset.
     """
-    source_type = source["type"]
     auth = source.get("auth", "none")
-
     if auth == "reddit":
-        client_id = os.environ.get("REDDIT_CLIENT_ID", "")
-        client_secret = os.environ.get("REDDIT_CLIENT_SECRET", "")
-        if not client_id or not client_secret:
-            print(
-                f"WARNING: Skipping {source['name']} — REDDIT_CLIENT_ID/SECRET not set",
-                file=sys.stderr,
-            )
-            return []
-        return fetch_reddit(source["url"], client_id, client_secret)
-
+        creds = _require_env(source["name"], "REDDIT_CLIENT_ID", "REDDIT_CLIENT_SECRET")
+        return fetch_reddit(source["url"], *creds) if creds else []
     if auth == "x_bearer":
-        bearer = os.environ.get("X_BEARER_TOKEN", "")
-        if not bearer:
-            print(
-                f"WARNING: Skipping {source['name']} — X_BEARER_TOKEN not set",
-                file=sys.stderr,
-            )
-            return []
-        return fetch_x_tweets(source["url"], bearer)
+        creds = _require_env(source["name"], "X_BEARER_TOKEN")
+        return fetch_x_tweets(source["url"], creds[0]) if creds else []
 
-    # No auth required — fetch as text and extract by type
     content = fetch_text(source["url"])
-    if source_type == "markdown":
+    if source["type"] == "markdown":
         return extract_markdown_entries(content)
     return extract_html_entries(content)
 
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
 
 def main() -> None:
     """Entry point for the community monitor script."""
     parser = argparse.ArgumentParser(
         description="Monitor community sources for CC features and tips."
     )
-    parser.add_argument(
-        "--community-docs-dir", required=True, type=Path,
-        help="Path to docs/cc-community/ directory",
-    )
-    parser.add_argument(
-        "--state-file", type=Path,
-        default=Path(".github/state/community-monitor-state.json"),
-        help="Path to state file tracking previously seen entries",
-    )
+    parser.add_argument("--community-docs-dir", required=True, type=Path,
+                        help="Path to docs/cc-community/ directory")
+    parser.add_argument("--state-file", type=Path,
+                        default=Path(".github/state/community-monitor-state.json"),
+                        help="Path to state file tracking previously seen entries")
     args = parser.parse_args()
 
     if not args.community_docs_dir.exists():
-        _fatal(
-            f"ERROR: Community docs dir does not exist: {args.community_docs_dir}"
-        )
+        fatal(f"ERROR: Community docs dir does not exist: {args.community_docs_dir}")
 
     run_monitor(
         sources=SOURCES,

--- a/.github/scripts/lib/community_sources.py
+++ b/.github/scripts/lib/community_sources.py
@@ -1,0 +1,70 @@
+"""Pure content extractors for community-monitor.py (markdown + HTML).
+
+No HTTP / os.environ / sys.exit here (the entry script does the fetching), so the
+parsing is unit-testable.
+"""
+from __future__ import annotations
+
+import re
+
+from .monitor_utils import strip_html_noise
+
+# Hoisted out of the per-line loop (was rebuilt every iteration).
+_FEATURE_KEYWORDS = frozenset({
+    "added", "new", "feature", "support", "improved", "fix",
+    "hook", "plugin", "skill", "agent", "team", "command",
+    "tool", "mode", "config", "memory", "context", "remote",
+})
+_HEADING_RE = re.compile(r"^(#{1,4})\s+(.*)")
+_LINK_ITEM_RE = re.compile(r"^\s*[-*]\s+\[([^\]]+)\]\(([^)]+)\)\s*[-–—:]?\s*(.*)")
+_BOLD_ITEM_RE = re.compile(r"^\s*[-*]\s+\*\*([^*]+)\*\*\s*[-–—:]?\s*(.*)")
+_VERSION_RE = re.compile(r"^v?(\d+\.\d+\.\d+)")
+
+
+def _markdown_item(line: str, heading: str) -> dict[str, str] | None:
+    """Parse one markdown list line into an entry (link item or bold item), else None."""
+    link = _LINK_ITEM_RE.match(line)
+    if link:
+        return {"heading": heading, "name": link.group(1).strip(),
+                "url": link.group(2).strip(), "description": link.group(3).strip()}
+    bold = _BOLD_ITEM_RE.match(line)
+    if bold:
+        return {"heading": heading, "name": bold.group(1).strip(),
+                "url": "", "description": bold.group(2).strip()}
+    return None
+
+
+def extract_markdown_entries(text: str) -> list[dict[str, str]]:
+    """Extract list entries (link + bold items) grouped under their headings."""
+    entries: list[dict[str, str]] = []
+    current_heading = ""
+    for line in text.splitlines():
+        h = _HEADING_RE.match(line)
+        if h:
+            current_heading = h.group(2).strip()
+            continue
+        entry = _markdown_item(line, current_heading)
+        if entry:
+            entries.append(entry)
+    return entries
+
+
+def extract_html_entries(text: str) -> list[dict[str, str]]:
+    """Extract feature-like lines from HTML (claudelog), grouped under version headings."""
+    clean = strip_html_noise(text)
+    clean = re.sub(r"<[^>]+>", "\n", clean)
+    clean = re.sub(r"\n{3,}", "\n\n", clean)
+
+    entries: list[dict[str, str]] = []
+    current_heading = ""
+    for raw in clean.splitlines():
+        line = raw.strip()
+        if not line or len(line) < 10:
+            continue
+        if _VERSION_RE.match(line):
+            current_heading = line
+            continue
+        if len(line) > 20 and set(line.lower().split()) & _FEATURE_KEYWORDS:
+            entries.append({"heading": current_heading, "name": line[:80],
+                            "url": "", "description": line})
+    return entries

--- a/tests/test_community_sources.py
+++ b/tests/test_community_sources.py
@@ -1,0 +1,43 @@
+"""Unit tests for lib/community_sources.py (pure markdown + HTML extractors)."""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".github" / "scripts"))
+
+from lib import community_sources as cs  # noqa: E402
+
+
+class MarkdownTests(unittest.TestCase):
+    def test_link_and_bold_items_under_heading(self):
+        md = (
+            "## Tools\n"
+            "- [Ruff](https://ruff.rs) - fast linter\n"
+            "- **Black** - formatter\n"
+            "not a list line\n"
+        )
+        entries = cs.extract_markdown_entries(md)
+        self.assertEqual(entries, [
+            {"heading": "Tools", "name": "Ruff", "url": "https://ruff.rs", "description": "fast linter"},
+            {"heading": "Tools", "name": "Black", "url": "", "description": "formatter"},
+        ])
+
+
+class HtmlTests(unittest.TestCase):
+    def test_strips_script_tracks_version_heading_and_matches_features(self):
+        html = (
+            "<script>junk</script>"
+            "<p>v2.1.80 release notes</p>"
+            "<p>Added new plugin support for hooks and skills</p>"
+            "<p>tiny</p>"
+            "<p>just prose without any matching terms at all here</p>"
+        )
+        entries = cs.extract_html_entries(html)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["heading"], "v2.1.80 release notes")
+        self.assertEqual(entries[0]["description"], "Added new plugin support for hooks and skills")
+        self.assertNotIn("junk", entries[0]["description"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**PR 4 of 4** in the `.github/scripts/` complexity cleanup (final).

`community-monitor.py` becomes a thin IO entry point; pure parsing moves to `lib/community_sources.py`:
- `extract_markdown_entries` (link + bold items via `_markdown_item`) and `extract_html_entries` (uses `monitor_utils.strip_html_noise`; feature-keyword set hoisted to a module constant).
- Script: `fetch_reddit` split into `_reddit_access_token` + `_fetch_reddit_search`; a `_require_env` helper dedupes the credential-check/skip blocks; uses `monitor_utils.fatal`.

**Behavior-preserving**; 2 new tests; full suite green (67).

Generated with Claude <noreply@anthropic.com>