### PR TITLE
docs: fix doc-hierarchy audit findings (orphans + cross-ref)

### DIFF
--- a/docs/cc-community/README.md
+++ b/docs/cc-community/README.md
@@ -19,6 +19,7 @@ Community-built skills, plugins, tooling, workflows, and patterns for Claude Cod
 | [CC-compass-mcp-analysis.md](CC-compass-mcp-analysis.md) | Compass MCP: cross-surface task/context bridge (architecture, status, alignment) |
 | [CC-repo-to-docs-tools-landscape.md](CC-repo-to-docs-tools-landscape.md) | Repo-to-docs AI tools: DeepWiki, Code2Tutorial, GitSummarize |
 | [CC-research-agents-landscape.md](CC-research-agents-landscape.md) | Research/discovery agents: STORM, GPT-Researcher, Elicit, FutureHouse, OpenScholar, PaperQA2 |
+| [CC-vlm-screen-sharing-landscape.md](CC-vlm-screen-sharing-landscape.md) | VLM + screen-sharing landscape: vision models, local runtimes, image token math, visual-context integration patterns |
 
 ## MAS & Agent Best Practices
 

--- a/docs/cc-native/README.md
+++ b/docs/cc-native/README.md
@@ -10,7 +10,7 @@ Deep-dive analyses of Anthropic-native Claude Code features and internals.
 | [sessions/](sessions/) | Session lifecycle, cost analysis, keepalive, headless mode, error messages | 5 |
 | [sandboxing/](sandboxing/) | Filesystem/network sandbox, Codespaces friction, platform comparison, permission bypass | 4 |
 | [ci-remote/](ci-remote/) | GitHub Actions, cloud sessions, remote access/control, web auth, version pinning, monitoring | 8 |
-| [configuration/](configuration/) | Hooks, model/provider config, fast/bash mode, loop/cron, env vars, tools, changelog, visuals | 9 |
+| [configuration/](configuration/) | Hooks, model/provider config, fast/bash mode, loop/cron, env vars, tools, binary + IDE/stream-json internals, models reference, changelog, visuals | 14 |
 | [context-memory/](context-memory/) | Extended context, memory system, llms.txt, prompt caching | 4 |
 | [plugins-ecosystem/](plugins-ecosystem/) | Official plugins, connectors, Cowork, packaging, web scraping | 8 |
 | [model-internals/](model-internals/) | Emotion vectors, interpretability, safety classifiers, alignment steering, first-party research index | 2 |

--- a/docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md
+++ b/docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md
@@ -48,7 +48,7 @@ Three layers: compact index (capped at 200 lines) stays in context permanently; 
 
 Background process runs periodically during idle time to review, deduplicate, prune, and reorganize agent memory. Referenced as `autoDream` mode with 8 phases and 5 types of context compaction. Merges duplicates, prunes contradictions, keeps index tight.
 
-**Cross-ref**: This repo documents the three-gate trigger (24h + 5 sessions + lock) and four phases (Orient, Gather Signal, Consolidate, Prune & Index) in [CC-community-reimplementations-landscape.md](../../../docs/cc-community/CC-community-reimplementations-landscape.md).
+**Cross-ref**: This repo documents the three-gate trigger (24h + 5 sessions + lock) and four phases (Orient, Gather Signal, Consolidate, Prune & Index) in [CC-community-reimplementations-landscape.md](../../cc-community/CC-community-reimplementations-landscape.md).
 
 ### 5. Progressive Context Compaction
 

--- a/docs/cc-native/configuration/README.md
+++ b/docs/cc-native/configuration/README.md
@@ -12,3 +12,9 @@ CC configuration features: hooks, model routing, execution modes.
 | [CC-loop-cron-analysis.md](CC-loop-cron-analysis.md) | Loop and cron scheduling patterns |
 | [CC-env-vars-reference.md](CC-env-vars-reference.md) | Consolidated CLAUDE_CODE_* env vars reference |
 | [CC-tools-inventory.md](CC-tools-inventory.md) | 28 public tools (CC 2.1.83) + internal/gated tools appendix, feature flags |
+| [CC-models-reference.md](CC-models-reference.md) | Newest Claude model (Fable 5) + free-tier/OSS provider snapshot behind the provider-configuration doc |
+| [CC-binary-architecture.md](CC-binary-architecture.md) | CLI binary + VS Code extension internals: build system, shared codebase, internal API endpoints, model IDs |
+| [CC-stream-json-protocol.md](CC-stream-json-protocol.md) | NDJSON event format for the stream-json output mode: event types, stream chaining, community parsers |
+| [CC-ide-integration-protocol.md](CC-ide-integration-protocol.md) | WebSocket-based MCP protocol between the CC CLI and IDE extensions: discovery, auth, transport |
+| [CC-inline-visuals-analysis.md](CC-inline-visuals-analysis.md) | Claude's inline visualization capabilities (charts, diagrams, interactive visuals in conversation) |
+| [CC-changelog-feature-scan.md](CC-changelog-feature-scan.md) | Actionable features from recent CC releases (v2.1.0–2.1.168) not yet covered by other analysis docs |

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -18,6 +18,10 @@ Distilled operational learnings from active development across the qte77 ecosyst
 | [per-repo/ralph-template.md](per-repo/ralph-template.md) | Ralph-specific patterns: shell scripting, prd.json, self-evolving loop |
 | [per-repo/so101-biolab.md](per-repo/so101-biolab.md) | so101-biolab-automation patterns (placeholder) |
 | [per-repo/deepvariant.md](per-repo/deepvariant.md) | DeepVariant ARM64/ML patterns (placeholder) |
+| [per-repo/claude-code-plugins.md](per-repo/claude-code-plugins.md) | Mirror of qte77/claude-code-plugins AGENT_LEARNINGS.md (auto-aggregated) |
+| [per-repo/cc-voice-plugin-prototype.md](per-repo/cc-voice-plugin-prototype.md) | Mirror of qte77/cc-voice-plugin-prototype AGENT_LEARNINGS.md (auto-aggregated) |
+| [per-repo/learnings-ralphy.md](per-repo/learnings-ralphy.md) | Mirror of qte77/learnings-ralphy AGENT_LEARNINGS.md (auto-aggregated) |
+| [per-repo/research-ralphy.md](per-repo/research-ralphy.md) | Mirror of qte77/research-ralphy AGENT_LEARNINGS.md (auto-aggregated) |
 | [contribution-sprint/style-cheatsheets.md](contribution-sprint/style-cheatsheets.md) | Per-repo coding style, commit format, PR process for compass-mcp, SimpleAgents, opencode |
 | [contribution-sprint/plugin-safety-matrix.md](contribution-sprint/plugin-safety-matrix.md) | Safe plugins per repo + pre-PR .claude/ leakage checklist |
 


### PR DESCRIPTION
## Summary

Fixes from the full-repo doc-hierarchy audit (read-only sweep). Semantic duplication/misplacement sweep deferred per request.

**Cross-ref normalization**
- `CC-agentic-harness-patterns-analysis.md` — the CC-community-reimplementations link used `../../../docs/cc-community/` (resolves correctly — hence lychee passed — but non-canonical); normalized to `../../cc-community/`. *The audit flagged this as a broken link; that was a false positive — it resolved fine.*

**Orphan index maintenance** (docs missing from their directory README index, per CONTRIBUTING's index rule)
- `cc-native/configuration/README.md` — added 6 rows (binary-architecture, changelog-feature-scan, ide-integration-protocol, inline-visuals-analysis, models-reference, stream-json-protocol); `cc-native/README.md` configuration count corrected **9 → 14** (actual file count).
- `cc-community/README.md` — added `CC-vlm-screen-sharing-landscape`.
- `learnings/README.md` — added 4 auto-aggregated AGENT_LEARNINGS mirror rows.

## Audit dimensions that came back clean
config-drift, lint-compat, unused-link-defs: none. markdownlint (173 files): 0 errors. lychee: external timeouts only, no 404s.

## Not addressed (pre-existing, out of this PR's scope)
- lychee doesn't resolve relative MD paths — a real blind spot the false-positive surfaced; worth a separate tracking issue if you want internal-link coverage.

Generated with Claude <noreply@anthropic.com>