### PR TITLE
fix(rxiv): collapse double blank line in build-rxiv-index render (#274)

### DIFF
--- a/.github/scripts/build-rxiv-index.py
+++ b/.github/scripts/build-rxiv-index.py
@@ -113,7 +113,14 @@ def render(records: list[dict], week_count: int) -> str:
             lines.append(f"- findings: {'; '.join(ex['key_findings'])}")
         lines.append("")
 
-    return "\n".join(lines).rstrip("\n") + "\n"
+    # Collapse consecutive blank lines (MD012): a record with empty `extracted`
+    # otherwise leaves two blank lines before the next heading. (#274)
+    collapsed: list[str] = []
+    for ln in lines:
+        if ln == "" and collapsed and collapsed[-1] == "":
+            continue
+        collapsed.append(ln)
+    return "\n".join(collapsed).rstrip("\n") + "\n"
 
 
 def main() -> None:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/rules/read-discipline.md` + `AGENT_LEARNINGS.md`: promoted the recurring **"verify subagent findings before acting"** learning to an always-loaded rule (subagent sweeps returned false negatives 3×+ this cycle — incl. "create-new" calls on already-existing docs).
 - `lychee.toml`: exclude `clarivate.com` (confirmed 403 bot-block via WebFetch, 2026-06-21) — sibling to the existing research-discovery 403 excludes (scispace/perplexity/qa.allen.ai). `marktechpost.com` 500 was transient (re-verified 200), left unchanged.
 
+### Fixed
+
+- `.github/scripts/build-rxiv-index.py`: `render()` no longer emits a double blank line (markdownlint MD012) when a paper has empty `extracted` metadata — consecutive blanks are collapsed before output. Regression test added (`tests/test_build_rxiv_index.py`). Closes #274.
+
 ### Added
 
 - `docs/non-cc/agent-frameworks-infrastructure-landscape.md`: new **§7 RAG & Retrieval Infrastructure** (pipeline taxonomy; GraphRAG family — Microsoft GraphRAG / LightRAG / RAPTOR / nano-graphrag; hybrid search, RRF, ColBERT, HyDE; rerankers; vector DBs; RAG eval — RAGAs / TruLens / DeepEval) + **"Compiling Agentic Workflows into LLM Weights"** ([arXiv:2605.22502](https://arxiv.org/abs/2605.22502)) under Production Patterns. First-party-verified; star/benchmark figures hedged.

--- a/tests/test_build_rxiv_index.py
+++ b/tests/test_build_rxiv_index.py
@@ -1,0 +1,48 @@
+"""Regression tests for build-rxiv-index render() — MD012 (no consecutive blank lines).
+
+The script filename is hyphenated (not a valid module name), so it is loaded via
+importlib rather than imported. Run: python3 -m unittest discover -s tests
+"""
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1] / ".github" / "scripts" / "build-rxiv-index.py"
+)
+_spec = importlib.util.spec_from_file_location("build_rxiv_index", _SCRIPT)
+build_rxiv_index = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build_rxiv_index)
+
+
+def _record(extracted, title="Some Paper", doi="2601.00001"):
+    return {
+        "title": title,
+        "doi": doi,
+        "extracted": extracted,
+        "server": "arxiv",
+        "year": 2026,
+        "week": 22,
+    }
+
+
+class RenderBlankLineTests(unittest.TestCase):
+    def test_no_double_blank_after_empty_extracted(self):
+        # A paper with no summary/methods/findings followed by another record must
+        # not leave two blank lines between their headings (markdownlint MD012). #274.
+        recs = [
+            _record({}, title="Empty", doi="2601.00001"),
+            _record({"summary": "x"}, title="Full", doi="2601.00002"),
+        ]
+        out = build_rxiv_index.render(recs, 1)
+        self.assertNotIn("\n\n\n", out)
+
+    def test_content_preserved(self):
+        # The fix must not drop real content or headings.
+        out = build_rxiv_index.render([_record({"summary": "abc"})], 1)
+        self.assertIn("- summary: abc", out)
+        self.assertIn("### [Some Paper](https://arxiv.org/abs/2601.00001)", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #274. `render()` emitted MD012 double blank lines when a paper had empty `extracted` metadata (heading → blank → blank before the next heading), which fails the rxiv weekly-eval lint. Fix collapses consecutive blanks before output. TDD: `tests/test_build_rxiv_index.py` (RED→GREEN); full suite 69 tests pass; markdownlint clean.

Generated with Claude <noreply@anthropic.com>