### PR TITLE
docs: refresh stale facts in CC-models-reference + CC-prompt-caching-behavior (#304)

### DIFF
--- a/changelog.d/20260622_stale-fact-refresh.md
+++ b/changelog.d/20260622_stale-fact-refresh.md
@@ -1,0 +1,7 @@
+### Changed
+
+- `docs/cc-native/configuration/CC-models-reference.md` + `docs/cc-native/context-memory/CC-prompt-caching-behavior.md`: **stale-fact refresh** against first-party Anthropic sources (claude-api reference) — Fable 5 tokenizer figure tightened to ≈1×–1.35× (was "~30%"); the Fable 5 CC-plan-access line reframed now that the 2026-06-22 credit-transition date has arrived; added the model-dependent **minimum cacheable prefix** (4096 tokens on Opus-tier, 2048 on Fable 5 / Sonnet 4.6). Partial #304.
+
+### Fixed
+
+- `docs/cc-native/context-memory/CC-prompt-caching-behavior.md`: corrected the doubled `/docs/en/docs/` path segment in the prompt-caching, pricing, and messages source URLs to the canonical first-party form.

--- a/docs/cc-native/configuration/CC-models-reference.md
+++ b/docs/cc-native/configuration/CC-models-reference.md
@@ -3,8 +3,8 @@ title: CC Models & Free-Tier Provider Reference
 source: https://platform.claude.com/docs/en/about-claude/models/overview, https://platform.claude.com/docs/en/about-claude/pricing
 purpose: Descriptive reference for the newest Claude model (Fable 5) and a snapshot of free-tier / OSS inference providers — the model/provider facts behind CC-model-provider-configuration.md.
 created: 2026-06-14
-updated: 2026-06-14
-validated_links: 2026-06-14
+updated: 2026-06-22
+validated_links: 2026-06-22
 ---
 
 **Status**: Reference (descriptive). For *how to configure* CC against these models/providers (env vars, endpoints, gateways), see [CC-model-provider-configuration.md](CC-model-provider-configuration.md).
@@ -22,10 +22,10 @@ Claude Fable 5 (`claude-fable-5`) — Anthropic's most capable widely released m
 
 CC-relevant caveats ([source][fable5-intro]):
 
-- **New tokenizer** (the one introduced with Opus 4.7): the same text is ~30% more tokens than on pre-4.7 models — re-baseline cost and `CLAUDE_CODE_MAX_OUTPUT_TOKENS` expectations.
+- **New tokenizer** (introduced with Opus 4.7, shared with Opus 4.8): the same text is roughly 1×–1.35× the tokens of pre-4.7 models (varies by content) — re-baseline cost and `CLAUDE_CODE_MAX_OUTPUT_TOKENS` expectations. Token counts are roughly unchanged when moving between Opus 4.7/4.8 and Fable 5.
 - **`refusal` stop reason**: safety classifiers may decline a request as a successful HTTP 200 (not an error); plan for refusal handling and fallback to another model.
 - **30-day data retention required** — not available to zero-data-retention orgs.
-- **CC plan access** (per the in-product `/model` notice, 2026-06): included in Claude plan limits until 2026-06-22, after which it continues via usage credits.
+- **CC plan access** (per the in-product `/model` notice, 2026-06): included in Claude plan limits through 2026-06-22; from 2026-06-22 it continues via usage credits.
 
 ## Free-Tier & OSS Provider Reference
 

--- a/docs/cc-native/context-memory/CC-prompt-caching-behavior.md
+++ b/docs/cc-native/context-memory/CC-prompt-caching-behavior.md
@@ -2,8 +2,8 @@
 title: CC Prompt Caching Behavior — Server-Side Mechanism and Session Economics
 purpose: How Anthropic's server-side prompt caching works in CC sessions — what's cached, matching, TTL, hit rates, and cost impact.
 created: 2026-03-27
-updated: 2026-03-27
-validated_links: 2026-03-27
+updated: 2026-06-22
+validated_links: 2026-06-22
 ---
 
 **Status**: Adopt
@@ -57,6 +57,12 @@ From the [caching docs][caching]:
 The server checks at most 20 block positions backward from the breakpoint. If the prior cache entry is beyond 20 blocks back, it's a miss even if the prefix is identical.
 
 Source: [prompt caching docs][caching], "How cache lookback works" section
+
+### Minimum cacheable prefix
+
+The cacheable prefix is model-dependent — **4096 tokens on Opus-tier models** (Opus 4.6/4.7/4.8, which CC defaults to), 2048 on Fable 5 / Sonnet 4.6. A prefix shorter than the minimum silently skips caching: no error, just `cache_creation_input_tokens: 0`.
+
+Source: [prompt caching docs][caching], "Cache limitations" section
 
 ## CC-Specific Caching Behavior
 
@@ -137,6 +143,6 @@ Slug is a CC-internal auto-generated session display name (e.g., `stateful-dream
 | [API messages docs][api] | Usage object fields (`cache_read_input_tokens`, `cache_creation_input_tokens`) |
 | CC 2.1.83, session `9f7de296`, Codespaces, 2026-03-27 | Cache warmup curve, 5m-only behavior, 96.3% hit rate |
 
-[caching]: https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching
-[pricing]: https://platform.claude.com/docs/en/docs/about-claude/pricing
-[api]: https://platform.claude.com/docs/en/docs/api/messages
+[caching]: https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+[pricing]: https://platform.claude.com/docs/en/about-claude/pricing
+[api]: https://platform.claude.com/docs/en/api/messages


### PR DESCRIPTION
First slice of #304 — stale-fact refresh, verified against first-party Anthropic sources (the claude-api reference).

## Changes

**`CC-models-reference.md`**
- Fable 5 tokenizer figure tightened: "~30% more tokens" → **≈1×–1.35×** of pre-4.7 models (varies by content); noted counts are ~unchanged across Opus 4.7/4.8 ↔ Fable 5.
- Fable 5 CC-plan-access line reframed now that the **2026-06-22** credit-transition date has arrived.

**`CC-prompt-caching-behavior.md`**
- Added the model-dependent **minimum cacheable prefix** (4096 tokens on Opus-tier, 2048 on Fable 5 / Sonnet 4.6).
- Fixed the doubled `/docs/en/docs/` path in the prompt-caching / pricing / messages source URLs → canonical first-party form.

Both frontmatter `updated`/`validated_links` bumped to 2026-06-22.

## Validation

- `make check_docs` (markdownlint): 0 errors across 177 files
- `lychee` on the 2 changed docs: 12/12 OK, 0 errors (confirms the corrected URLs resolve)

Changelog fragment included. The free-tier provider table (Feb-2026 snapshot) was left as-is — it's already hedged and refreshing it needs per-provider web verification, out of scope here.

Generated with Claude <noreply@anthropic.com>