### PR TITLE
docs: re-apply un-merged PR #206 content against current main (#243)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,9 @@
     "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
     "pr": "Generated with Claude <noreply@anthropic.com>"
   },
+  "env": {
+    "BASH_MAX_OUTPUT_LENGTH": "15000"
+  },
   "permissions": {
     "allow": [
       "Bash(lychee --config *)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `.claude/settings.json`: add `env.BASH_MAX_OUTPUT_LENGTH=15000` (CodeBurn `detectBashBloat` rule — caps bash tool output to trim per-session tokens). Re-homed from closed PR #206 per #243.
 - `lychee.toml`: set `timeout = 30` (lychee default is 20) — keeps genuinely-slow hosts (apmdigest/techsy/qa.allen.ai/e2b.dev/…) link-checked instead of timing out into the exclude list. Orthogonal to transient 5xx, which `max_retries` handles.
 - `README.md`: restructured to the qte77 README canon (Hero → Badges → What → How → Why → Refs → License) — added License/Changelog/CI badges, folded the 10-row Contents table and the monitor table into `What` bullets that defer to [`docs/architecture.md`](docs/architecture.md), renamed "Related Repos" → "Refs" (links only), and trimmed local-dev into `How`. Closes #280.
 - `docs/architecture.md`: corrected the stale `src/pages_build.py` reference to `scripts/pages_build.py` (the module moved this cycle).
@@ -28,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/cc-community/CC-usage-tooling-landscape.md`: **CodeBurn Optimization Rules** — the full 16-detector `codeburn optimize` taxonomy table (cache bloat, read:edit ratio, junk/duplicate reads, MCP coverage/profile, ghost agents/skills/commands, bash & `CLAUDE.md` bloat, …), sourced to `src/optimize.ts` (README's ~7-category grouping undercounts). Re-homed from closed PR #206 per #243.
+- `docs/cc-native/ci-remote/CC-github-actions-analysis.md`: **`/install-github-app` interactive wizard** (pre-flight warnings, OAuth-token vs API-key chooser, workflow selector), **Custom GitHub App (Bedrock/Vertex)** setup, App provenance, and the `CLAUDE_CODE_OAUTH_TOKEN` path in Manual Setup. Re-homed from PR #206 per #243.
+- `docs/cc-native/context-memory/CC-llms-txt-analysis.md`: **Pattern Adoption Beyond Product Docs** — HuggingScience (`/llms-full.txt` for 100+ scientific models across 17 domains) as an `llms-full.txt` adoption example beyond product docs. Re-homed from PR #206 per #243.
 - `pyproject.toml` + `.github/workflows/{bump-my-version,tag-release,publish-release}.yaml` + `changelog.d/`: **operator-driven release flow** adapted from [qte77/paperverse](https://github.com/qte77/paperverse) — bump-my-version (version SSOT in `[tool.bumpversion]`) + scriv changelog fragments, run ephemerally via `pipx` (no repo venv/lockfile). Adds `make changelog_new`/`changelog_preview`/`changelog_release` recipes and a CONTRIBUTING "Release & Changelog" section. Adopts the `changelog.d/` fragment workflow deferred in #217. Closes #217.
 - `docs/cc-native/configuration/CC-tools-inventory.md`: documented the **WebFetch default User-Agent** (`Claude-User (claude-code/2.1.185; +https://support.anthropic.com/)`, captured 2026-06-22, no override path) and a **bimodal bot-block model** (server WAF 403 vs CC-side denylist) with an observed status-code table (clarivate/g2/crunchbase 403, reddit denylist, langtrace 404, marktechpost 200). Closes #188.
 - `docs/cc-community/CC-openmontage-analysis.md`: **OpenMontage** (calesthio, AGPL-3.0) — agentic video production as a `CLAUDE.md`→`AGENT_GUIDE.md` domain-controller workspace (three-layer skill architecture, runtime capability discovery, checkpoint-gated pipelines); plus a **Palmier** concepts + coding-agent→video pivot-signal note (timeline-as-MCP-workspace, control/generation-plane split). Cross-refs `CC-domain-claudemd-showcase.md`.

--- a/docs/cc-community/CC-usage-tooling-landscape.md
+++ b/docs/cc-community/CC-usage-tooling-landscape.md
@@ -4,8 +4,8 @@ purpose: Token-usage and cost observability tools for Claude Code (and sibling a
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-14
-validated_links: 2026-06-14
+updated: 2026-06-22
+validated_links: 2026-06-22
 ---
 
 **Status**: Research (informational)
@@ -36,7 +36,7 @@ Per the [README][codeburn]: Claude Code, Claude Desktop, Codex, Cursor, cursor-a
 
 - **TUI dashboard** with gradient charts and responsive panels
 - **13 task categories** classified from tool patterns: Coding, Debugging, Feature Dev, Refactoring, Testing, Exploration, Planning, Delegation, Git Ops, Build/Deploy, Brainstorming, Conversation, General
-- **[`codeburn optimize`](https://github.com/getagentseal/codeburn#optimize)** — surfaces nine waste patterns (files re-read across sessions, low Read:Edit ratio, unused MCP servers, ghost agents/skills/slash commands, bloated `CLAUDE.md`, wasted bash output, cache-creation overhead, context-heavy and low-worth sessions) with copy-paste token/$ fixes ranked into an A–F health grade
+- **[`codeburn optimize`](https://github.com/getagentseal/codeburn#optimize)** — scans recent sessions for token-waste patterns, grades the setup A–F, and emits copy-paste token/$ fixes ranked by impact (full detector list in [Optimization Rules](#optimization-rules) below)
 - **`codeburn compare`** — side-by-side model performance metrics
 - **`codeburn report -p 30days`** — rolling-window analysis
 - **`codeburn export`** — CSV/JSON across multiple time periods
@@ -55,6 +55,31 @@ npm install -g codeburn
 # or run without installing:
 npx codeburn
 ```
+
+### Optimization Rules
+
+`codeburn optimize` scans recent sessions (default ~30 days), ranks each finding by token/dollar impact, grades the setup A–F, and emits copy-paste fixes. The [README][codeburn] presents these as ~7 categories and `docs/architecture.md` lists 14, but the source of truth — [`src/optimize.ts`][codeburn-optimize] — runs **16 waste detectors**:
+
+| # | Detector | Flags | Fix |
+|---|----------|-------|-----|
+| 1 | `detectCacheBloat` | Cache-creation tokens above the p25 baseline +40% (bloated MCP/skill warm-up) | Trim per-session loaded context |
+| 2 | `detectLowReadEditRatio` | Read:edit ratio under 4:1 (high severity <2:1) → retries | "Read before edit; grep callers first" |
+| 3 | `detectJunkReads` | Reads into generated/dependency dirs (`node_modules`, `.git`, `dist`, `.venv`…), ~600 tokens each | Exclude paths |
+| 4 | `detectDuplicateReads` | Same file re-read within a session (high severity >30) | Cite `file:lines`, hold context |
+| 5 | `detectUnusedMcp` | MCP servers configured but never invoked (24h grace for new configs) | Disable unused servers |
+| 6 | `detectMcpToolCoverage` | MCP servers with >10 tools where <20% are ever called | Prune tools / split the server |
+| 7 | `detectMcpProfileAdvisor` | Server invoked ≥80% in a few projects but loaded globally | Project-scope the server |
+| 8 | `detectCapabilityReliability` | MCP/skill correlated with high retry/edit-cycle rates | Replace the unreliable capability |
+| 9 | `detectLowWorthSessions` | Costly sessions with weak delivery (no edits ≥$3, or ≥3 retries) | Revisit the prompting approach |
+| 10 | `detectContextBloat` | Effective input ≥75K tokens and input:output ≥25:1 (target 15:1) | Compact / clear stale context |
+| 11 | `detectSessionOutliers` | Session costing ≥2× its project peer-session average | Investigate the cost anomaly |
+| 12 | `detectBloatedClaudeMd` | `CLAUDE.md` >200 lines after `@`-import expansion (high >400) | Trim, hoist to skills |
+| 13 | `detectBashBloat` | `BASH_MAX_OUTPUT_LENGTH` set above 15000 chars | Lower the cap |
+| 14 | `detectGhostAgents` | `~/.claude/agents/` entries never invoked (~80 tok/session each) | Archive or delete |
+| 15 | `detectGhostSkills` | `~/.claude/skills/` entries never invoked (~80 tok/session each) | Archive or delete |
+| 16 | `detectGhostCommands` | `~/.claude/commands/` entries never referenced (~60 tok/session each) | Archive or delete |
+
+Each finding ships estimated token/dollar savings plus copy-paste remediation (`CLAUDE.md` edits, env vars, or archival commands). No standalone docs site yet; the canonical, complete list lives in [`src/optimize.ts`][codeburn-optimize] — the [README][codeburn] grouping undercounts it.
 
 ### Key Differentiator
 
@@ -155,5 +180,6 @@ Cross-ref: [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-a
 - [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-analysis.md) — CC's native session-cost extraction
 
 [codeburn]: https://github.com/getagentseal/codeburn
+[codeburn-optimize]: https://github.com/getagentseal/codeburn/blob/main/src/optimize.ts
 [ccusage]: https://github.com/ryoppippi/ccusage
 [claude-monitor]: https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor

--- a/docs/cc-native/ci-remote/CC-github-actions-analysis.md
+++ b/docs/cc-native/ci-remote/CC-github-actions-analysis.md
@@ -3,8 +3,8 @@ title: CC GitHub Actions — claude-code-action & Claude GitHub App
 source: https://code.claude.com/docs/en/github-actions, https://github.com/apps/claude, https://github.com/anthropics/claude-code-action/blob/main/action.yml, https://github.com/anthropics/claude-code-action/discussions/578, https://code.claude.com/docs/en/amazon-bedrock, https://code.claude.com/docs/en/google-vertex-ai, https://code.claude.com/docs/en/microsoft-foundry, https://dev.to/myougatheaxo/automate-your-entire-pr-workflow-with-claude-code-description-review-tests-1i41
 purpose: Evaluate Claude Code GitHub Actions for PR automation, code review, issue triage, and scheduled workflows — setup, capabilities, limitations, and cost.
 created: 2026-03-12
-updated: 2026-06-11
-validated_links: 2026-06-11
+updated: 2026-06-22
+validated_links: 2026-06-22
 ---
 
 **Status**: Research (informational — not implementation requirements)
@@ -15,7 +15,7 @@ Claude Code GitHub Actions (`anthropics/claude-code-action@v1`) brings AI-powere
 
 Built on the [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview). Defaults to Sonnet; Opus 4.6 available via `--model claude-opus-4-6` ([source][cc-gha-docs]).
 
-The **Claude GitHub App** ([github.com/apps/claude][claude-app]) is the companion app that provides the GitHub integration layer — handling permissions, webhooks, and token management. The full permission surface is documented in [GitHub App Permission Surface](#github-app-permission-surface) below.
+The **Claude GitHub App** ([github.com/apps/claude][claude-app]) is the companion app that provides the GitHub integration layer — handling permissions, webhooks, and token management. Publisher: Anthropic (`@anthropics`); built on the publicly available Claude Agent SDK and provided as a third-party GitHub App governed by separate terms beyond GitHub's ([setup.md][gha-setup]). The full permission surface is documented in [GitHub App Permission Surface](#github-app-permission-surface) below.
 
 ## GitHub App Permission Surface
 
@@ -49,13 +49,56 @@ The App identity (`claude[bot]`) is honest only because `claude-code-action` is 
 
 Requires repository admin. Only available for direct Anthropic API users (not Bedrock/Vertex) ([source][cc-gha-docs]).
 
+### Interactive Setup Flow
+
+`/install-github-app` is an interactive wizard with three panels (observed in `claude-code` 2.1.x — UI surfaces verified against [`claude-code-action` setup.md][gha-setup] and [`examples/`][gha-examples]):
+
+#### 1. Pre-flight warnings
+
+Detects environment issues before proceeding. Most common: `gh` CLI not authenticated. The wizard displays a warnings panel listing the issues and lets you continue (Enter) or abort (Ctrl+C). Recovery options:
+
+- `gh auth login` — interactive GitHub login
+- Set environment variables (`GITHUB_TOKEN`)
+- Bail out and follow the [manual setup guide][gha-setup]
+
+#### 2. API key chooser
+
+Two authentication paths, gated by repository secret name ([setup.md][gha-setup]):
+
+| Choice | Secret name | Source |
+|---|---|---|
+| **Long-lived OAuth token** | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Pro/Max subscription via `claude setup-token` |
+| **Anthropic API key** | `ANTHROPIC_API_KEY` | Console-issued, value starts `sk-ant-` |
+
+The OAuth path lets Pro/Max subscribers run the action without a separate API key — the workflow consumes subscription quota. API key remains the path for org accounts and Bedrock/Vertex routing.
+
+#### 3. Workflow selector
+
+Checkbox list of workflow templates to install into `.github/workflows/`:
+
+| Template | What it does |
+|---|---|
+| **@Claude Code** | Tag `@claude` in issues and PR comments to trigger interactive responses |
+| **Claude Code Review** | Automated review on every new PR (no mention required) |
+
+More templates (issue triage, CI fixes, scheduled reports) at [`claude-code-action/examples/`][gha-examples] — install manually after the wizard.
+
 ### Manual Setup
 
 1. Install the [Claude GitHub App][claude-app] to your repository
-2. Add `ANTHROPIC_API_KEY` to repository secrets
+2. Add `ANTHROPIC_API_KEY` **or** `CLAUDE_CODE_OAUTH_TOKEN` to repository secrets ([setup.md][gha-setup])
 3. Copy the [example workflow](https://github.com/anthropics/claude-code-action/blob/main/examples/claude.yml) into `.github/workflows/`
 
 Test by tagging `@claude` in an issue or PR comment ([source][cc-gha-docs]).
+
+### Custom GitHub App (Bedrock/Vertex)
+
+For AWS Bedrock or Google Vertex AI routing, the wizard does not apply — install your own GitHub App. The [setup.md][gha-setup] documents two approaches:
+
+- **App manifest** (recommended) — download `create-app.html`, click "Create App", GitHub auto-configures permissions
+- **Manual** — create app at `github.com/settings/apps`, generate `.pem` private key, add `APP_ID` + `APP_PRIVATE_KEY` to secrets
+
+Required permissions (Repository): **Contents** Read & Write, **Issues** Read & Write, **Pull requests** Read & Write ([setup.md][gha-setup]).
 
 ## Capabilities
 
@@ -335,6 +378,8 @@ A Python composite GHA addressing all four gaps is planned at [qte77/gha-issue-t
 [gh-runner-pricing]: https://docs.github.com/en/billing/reference/actions-runner-pricing
 [gh-larger-runner-jobs]: https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners/use-larger-runners
 [cc-action-repo]: https://github.com/anthropics/claude-code-action
+[gha-setup]: https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md
+[gha-examples]: https://github.com/anthropics/claude-code-action/blob/main/examples/
 [copilot-agent]: https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent
 [copilot-cli]: https://github.com/github/copilot-cli
 [codex-action]: https://github.com/openai/codex-action

--- a/docs/cc-native/context-memory/CC-llms-txt-analysis.md
+++ b/docs/cc-native/context-memory/CC-llms-txt-analysis.md
@@ -4,8 +4,8 @@ description: Analysis of the llms.txt standard, Anthropic's documentation surfac
 source: https://llmstxt.org/, https://platform.claude.com/llms.txt, https://code.claude.com/docs/llms.txt
 category: analysis
 created: 2026-03-07
-updated: 2026-03-08
-validated_links: 2026-03-12
+updated: 2026-06-22
+validated_links: 2026-06-22
 ---
 
 **Status**: Stable (spec analysis + 651-page Anthropic index + example project implementation)
@@ -184,10 +184,19 @@ A template file (e.g., `.github/templates/llms.txt.tpl`) holds curated markdown 
 - [ ] Add section for autonomous development loop documentation
 - [ ] Add blockquote summary (spec recommends it)
 
+## Pattern Adoption Beyond Product Docs
+
+The `llms.txt` / `llms-full.txt` pattern is spreading from product-doc sites into curated **resource catalogs**:
+
+- **[HuggingScience](https://huggingscience.co/)** (Hugging Face, 2026) — curated index of 100+ scientific datasets and models across 17 domains (Astronomy, Biology, Chemistry, Climate, Genomics, Medicine, etc.). Ships `/llms-full.txt` for bulk LLM ingestion alongside the human-browsable site. Covers domain-specific models like Evo-2, ESM2, FourCastNet 3, MedGemma, AstroCLIP. Demonstrates the pattern extending beyond software-product docs into curated scientific-resource indexes — directly relevant for agents doing literature/dataset/model discovery in scientific domains.
+
+This is a meaningful generalization of the spec's intent: the `llms-full.txt` artifact is no longer just a docs-site convention but a publishing format for curated knowledge bases consumable by agentic workflows.
+
 ## References
 
 - [llmstxt.org](https://llmstxt.org/) — specification
 - [platform.claude.com/llms.txt](https://platform.claude.com/llms.txt) — API docs index
 - [platform.claude.com/llms-full.txt](https://platform.claude.com/llms-full.txt) — full API docs
 - [code.claude.com/docs/llms.txt](https://code.claude.com/docs/llms.txt) — CC docs index
+- [HuggingScience](https://huggingscience.co/) — curated AI-for-science catalog shipping `/llms-full.txt`
 - `llms_txt2ctx` — CLI tool to expand llms.txt into a flat context file


### PR DESCRIPTION
Re-homes the four in-scope pieces from the closed PR #206 (`docs/research-updates`) to their current-main locations, recovered via `gh pr diff 206`. One topic commit each.

## Pieces

| # | Piece | Target | Notes |
|---|---|---|---|
| 1 | CodeBurn **Optimization Rules** | `CC-usage-tooling-landscape.md` | Full **16-detector** `codeburn optimize` table (sourced to `src/optimize.ts`; README's ~7-category grouping undercounts). Landed in the usage-tooling doc per #243 (CodeBurn moved there in #238), not where #206 originally put it. |
| 2 | `/install-github-app` wizard + provenance + OAuth | `CC-github-actions-analysis.md` | Interactive Setup Flow (pre-flight / API-key chooser / workflow selector), Custom App (Bedrock/Vertex), `CLAUDE_CODE_OAUTH_TOKEN` path. The existing live **Permission Surface** section already subsumed #206's lighter permission note, so only the genuinely-new wizard/provenance/OAuth content was added. |
| 3 | HuggingScience `llms-full.txt` | `CC-llms-txt-analysis.md` | New "Pattern Adoption Beyond Product Docs" section. |
| 4 | `BASH_MAX_OUTPUT_LENGTH=15000` | `.claude/settings.json` | Added `env` block (CodeBurn `detectBashBloat` rule). |

## Deliberately excluded

PR #206 also added a **`devstral-analysis.md`** (+150) + a `non-cc/README.md` "Coding Models" row. This is **not in #243's task list**, is not on main, and is partly stale now (Mistral Small 4 / 2603 has since absorbed Devstral's line). Left out to respect issue scope — flag if you want it re-homed separately with a freshness pass.

## Validation

- `make check_docs` → 0 errors
- `python3 -m json.tool` on `.claude/settings.json` → valid
- `lychee` on the 3 changed docs → 60 links, 0 errors (new links resolve)

Closes #243.

Generated with Claude <noreply@anthropic.com>