### PR TITLE
fix(docs): repoint dead Langtrace URL + drop lychee exclude (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `.github/scripts/build-rxiv-index.py`: `render()` no longer emits a double blank line (markdownlint MD012) when a paper has empty `extracted` metadata — consecutive blanks are collapsed before output. Regression test added (`tests/test_build_rxiv_index.py`). Closes #274.
+- `docs/cc-community/CC-agent-observability-methods-analysis.md` + `lychee.toml`: repoint the dead Langtrace link (`www.langtrace.ai/` returns 404) to the canonical [Scale3-Labs/langtrace](https://github.com/Scale3-Labs/langtrace) repo and drop the `langtrace.ai` lychee exclude (the `docs.langtrace.ai` setup link still resolves). Closes #242.
 
 ### Added
 

--- a/docs/cc-community/CC-agent-observability-methods-analysis.md
+++ b/docs/cc-community/CC-agent-observability-methods-analysis.md
@@ -372,7 +372,7 @@ This pattern leverages the OpenTelemetry standard for vendor-neutral observabili
 
 **Primary Sources**:
 
-- [Langtrace](https://www.langtrace.ai/)
+- [Langtrace (Scale3-Labs)](https://github.com/Scale3-Labs/langtrace)
 - [Langtrace Local Setup Documentation](https://docs.langtrace.ai/hosting/using_local_setup)
 
 #### Datadog LLM Observability

--- a/lychee.toml
+++ b/lychee.toml
@@ -65,7 +65,6 @@ exclude = [
     "scispace.com",  # 403 to automated requests — CC-research-agents-landscape.md
     "perplexity.ai",  # 403 to HEAD on /academic — CC-research-agents-landscape.md
     "qa.allen.ai",  # Ai2 Scholar QA — times out lychee — CC-research-agents-landscape.md
-    "langtrace.ai",  # 404 to root (site relocated?) — pre-existing Langtrace entry in CC-agent-observability-methods-analysis.md; revisit/update URL
     "clarivate.com",  # 403 (anti-bot) to lychee AND WebFetch (verified 2026-06-21) — CC-research-agents-landscape.md (Web of Science Research Assistant)
     # PR #248 — bot-blocked / protocol-incompatible to lychee (browser-OK)
     "iso.org",  # 403 to HEAD (anti-bot) — pre-existing in CC-ai-security-governance-analysis.md


### PR DESCRIPTION
Closes #242. `www.langtrace.ai/` now 404s (verified via WebFetch). Repoints the Langtrace entry in `CC-agent-observability-methods-analysis.md` to the canonical [Scale3-Labs/langtrace](https://github.com/Scale3-Labs/langtrace) repo and drops the `langtrace.ai` lychee exclude added in #237. The `docs.langtrace.ai` setup link still resolves — lychee on the doc reports 0 errors.

Generated with Claude <noreply@anthropic.com>