### PR TITLE
docs: add ACE, autoharness, TimesFM + refresh codebase-memory-mcp

### DIFF
--- a/docs/cc-community/CC-code-tooling-landscape.md
+++ b/docs/cc-community/CC-code-tooling-landscape.md
@@ -4,7 +4,7 @@ purpose: Code-understanding tools that integrate with Claude Code — knowledge 
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-14
+updated: 2026-06-18
 validated_links: 2026-06-14
 ---
 
@@ -99,7 +99,7 @@ Cross-ref: [CC-repo-to-docs-tools-landscape.md](CC-repo-to-docs-tools-landscape.
 
 ## codebase-memory-mcp (DeusData)
 
-**Repo**: [DeusData/codebase-memory-mcp][codebase-memory-mcp] | **Stars**: 3.2K | **License**: MIT | **Version**: v0.7.0 (2026-05-30)
+**Repo**: [DeusData/codebase-memory-mcp][codebase-memory-mcp] | **Docs**: [deusdata.github.io][codebase-memory-mcp-docs] | **Stars**: 6.8K | **License**: MIT | **Version**: v0.8.1 (2026-06-12)
 
 Single static binary that builds a persistent code knowledge graph for agents — no runtime dependencies, no external API. Combines 159 vendored tree-sitter grammars (syntactic parse), a clean-room hybrid-LSP type-resolution layer (Python, TS/JS, PHP, C#, Go, C/C++), and bundled `nomic-embed-code` embeddings (semantic search) into a SQLite-backed graph of typed nodes (Function, Class, Route) and edges (CALLS, IMPORTS, HTTP_CALLS).
 
@@ -214,6 +214,7 @@ Rust CLI that renders a codebase into a single prompt with a source tree, Handle
 [graphify]: https://github.com/safishamsi/graphify
 [code-review-graph]: https://github.com/tirth8205/code-review-graph
 [codebase-memory-mcp]: https://github.com/DeusData/codebase-memory-mcp
+[codebase-memory-mcp-docs]: https://deusdata.github.io/codebase-memory-mcp/
 [serena]: https://github.com/oraios/serena
 [ast-grep-mcp]: https://github.com/ast-grep/ast-grep-mcp
 [ast-grep]: https://github.com/ast-grep/ast-grep

--- a/docs/non-cc/agent-frameworks-infrastructure-landscape.md
+++ b/docs/non-cc/agent-frameworks-infrastructure-landscape.md
@@ -1,10 +1,10 @@
 ---
 title: Agent Frameworks & Infrastructure Landscape
-purpose: Catalog of multi-agent orchestration frameworks, LLM-orchestration/routing tools, agent memory infrastructure, and agent-oriented foundation models beyond Claude Code — restored and refreshed from the archived frameworks-infrastructure landscape.
+purpose: Catalog of multi-agent orchestration frameworks, LLM-orchestration/routing tools, agent memory infrastructure, agent-oriented foundation models, and specialist models agents call as tools beyond Claude Code — restored and refreshed from the archived frameworks-infrastructure landscape.
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-16
+updated: 2026-06-18
 validated_links: 2026-03-12
 ---
 
@@ -45,6 +45,7 @@ Catalog of agent frameworks and supporting infrastructure beyond Claude Code. Re
 - [Youtu-Agent (Tencent)](https://github.com/Tencent/Youtu-agent) — async, YAML-configured agents; 71.47% WebWalkerQA, OSS-model friendly.
 - [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT), [BabyAGI](https://github.com/yoheinakajima/babyagi), [SuperAGI](https://github.com/TransformerOptimus/SuperAGI) — the original autonomous-task-loop projects (recursive planning; AutoGPT/BabyAGI/SuperAGI respectively minimal→GUI).
 - [Rippletide](https://www.rippletide.com/) — neuro-symbolic "hypergraph decision engine" for autonomous sales agents (zero-hallucination claims).
+- [autoharness (Kayba)](https://github.com/kayba-ai/autoharness) — autonomous, benchmark-driven optimizer for an *existing* agent harness: runs proposal→evaluate→promote-champion loops (overnight) using pluggable generators (`claude_code`, `codex_cli`, `openai_responses`) and benchmark adapters (`pytest`, `harbor`, `tau2_bench`, `hal`, …) (MIT, Python 3.11+). Online learning counterpart: ACE (§4); benchmarks → [CC-evaluation-data-resources-landscape.md](../cc-community/CC-evaluation-data-resources-landscape.md).
 
 ## 4. Agent Memory Infrastructure
 
@@ -59,6 +60,7 @@ The field has reframed memory as **context engineering** — assembling persiste
 - [A-MEM](https://github.com/agiresearch/A-mem) — Zettelkasten-style agentic memory with dynamic linking ([paper](https://arxiv.org/abs/2502.12110)).
 - [LangMem](https://github.com/langchain-ai/langmem) — LangGraph-native semantic/episodic/procedural memory (MIT).
 - [Gulp.ai (Osmosis)](https://docs.gulp.ai/introduction) — agent-improvement API enriching prompts with past-interaction knowledge.
+- [ACE — Agentic Context Engine (Kayba)](https://github.com/kayba-ai/agentic-context-engine) — self-improving context layer: a three-role loop (Agent / Reflector / SkillManager) curates a persistent "Skillbook" of strategies that evolves with every task, so agents stop repeating mistakes without fine-tuning or a vector DB (Apache-2.0, [paper](https://arxiv.org/abs/2510.04618)). PydanticAI-based; ships an MCP server (`ace-mcp`) and a Claude Code runner. Offline benchmark-driven counterpart: autoharness (§3).
 
 ## 5. Foundation Models for Agents
 
@@ -67,6 +69,12 @@ Frontier model facts and pricing change fast and live in [CC-models-reference.md
 - [DeepSeek V3.2 / V3.2-Speciale / R1](https://api-docs.deepseek.com/news/news251201) — reasoning-first, agent-trained models (V3.2-Speciale synthesized 1,800+ environments, 85K+ instructions; integrates thinking into tool use). Cost-efficient OSS.
 - [Devstral (Mistral)](https://mistral.ai/news/devstral) — Apache-2.0 agentic-coding model family (All Hands AI / OpenHands lineage). Devstral Small 2 (24B) hits 68.0% SWE-Bench Verified (123B: 72.2%) — the top open-source agentic-coding scores; runs on a single RTX 4090 / 32GB Mac, ~30–50× cheaper than Sonnet, and is a listed [Claude Code model backend](https://huggingface.co/mistralai/Devstral-Small-2-24B-Instruct-2512) via OpenAI-compatible routing. Capabilities are folding into the unified Mistral Small 4 line.
 - [Arcee Foundation Models (AFM)](https://www.arcee.ai/) — ~4.5B CPU-optimized enterprise model for private/offline deployment.
+
+## 6. Specialist Models Agents Call as Tools
+
+Non-LLM foundation models an agent invokes as a *tool* for one narrow capability (forecasting, ranking, etc.) — distinct from the agent-driving LLMs in §5. Listed when reachable from an agent via an endpoint or SDK.
+
+- [TimesFM (Google Research)](https://github.com/google-research/timesfm) — time-series **forecasting** foundation model (v2.5: ~200M params, up to 16k context, point + quantile forecasts; PyTorch + JAX/Flax, Apache-2.0). Not an agent LLM — an agent calls it for numeric forecasting, exposed for programmatic/agent use via Vertex AI Model Garden and BigQuery ML.
 
 ## Production Patterns & Reference Frameworks
 


### PR DESCRIPTION
## Summary

Adds four agent/CC research resources to the landscape catalogs (extends existing docs; no new standalone files).

- **codebase-memory-mcp** (`docs/cc-community/CC-code-tooling-landscape.md`) — refreshed the existing entry: added the official docs-site link, updated verified-stale stats (stars 3.2K→6.8K, v0.7.0→v0.8.1 via `gh api`).
- **ACE — Agentic Context Engine** (`docs/non-cc/agent-frameworks-infrastructure-landscape.md` §4, memory-as-context-engineering) — self-improving context layer (Agent/Reflector/SkillManager + Skillbook), Apache-2.0, [arXiv:2510.04618](https://arxiv.org/abs/2510.04618).
- **autoharness** (§3, specialized frameworks) — benchmark-driven harness optimizer; cross-refs ACE and the evaluation landscape.
- **TimesFM** (new §6 "Specialist Models Agents Call as Tools") — agent-callable forecasting model, explicitly distinguished from the agent-driving LLMs in §5.

## Notes

- All external links verified live (WebFetch / `gh api`); internal cross-ref target and arXiv ID confirmed.
- Two commits, split by topic (cc-code-tooling refresh vs. non-cc additions).

Generated with Claude <noreply@anthropic.com>