### PR TITLE
ci(make): add setup_shellcheck recipe for local actionlint parity (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Makefile`: `setup_shellcheck` recipe (+ wired into `setup_all`) — installs shellcheck user-locally so `make check_actions` (actionlint) runs its shellcheck integration locally, matching CI's pre-installed shellcheck. Closes #185.
 - `docs/non-cc/agent-frameworks-infrastructure-landscape.md`: new **§7 RAG & Retrieval Infrastructure** (pipeline taxonomy; GraphRAG family — Microsoft GraphRAG / LightRAG / RAPTOR / nano-graphrag; hybrid search, RRF, ColBERT, HyDE; rerankers; vector DBs; RAG eval — RAGAs / TruLens / DeepEval) + **"Compiling Agentic Workflows into LLM Weights"** ([arXiv:2605.22502](https://arxiv.org/abs/2605.22502)) under Production Patterns. First-party-verified; star/benchmark figures hedged.
 - `docs/cc-community/CC-code-tooling-landscape.md`: **cocoindex-code** (embedded AST + embeddings semantic code-search CLI + `ccc mcp` server, Apache-2.0) added as the embedded-semantic-search entry; `docs/non-cc/cocoindex-analysis.md` cocoindex-code stats refreshed (→~2.2k★, v0.2.36) + bidirectional cross-ref.
 - `docs/non-cc/databricks-genie-analysis.md`: Databricks **Genie One** (agentic data coworker, GA 2026-06-16) — **Genie Ontology** authority-ranked, MCP-exposed semantic graph (Public Preview) + **Genie Agents**; first-party Databricks blog + press release; benchmark/pricing claims hedged; OKF-vs-Genie-Ontology cross-ref.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 .SILENT:
 .ONESHELL:
 .PHONY: \
-	setup_node setup_lychee setup_mdlint setup_actionlint setup_skills setup_all \
+	setup_node setup_lychee setup_mdlint setup_actionlint setup_shellcheck setup_skills setup_all \
 	check_links check_docs check_actions autofix lint test \
 	graph-build graph-html graph-query graph-explain graph-path graph-fonts graph-page preview \
 	help
@@ -194,7 +194,32 @@ setup_skills: ## Clone claude-code-plugins (if missing) and symlink its skills i
 		fi
 	done
 
-setup_all: setup_lychee setup_mdlint setup_actionlint ## Install all tooling (lychee + node + markdownlint-cli2 + actionlint)
+setup_shellcheck: ## Install shellcheck user-locally to ~/.local/bin (no sudo); actionlint runs it when on PATH
+	if command -v shellcheck > /dev/null 2>&1; then
+		echo "shellcheck already installed: $$(shellcheck --version 2>&1 | grep '^version:' || true)"
+	elif [ "$(UNAME_S)" = "Darwin" ]; then
+		echo "Installing shellcheck via brew ..."
+		brew install shellcheck
+	else
+		case "$(UNAME_M)" in \
+		x86_64) SC_ARCH="x86_64" ;; \
+		aarch64|arm64) SC_ARCH="aarch64" ;; \
+		*) echo "ERROR: unsupported arch for shellcheck binary"; exit 1 ;; \
+		esac
+		echo "Installing shellcheck (stable, linux/$$SC_ARCH) to $(LOCAL_BIN) ..."
+		mkdir -p $(LOCAL_BIN)
+		# Tarball (.tar.xz) holds shellcheck-stable/shellcheck — extract to tmp,
+		# install with explicit mode (mirrors setup_lychee / setup_actionlint).
+		tmp=$$(mktemp -d) \
+			&& curl -sSfL "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.$${SC_ARCH}.tar.xz" \
+				| tar xJ -C "$$tmp" \
+			&& install -m 755 "$$tmp"/shellcheck-stable/shellcheck $(LOCAL_BIN)/shellcheck \
+			&& rm -rf "$$tmp" \
+			&& echo "shellcheck installed to $(LOCAL_BIN)/shellcheck — ensure $(LOCAL_BIN) is on PATH" \
+			|| { rm -rf "$$tmp"; echo "Install failed — download manually from https://github.com/koalaman/shellcheck/releases"; exit 1; }
+	fi
+
+setup_all: setup_lychee setup_mdlint setup_actionlint setup_shellcheck ## Install all tooling (lychee + node + markdownlint-cli2 + actionlint + shellcheck)
 
 
 # MARK: DEV


### PR DESCRIPTION
Closes #185. GitHub `ubuntu-latest` ships shellcheck, so CI's `actionlint` runs its shellcheck integration; local dev environments often lack it, making local `make check_actions` less strict than CI. Adds a user-local `setup_shellcheck` recipe (mirrors `setup_actionlint`; `stable` tarball) wired into `setup_all`. No CI workflow change — the runner already has shellcheck. Validated: `make setup_shellcheck` + `make check_actions` green.

Generated with Claude <noreply@anthropic.com>