### PR TITLE
docs: fit 5 new research targets into existing landscapes (#276)

### DIFF
--- a/changelog.d/20260622_r5-new-targets.md
+++ b/changelog.d/20260622_r5-new-targets.md
@@ -1,0 +1,5 @@
+### Added
+
+- `docs/cc-community/CC-research-agents-landscape.md`: **local-deep-researcher** (langchain-ai LangGraph *reference* impl — explicitly distinguished from the look-alike LearningCircuit `local-deep-research`) and **dataroom** (hanxiao/Jina local-gather → frontier-synthesize harness, Pi-based) added to §1 + the `/deep-research` mapping table.
+- `docs/cc-community/CC-vlm-screen-sharing-landscape.md`: **PixelRAG** (StarTrail-org) added to Observed Implementations — pixel-native RAG (Qwen3-VL-Embedding) shipping a Claude Code `pixelbrowse` plugin.
+- `docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md`: **Academic Design-Space Analysis** section for arXiv 2604.14228 ("Dive into Claude Code"), mapping its findings onto the Ibryam pattern taxonomy. (#276)

--- a/docs/cc-community/CC-research-agents-landscape.md
+++ b/docs/cc-community/CC-research-agents-landscape.md
@@ -4,8 +4,8 @@ purpose: Catalog of autonomous research agents, scientific-domain models, and li
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-14
-validated_links: 2026-06-14
+updated: 2026-06-22
+validated_links: 2026-06-22
 ---
 
 **Status**: Research (informational)
@@ -32,6 +32,8 @@ Agents that conduct multi-step research and generate research outputs.
 - [Gemini Deep Research](https://blog.google/technology/developers/deep-research-agent-gemini-api/) — Gemini 3 Pro long-horizon agent via the Interactions API (`deep-research-pro-preview-12-2025`); 46.4% HLE, 66.1% DeepSearchQA, background execution + remote MCP.
 - [AutoScientists (mims-harvard)](https://github.com/mims-harvard/AutoScientists) — decentralized team of AI agents for long-running computational-science experiments, self-organizing around promising hypotheses; **packaged as Claude Code subagents** coordinating via a local ClawInstitute server (no central planner). BioML-Bench 74.4% mean leaderboard percentile (629★, Python) — the most direct CC-harness tie-in here.
 - [local-deep-research (LearningCircuit)](https://github.com/LearningCircuit/local-deep-research) — LLM-agnostic deep-research assistant: local (Ollama/LM Studio/llama.cpp) + cloud (Claude, OpenAI, Gemini, OpenRouter), LangGraph agent strategies, 20+ search sources (arXiv/PubMed/SearXNG/…), cited reports; 95.7% SimpleQA. MIT, 8.5k★, v1.7.0 (2026-06) — a close OSS parallel to CC's `/deep-research`.
+- [local-deep-researcher (langchain-ai)](https://github.com/langchain-ai/local-deep-researcher) — **distinct from the above** despite the near-identical name: LangChain's minimal LangGraph *reference* implementation of the search→summarize→reflect loop (Ollama/LMStudio, local-only by default) — the canonical starting pattern, not a full assistant. MIT, ~9.2k★.
+- [dataroom (hanxiao / Jina)](https://github.com/hanxiao/dataroom) — self-hosted research *harness*: a local LLM (Qwen3.6 on a single GPU) runs the mechanical search/read/rerank via Jina CLI tools and emits a structured "dataroom" knowledge package for a frontier model to synthesize — the "cheap local gathering, expensive frontier reasoning" split. Pi-based (see [pi-analysis.md](../non-cc/pi-analysis.md)); ~168★, new.
 
 **Domain-specific science agents**: [Coscientist (CMU, Nature)](https://www.nature.com/articles/s41586-023-06792-0) — GPT-4 chemistry agent driving cloud-lab experiments; [ChemCrow](https://arxiv.org/abs/2304.05376) — GPT-4 + 18 chemistry tools; [BioPlanner](https://arxiv.org/abs/2310.10632) — biology protocol generation (BIOPROT, 9K+ protocols); [BioChatter](https://biochatter.org/) — privacy-preserving biomedical conversational-AI framework.
 
@@ -74,6 +76,8 @@ Claude Code ships one bundled workflow, [`/deep-research`](../cc-native/agents-s
 | Agent | Overlap with `/deep-research` | Beyond / gap vs the CC workflow | CC-based? |
 |---|---|---|---|
 | **local-deep-research** | Same fan-out → search → cross-check → cited-report loop | Local/offline LLMs, 20+ specialized sources (PubMed/arXiv/SearXNG), persistence + encryption | No (LangGraph; runs Claude as a model option) |
+| **local-deep-researcher** | Same iterative search→summarize→reflect loop | Minimal LangGraph *reference* design; local-only by default; not a full assistant | No (LangGraph reference impl) |
+| **dataroom** | Gathers + cross-checks sources into a structured package | Two-stage local-gather / frontier-synthesize split; Jina CLI tools; no CC tie-in | No (Pi + local LLM) |
 | **AutoScientists** | Multi-agent fan-out + peer-critique ≈ cross-check/vote | Runs *experiments* (code/compute), not just literature; computational-science domain | **Yes** — built on CC subagents |
 | **GPT-Researcher** | Multi-agent web+local research → cited long-form report | Self-hosted LangGraph with explicit planner/executor roles | No |
 | **OpenAI Deep Research** | Agentic multi-step browse → cited analyst report | Hosted `o3`-tuned browsing model, RL-trained; API-gated, not local | No |

--- a/docs/cc-community/CC-vlm-screen-sharing-landscape.md
+++ b/docs/cc-community/CC-vlm-screen-sharing-landscape.md
@@ -5,8 +5,8 @@ category: landscape
 status: research
 platform_scope: [claude-code]
 created: 2026-04-11
-updated: 2026-06-10
-validated_links: 2026-06-10
+updated: 2026-06-22
+validated_links: 2026-06-22
 ---
 
 **Status**: Assess
@@ -132,6 +132,7 @@ Using a router is orthogonal to the VLM landscape above — a Tier 2 workflow co
 ## Observed Implementations
 
 - [qte77/cc-voice-plugin-prototype][cc-voice] — plugin integration demonstrating a Tier 2 pipeline (local VLM → text) for a voice-driven CC workflow. See the repo's own docs and ADRs for the specific model / runtime / resize choices adopted there.
+- [StarTrail-org/PixelRAG][pixelrag] — **pixel-native RAG**: renders pages/PDFs to image tiles and retrieves by visual similarity with a fine-tuned [Qwen3-VL][qwen3-vl]-Embedding model, skipping text parsing entirely. Ships a Claude Code **`pixelbrowse`** plugin (`claude plugin install pixelbrowse@pixelrag-plugins`) — a skill calling `pixelshot` (Playwright/CDP) via a `/screenshot <url>` command; no MCP server or backend. A Tier 1 (CC-native plugin) visual-retrieval pattern, distinct from the Tier 2 local-VLM→text prototype above. ~3.3k★.
 
 ## Sources
 
@@ -143,6 +144,7 @@ Using a router is orthogonal to the VLM landscape above — a Tier 2 workflow co
 | [python-mss][python-mss], [Peekaboo][peekaboo] | Screen capture primitives |
 | [anthropics/claude-code#22903][cc-22903], [anthropics/claude-code#38698][cc-38698] | First-party feature-request status |
 | [claude-code-router][cc-router] | Community routing layer |
+| [StarTrail-org/PixelRAG][pixelrag] | Pixel-native RAG + Claude Code `pixelbrowse` plugin (Qwen3-VL-Embedding) |
 
 [anthropic-vision]: https://platform.claude.com/docs/en/build-with-claude/vision
 [qwen25-vl]: https://huggingface.co/Qwen/Qwen2.5-VL-3B-Instruct
@@ -165,3 +167,4 @@ Using a router is orthogonal to the VLM landscape above — a Tier 2 workflow co
 [cc-router]: https://github.com/musistudio/claude-code-router
 [cc-router-config]: ../cc-native/configuration/CC-model-provider-configuration.md
 [cc-voice]: https://github.com/qte77/cc-voice-plugin-prototype
+[pixelrag]: https://github.com/StarTrail-org/PixelRAG

--- a/docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md
+++ b/docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md
@@ -5,8 +5,8 @@ purpose: Taxonomy of reusable harness-level patterns extracted from the Claude C
 category: analysis
 status: research
 created: 2026-04-06
-updated: 2026-06-19
-validated_links: 2026-06-19
+updated: 2026-06-22
+validated_links: 2026-06-22
 ---
 
 **Status**: Research (informational)
@@ -122,6 +122,7 @@ Pattern taxonomist by trade: Kubernetes patterns -> Camel patterns -> Prompt pat
 - [Kubernetes Patterns (O'Reilly)](https://k8spatterns.com/)
 - [Prompt Patterns catalog](https://www.promptpatterns.dev/)
 - [The Generative Programmer Substack](https://generativeprogrammer.com/)
+- ["Dive into Claude Code: The Design Space of Today's and Future AI Agent Systems" (arXiv 2604.14228)](https://arxiv.org/abs/2604.14228) — academic design-space analysis of CC's source (Liu et al., 2026)
 
 ## Security-Domain Application: Defending Code Reference Harness
 
@@ -149,6 +150,17 @@ A concrete application of Context-Isolated Subagents + Fork-Join Parallelism to 
 [claude-security]: https://claude.com/product/claude-security
 [skill-issue-post]: https://www.hlyr.dev/blog/skill-issue-harness-engineering-for-coding-agents
 [humanlayer]: https://www.humanlayer.dev/
+
+## Academic Design-Space Analysis (arXiv 2604.14228)
+
+["Dive into Claude Code: The Design Space of Today's and Future AI Agent Systems"](https://arxiv.org/abs/2604.14228) (Liu, Zhao, Shang, Shen, 2026) reverse-engineers CC's published TypeScript source — an academic complement to Ibryam's pattern taxonomy above, framing the same artifact as a *design space*. It extracts five design motivations and traces them to concrete mechanisms:
+
+- **Seven-mode permission system** + an ML-based command risk classifier — cf. patterns 9–10 (Progressive Tool Expansion, Command Risk Classification).
+- **Five-layer context-compaction pipeline** — cf. pattern 5 (Progressive Context Compaction).
+- **Four extensibility mechanisms** — MCP, plugins, skills, hooks.
+- **Subagent + worktree delegation** and append-oriented session management.
+
+It compares CC against a second system ("OpenClaw") to show how deployment context drives divergent architectural choices, and closes with six open design directions. Cross-ref: [CC-reverse-engineering-landscape.md](../../cc-community/CC-reverse-engineering-landscape.md) for the broader source/binary analysis lineage.
 
 ## Action Items
 


### PR DESCRIPTION
Final R-series topic — the five targets you supplied, each **fit into an existing doc** (per the "fit existing first" steer); no new standalone docs needed.

| Target | Home | Treatment |
|---|---|---|
| `langchain-ai/local-deep-researcher` (~9.2k★) | `CC-research-agents-landscape.md` §1 + mapping table | Added; **explicitly distinguished** from the look-alike `LearningCircuit/local-deep-research` (different repos, near-identical names) |
| `hanxiao/dataroom` (~168★) | `CC-research-agents-landscape.md` §1 + mapping table | Local-gather → frontier-synthesize harness; Pi-based, cross-ref `pi-analysis.md` |
| `LearningCircuit/local-deep-research` | — | **Already covered**; stars current (~8.5k), no change |
| `StarTrail-org/PixelRAG` (~3.3k★) | `CC-vlm-screen-sharing-landscape.md` → Observed Implementations | Pixel-native RAG (Qwen3-VL-Embedding) + CC `pixelbrowse` plugin; best fit is the VLM doc, not community-tooling |
| arXiv 2604.14228 "Dive into Claude Code" | `CC-agentic-harness-patterns-analysis.md` → new section | Academic design-space analysis folded next to the Ibryam pattern taxonomy (both derive from CC's source) |

## Principles applied

- **Fit existing / DRY** — 4 extensions + 1 already-covered; zero new files. PixelRAG and the arXiv paper were routed to their most precise existing homes (VLM landscape; harness-patterns analysis) rather than forced into a generic catalog.
- **Accuracy** — the two near-identically-named `local-deep-research*` repos are cross-distinguished so readers don't conflate them.
- **First-party** — GitHub repos + the arXiv abstract (URL as you supplied it); all resolve under lychee.

## Validation

- `make check_docs` → 0 errors (177 files)
- `lychee` on the 3 changed docs → 85 OK, 0 errors
- Changelog: `changelog.d/` fragment

Part of #276. With R1–R5 merged, #276's enumerated scope is complete (semantic-layer, agentic-memory, context-compression, protocol-interop) + your 5 new targets — #276 can be closed once this lands.

Generated with Claude <noreply@anthropic.com>