### PR TITLE
chore(release): cut v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Types of changes**: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
 
-## [Unreleased]
+<!-- scriv-insert-here -->
+
+## [0.4.0] - 2026-06-22
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 # here on a workflow bump; tag-release.yaml reads it to create the v* tag.
 # Seeded at 0.3.0 — the latest version section already present in CHANGELOG.md.
 [tool.bumpversion]
-current_version = "0.3.0"
+current_version = "0.4.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true


### PR DESCRIPTION
First release under the new flow (#292). **Transition cut** — the accumulated hand-written `## [Unreleased]` (which predates scriv fragments) is renamed to `## [0.4.0] - 2026-06-22`, a `<!-- scriv-insert-here -->` marker is added for future `scriv collect` runs, and `current_version` is bumped 0.3.0 → 0.4.0.

## What happens on merge

1. `tag-release.yaml` fires on the `pyproject.toml` change → annotated `v0.4.0` tag on the merge commit.
2. I then dispatch `publish-release` → GitHub Release `v0.4.0` with notes from the `[0.4.0]` CHANGELOG block.

From **v0.5.0** onward, releases are fragment-driven: PRs add `changelog.d/` fragments and the `bump-my-version` workflow collects them. This cut is the one-time manual transition.

## Scope

`v0.4.0` snapshots this session's work: WebFetch UA docs (#188), the release flow itself (#217), lychee timeout, and the PR #206 re-home (#243), on top of the prior accumulated `[Unreleased]`.

## Validation

- `make check_docs` → 0 errors
- `current_version = "0.4.0"`; `[0.4.0]` header + scriv marker verified; `[0.3.0]`/`[0.2.0]`/`[0.1.0]` history intact

Generated with Claude <noreply@anthropic.com>