### PR TITLE
docs: sync CHANGELOG + dev docs/docstrings with this session's changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ui/` branded GitHub Pages site: EyeRest-themed landing page (`index.html`, System/Light/Dark theme picker), restyled knowledge graph (`graph.html`), `style.css`, `favicon.svg`, vendored `vis-network` + self-hosted Inter/JetBrains Mono fonts. (PR #253)
+- `.github/workflows/gh-pages.yaml`: GitHub Actions Pages deploy (Pages API); repo Pages source set to "GitHub Actions". (PR #253)
+- `src/pages_build.py` + `tests/test_pages_build.py`: pure, unit-tested helpers (EyeRest restyle, tooling-node pruning, woff2 validation). (PR #253)
+- `.github/scripts/lib/` pure-logic modules (`status_report`, `status_incidents`, `changelog`, `native_sources`, `community_sources`, expanded `monitor_utils`) + a stdlib `unittest` suite under `tests/` (67 tests total); `make test`. (PRs #256–#259)
+- `Makefile`: `graph-page`, `graph-fonts`, `preview`, and `test` targets. (PRs #253, #256)
 - `.github/workflows/rxiv-paper-eval.yaml`: fourth monitor — weekly Tuesday ArXiv preprint eval via `qte77/gha-rxiv-paper-eval@v0.2.2`, GITHUB_TOKEN-only auth posture (no PAT), outputs to `triage/rxiv/`. (PR #175)
 - `.github/state/rxiv-paper-eval-state.json` + dedup step in rxiv triage job: content-hash skip keyed by `(server, year, week)` so same-params re-dispatch on a different UTC day no longer opens duplicate PRs. Closes #181. (PR #182)
 - `Makefile` + `.github/workflows/lint.yaml`: actionlint v1.7.12 as third lint job; path filter widened to `.github/workflows/**` + `.github/actions/**`. (PR #182)
@@ -41,10 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `scripts/graphify-publish-pages.py` + the `Makefile` `graph-publish` target: superseded by `make graph-page` (render + EyeRest-restyle into committed `ui/graph.html`) and the `gh-pages.yaml` workflow. (PR #253)
+- `gh-pages` branch: deleted — deploys now come from the GitHub Actions artifact. (PR #253)
 - `docs/TODO.md`: GitHub issues are the authoritative roadmap; the static file duplicated CHANGELOG (Done items) and drifted from issue state (Next/Backlog). Remaining pending items migrated to #191 (research backlog tracking issue); deferred items dropped.
 
 ### Fixed
 
+- Monitor scripts (`community-monitor.py`, `native-sources-monitor.py`): CodeQL `py/bad-tag-filter` hardening — the `<script>`/`<style>` strip regex is now case- and trailing-whitespace-tolerant via `monitor_utils.strip_html_noise`. (PR #255)
 - `Makefile` setup_lychee: tarball-wrapper-dir bug — switch to `mktemp + install -m 755` mirroring `lycheeverse/lychee-action`. Closes #160. (PRs #170, #174)
 - Triage-output generators (`monitor_utils.build_report`, `changelog-compare.build_report`, `status-stats.generate_report`) + `create-triage-pr` H1 prepend: md-lint-clean output going forward; historical `triage/**/*.md` cleaned in one pass. Closes #159. (PR #171)
 - `learnings-aggregator.py` + 7 mirrored `docs/learnings/per-repo/*.md`: strip upstream frontmatter, conditional H1 demotion (only when upstream has its own H1). (PR #173)
@@ -57,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- GitHub Pages now deploys via the Actions workflow instead of a `gh-pages` branch push; the published knowledge graph prunes tooling/code nodes (`scripts/`, `tests/`, `ui/`, `src/`, `.github/scripts/`). (PR #253)
+- `.github/scripts/` monitors (status, changelog, native-sources, community) refactored to thin IO entry points with pure logic extracted to importable `.github/scripts/lib/` modules — behavior-preserving (`status-stats` + `changelog-compare` output byte-identical on fixtures). (PRs #256–#259)
 - `docs/cc-community/CC-repo-to-docs-tools-landscape.md`: consolidate cross-references, link Graphify and Code-Review-Graph
 - `docs/non-cc/README.md`: add Infrastructure section (InsForge, GoClaw), expand Agents section (Feynman, Hermes, Rowboat)
 - `README.md`: update contents table with expanded non-cc and cc-community descriptions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,7 @@ Doc linting is wired into the top-level `Makefile`. All tools install user-local
 make setup_all   # install lychee, Node.js (user-local), markdownlint-cli2
 make lint        # run lychee + markdownlint-cli2 over the full repo
 make autofix     # mechanical markdownlint --fix pass
+make test        # unit tests for src/ + .github/scripts/lib/ modules (stdlib unittest)
 make help        # list all recipes grouped by section
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Each monitor fingerprints its output and skips PR creation when content hasn't c
 make setup_all   # lychee + Node.js + markdownlint-cli2 + actionlint
 make lint        # link check (lychee) + markdown (markdownlint-cli2) + action (actionlint)
 make autofix     # mechanical markdownlint --fix pass
+make test        # unit tests for src/ + .github/scripts/lib/ modules
 make help        # all recipes grouped by section
 ```
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -69,6 +69,7 @@ exclude = [
     "iso.org",  # 403 to HEAD (anti-bot) — pre-existing in CC-ai-security-governance-analysis.md
     "lens.org",  # 403 to automated requests — web-scraping-extraction-landscape.md (migrated catalog)
     "epo.org",  # HTTP/2 protocol error to lychee — web-scraping-extraction-landscape.md (migrated catalog)
+    "patentscope.wipo.int",  # 403 (anti-bot) to lychee — web-scraping-extraction-landscape.md (migrated catalog)
     "codebuddy.ai",  # geo/IP-blocks CI (302 -> /banned); real site is browser-OK — codebuddy-analysis.md
     "api.semanticscholar.org",  # SSL cert expired upstream (persists) — pre-existing in CC-research-agents-landscape.md; drop this exclude once renewed
     "orbisius.com",  # 500 to lychee (persists) — pre-existing third-party blog link in CC-error-messages-reference.md

--- a/scripts/fetch-web-fonts.py
+++ b/scripts/fetch-web-fonts.py
@@ -2,10 +2,9 @@
 """Download self-hosted web fonts (Inter + JetBrains Mono, latin woff2) into
 ui/assets/fonts/.
 
-Mirrors the qte77/brand fonts-on-demand convention: the woff2 files are
-gitignored and fetched when needed (before `make graph-publish`). The site's
-@font-face falls back to system-ui if they are absent, so this step is optional
-but recommended for true brand rendering.
+The woff2 files are committed to the repo; run this (via `make graph-fonts`) to
+fetch or refresh them. The site's @font-face falls back to system-ui if they are
+absent, so this step is only needed when adding or updating the brand fonts.
 
 Stdlib only. Run from the repo root, or via `make graph-fonts`.
   --force   re-download even if the file already exists

--- a/src/pages_build.py
+++ b/src/pages_build.py
@@ -1,7 +1,7 @@
 """Pure helpers for building the branded GitHub Pages site.
 
 Stdlib only, no side effects on import — so it is unit-testable. The
-`scripts/*.py` entry points (graphify-publish-pages.py, fetch-web-fonts.py) are
+`scripts/*.py` entry points (render-graph-page.py, fetch-web-fonts.py) are
 thin IO wrappers that import from here; all testable logic lives in this module.
 
 Brand source of truth: qte77/qte77/brand/DESIGN.md (EyeRest — zero-blue, warm


### PR DESCRIPTION
Documentation sync for the work merged this session (the branded Pages site #253, CodeQL fix #255, and the `.github/scripts` refactor #256–#259).

- **CHANGELOG.md** `[Unreleased]`: Added (site + theme picker, `gh-pages.yaml`, `src/pages_build.py` + tests, `.github/scripts/lib/` modules + `tests/`, new make targets), Changed (Actions deploy + node pruning; monitors refactored), Removed (`graphify-publish-pages.py`, `graph-publish`, `gh-pages` branch), Fixed (CodeQL `py/bad-tag-filter`).
- Fix two **stale docstrings** in merged code: `src/pages_build.py` (named the deleted `graphify-publish-pages.py`) and `scripts/fetch-web-fonts.py` (fonts are committed now, not gitignored/`make graph-publish`).
- **README.md** + **CONTRIBUTING.md**: add the new `make test` target.

Verification: markdownlint 0 errors; `py_compile` clean; full suite green (67).

Generated with Claude <noreply@anthropic.com>