### PR TITLE
ci(lychee): set per-link timeout to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `lychee.toml`: set `timeout = 30` (lychee default is 20) — keeps genuinely-slow hosts (apmdigest/techsy/qa.allen.ai/e2b.dev/…) link-checked instead of timing out into the exclude list. Orthogonal to transient 5xx, which `max_retries` handles.
 - `README.md`: restructured to the qte77 README canon (Hero → Badges → What → How → Why → Refs → License) — added License/Changelog/CI badges, folded the 10-row Contents table and the monitor table into `What` bullets that defer to [`docs/architecture.md`](docs/architecture.md), renamed "Related Repos" → "Refs" (links only), and trimmed local-dev into `How`. Closes #280.
 - `docs/architecture.md`: corrected the stale `src/pages_build.py` reference to `scripts/pages_build.py` (the module moved this cycle).
 - `src/pages_build.py` → `scripts/pages_build.py`: co-located the pure site-build module with its only consumer (`render-graph-page.py`), dropped the `sys.path` shim, and removed the now-empty `src/`. `tests/` kept at root (67 module tests unchanged); `make test` comment updated.

--- a/lychee.toml
+++ b/lychee.toml
@@ -16,6 +16,13 @@ accept = [200, 204, 429, 405, 418, 202, 415]
 max_retries = 3
 retry_wait_time = 2
 
+# Per-link timeout in seconds (lychee default: 20). Several genuinely-slow hosts
+# (apmdigest.com, techsy.io, qa.allen.ai, e2b.dev, finance.biggo.com, …) time out
+# at the default and end up in the exclude list below; 30s keeps more of them
+# actually link-checked. Does not affect transient 5xx/connection errors, which
+# are handled by max_retries.
+timeout = 30
+
 # Exclude domains that block automated requests (return 403/401 to HEAD)
 exclude = [
     "medium.com",


### PR DESCRIPTION
## What

Sets `timeout = 30` in `lychee.toml` (lychee's default is 20s).

## Why

This repo's `lychee.toml` already excludes ~10 domains specifically because they **time out** at the 20s default (`apmdigest.com`, `techsy.io`, `qa.allen.ai`, `e2b.dev`, `finance.biggo.com`, …). A higher timeout keeps more of those genuinely-reachable-but-slow hosts actually link-checked rather than silently excluded.

Note: this is **orthogonal to transient 5xx / connection blips** (e.g. the `autoagent-ai.github.io` 503 seen flaking CI today) — those are handled by `max_retries = 3`. This change only helps the slow-host timeout class.

## Validation

- `lychee --config lychee.toml` parses the config (14/14 OK on README.md)
- `make check_docs` → 0 errors

Follow-up (not in this PR): once this lands, some timeout-driven excludes could be re-tested and dropped — tracked separately.