### PR TITLE
docs: gateway back-ports + Aider repo-map (#304)

### DIFF
--- a/changelog.d/20260622_gateways-aider.md
+++ b/changelog.d/20260622_gateways-aider.md
@@ -1,0 +1,8 @@
+### Added
+
+- `docs/cc-native/configuration/CC-model-provider-configuration.md`: **5 hosted CC-integrated gateways** (Portkey, Martian, Vercel AI Gateway, Zuplo, RelayPlane) back-ported as a compact CC-config table — each `ANTHROPIC_BASE_URL` / auth pattern verified against the gateway's own Claude Code docs (2026-06-22). Defers to `llm-routers-gateways-landscape.md` for the full catalog (router-architecture consolidation, DRY). Partial #304.
+- `docs/non-cc/aider-analysis.md`: expanded the **repo-map** mechanism — symbol extraction, PageRank-style graph ranking over the dependency graph, `--map-tokens` (default 1,000), and dynamic auto-sizing (first-party `aider.chat/docs/repomap.html`). Partial #304.
+
+### Changed
+
+- `docs/non-cc/llm-routers-gateways-landscape.md`: bottom cross-ref now records that the five CC-integrated gateways are back-ported into the CC config doc, with the landscape kept as the single authoritative catalog (license/pricing/breadth).

--- a/docs/cc-native/configuration/CC-model-provider-configuration.md
+++ b/docs/cc-native/configuration/CC-model-provider-configuration.md
@@ -3,8 +3,8 @@ title: CC Model & Provider Configuration
 source: https://code.claude.com/docs/en/settings#environment-variables, https://openrouter.ai/docs/guides/coding-agents/claude-code-integration, https://ollama.com/blog/claude, https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models, https://www.infomaniak.com/en/hosting/ai-services/open-source-models
 purpose: Reference for configuring CC with alternative models, endpoints, API keys, third-party providers (OpenRouter, Bedrock, Vertex, Foundry, Infomaniak), local models (Ollama, llama.cpp, LM Studio), and LLM gateway proxies.
 created: 2026-03-07
-updated: 2026-06-16
-validated_links: 2026-06-11
+updated: 2026-06-22
+validated_links: 2026-06-22
 ---
 
 **Status**: Reference (actionable configuration guide)
@@ -326,6 +326,20 @@ export ANTHROPIC_AUTH_TOKEN=<requesty-api-key>
 - **Pricing**: pay-per-token at provider rates; $10 free credits for new accounts; enterprise volume discounts. No open-source core.
 - **Analytics**: optional wrapper tags sessions with git metadata for per-developer cost attribution.
 
+#### Hosted CC-Integrated Gateways (Portkey · Martian · Vercel · Zuplo · RelayPlane)
+
+Five more hosted gateways document explicit Claude Code support — set `ANTHROPIC_BASE_URL` (plus the gateway's auth token) and CC routes through them. To avoid duplicating the catalog, provider breadth, licensing, and pricing for these (and ~30 more routers/gateways) live in [llm-routers-gateways-landscape.md](../../non-cc/llm-routers-gateways-landscape.md); the **CC-specific config** is below (each verified against the gateway's own CC docs, 2026-06-22):
+
+| Gateway | CC config | First-party CC doc |
+|---|---|---|
+| **Portkey** | `ANTHROPIC_BASE_URL=https://api.portkey.ai` + `ANTHROPIC_AUTH_TOKEN=<portkey-key>` + `ANTHROPIC_CUSTOM_HEADERS` carrying `x-portkey-api-key` and `x-portkey-provider: @<provider-slug>` — one unified endpoint fronting Anthropic/Bedrock/Vertex backends; OSS gateway is also self-hostable | [portkey.ai/docs][portkey-cc] |
+| **Martian** | `ANTHROPIC_BASE_URL=https://api.withmartian.com/v1`; key via `apiKeyHelper: echo $MARTIAN_API_KEY` — per-request ML cost-quality routing | [docs.withmartian.com][martian-cc] |
+| **Vercel AI Gateway** | `ANTHROPIC_BASE_URL=https://ai-gateway.vercel.sh` — Anthropic Messages API, zero token markup, BYOK option | [vercel.com/docs][vercel-gw] |
+| **Zuplo AI Gateway** | `ANTHROPIC_BASE_URL=<your-app-gateway-url>` + `ANTHROPIC_AUTH_TOKEN=<app-key>` — per-app URL after provider/team/app setup; serves Anthropic `/v1/messages` | [zuplo.com/docs][zuplo-cc] |
+| **RelayPlane** | local Node.js proxy (no Docker) wired via a `settings.json` hook; `rp:best` / `rp:cheap` model offload through OpenRouter | [relayplane.com][relayplane] |
+
+All five satisfy the [Gateway Requirements](#gateway-requirements) below (Anthropic `/v1/messages` + forwarded `anthropic-beta` / `anthropic-version` headers).
+
 #### Direct CC-Compatible Endpoints
 
 Some providers expose Anthropic-compatible endpoints natively (no proxy needed):
@@ -398,6 +412,7 @@ When routing through gateways, additionally set ([source][cc-settings]):
 - [CC-models-reference.md](CC-models-reference.md) — Fable 5 model card + free-tier/OSS provider reference table
 - [CC-cli-reference.md](CC-cli-reference.md) — canonical flag definitions (`--model`, `--effort`, `--fallback-model`, `--betas`)
 - [CC-env-vars-reference.md](CC-env-vars-reference.md) — env var reference for `ANTHROPIC_MODEL`, `CLAUDE_CODE_EFFORT_LEVEL`, etc.
+- [llm-routers-gateways-landscape.md](../../non-cc/llm-routers-gateways-landscape.md) — authoritative provider-agnostic router/gateway catalog (license, pricing, model breadth) for the gateways above and ~30 more; this doc holds only their CC-specific config
 
 ## References
 
@@ -418,6 +433,11 @@ When routing through gateways, additionally set ([source][cc-settings]):
 - [llama-swap][llama-swap]
 - [Claudish (MadAppGang)][claudish]
 - [Requesty — Claude Code Integration][requesty]
+- [Portkey — Claude Code integration][portkey-cc]
+- [Martian — Claude Code integration][martian-cc]
+- [Vercel AI Gateway docs][vercel-gw]
+- [Zuplo AI Gateway — Claude Code integration][zuplo-cc]
+- [RelayPlane][relayplane]
 - [Local setup guide][local-setup]
 - [Infomaniak — Open-Source AI Models][infomaniak-ai]
 - [Infomaniak — vLLM TranslateGemma-27B (Hugging Face)][infomaniak-translategemma]
@@ -447,3 +467,8 @@ When routing through gateways, additionally set ([source][cc-settings]):
 [infomaniak-translategemma]: https://huggingface.co/Infomaniak-AI/vllm-translategemma-27b-it
 [infomaniak-opencode]: https://janikvonrotz.ch/2026/04/01/setup-opencode-with-infomaniak-ai-tools/
 [infomaniak-n8n]: https://community.n8n.io/t/add-new-language-model-informaniak-ai/73182
+[portkey-cc]: https://portkey.ai/docs/integrations/libraries/claude-code
+[martian-cc]: https://docs.withmartian.com/integrations/claude-code
+[vercel-gw]: https://vercel.com/docs/ai-gateway
+[zuplo-cc]: https://zuplo.com/docs/ai-gateway/integrations/claude-code
+[relayplane]: https://relayplane.com/

--- a/docs/non-cc/aider-analysis.md
+++ b/docs/non-cc/aider-analysis.md
@@ -3,8 +3,8 @@ title: Aider — Terminal AI Pair Programmer
 source: https://aider.chat/
 purpose: OSS terminal coding agent with git-native workflow and multi-LLM support
 created: 2026-06-16
-updated: 2026-06-16
-validated_links: 2026-06-16
+updated: 2026-06-22
+validated_links: 2026-06-22
 ---
 
 **Status**: Adopt
@@ -42,12 +42,30 @@ aider-install
 Then invoke `aider` in a git repository with an LLM API key set in the
 environment (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`).
 
-### Codebase mapping
+### Codebase mapping (repo map)
 
 Aider builds a **repo map** — a compressed, token-efficient index of all
 files, classes, and functions — so the LLM can reason about large codebases
 without loading every file into context. The map is regenerated incrementally
 as files change ([aider.chat docs][aider-repomap]).
+
+How the map is built and sized ([aider.chat docs][aider-repomap]):
+
+- **Symbol extraction** — each file is parsed for its key identifiers (classes,
+  functions, method signatures) and the critical lines that define them.
+- **Graph ranking** — Aider builds a dependency graph (files as nodes,
+  references as edges) and applies a PageRank-style ranking to surface the
+  identifiers most often referenced elsewhere, so the most load-bearing symbols
+  win the limited budget rather than a flat file listing.
+- **Token budget** — `--map-tokens` (default **1,000**) caps the map; Aider
+  **auto-sizes** it dynamically, expanding well past the default when no files
+  are in the chat and shrinking as files are added to the session.
+- **Delivery** — the ranked map is sent to the LLM with each request, alongside
+  the contents of the files currently in the chat.
+
+This graph-ranked, budget-bounded map is the mechanism behind Aider's
+"scales to large codebases" claim — only the highest-signal slice of the
+repository competes for context on any given turn.
 
 ### Edit loop
 
@@ -152,6 +170,7 @@ cross-session memory or cloud sandbox.
 | [Aider releases page][aider-releases] | Latest release v0.86.0, 2025-08-09 (accessed 2026-06-16) |
 | [Aider LLM leaderboard][aider-leaderboard] | Polyglot benchmark methodology, top scores, last updated 2025-11-20 (accessed 2026-06-16) |
 | [Aider HISTORY][aider-history] | v0.86.0 self-authorship stat (88 %), main-branch Claude 4.x aliases (accessed 2026-06-16) |
+| [Aider repo-map docs][aider-repomap] | Repo-map construction: symbol extraction, graph/PageRank ranking, `--map-tokens` default (1,000), dynamic auto-sizing (accessed 2026-06-22) |
 
 [aider-home]: https://aider.chat/
 [aider-gh]: https://github.com/Aider-AI/aider

--- a/docs/non-cc/llm-routers-gateways-landscape.md
+++ b/docs/non-cc/llm-routers-gateways-landscape.md
@@ -3,7 +3,7 @@ title: LLM Routers & Gateways Landscape
 source: https://openrouter.ai/
 purpose: Provider-agnostic model routers, hosted aggregators, self-hostable gateways, and model-fusion/ensemble routing tools — a reference catalog verified 2026-06-16.
 created: 2026-06-16
-updated: 2026-06-16
+updated: 2026-06-22
 validated_links: 2026-06-16
 ---
 
@@ -108,4 +108,4 @@ Facts compiled from each tool's first-party page (1p-verified 2026-06-16). No th
 | [github.com/glama-ai/lightport](https://github.com/glama-ai/lightport) | Lightport license, providers |
 | [github.com/lm-sys/RouteLLM](https://github.com/lm-sys/RouteLLM) | RouteLLM paper/OSS router |
 
-Cross-ref: [CC-model-provider-configuration.md](../cc-native/configuration/CC-model-provider-configuration.md) — OpenRouter and LiteLLM appear there as Claude Code integration targets (ANTHROPIC\_BASE\_URL patterns, model-slot env vars).
+Cross-ref: [CC-model-provider-configuration.md](../cc-native/configuration/CC-model-provider-configuration.md) — OpenRouter and LiteLLM appear there as Claude Code integration targets, and the five hosted CC-integrated gateways here (Portkey, Martian, Vercel AI Gateway, Zuplo, RelayPlane) are back-ported there with their Claude Code `ANTHROPIC_BASE_URL` config. This landscape stays the authoritative catalog (license/pricing/breadth); the CC doc holds only the CC-specific setup.


### PR DESCRIPTION
Second slice of #304 — verified against first-party sources.

## Changes

**Gateway back-ports + router consolidation** (`CC-model-provider-configuration.md` + `llm-routers-gateways-landscape.md`)
- Added 5 hosted CC-integrated gateways as a compact CC-config table: **Portkey** (`api.portkey.ai` + `x-portkey-*` headers), **Martian** (`api.withmartian.com/v1`), **Vercel AI Gateway** (`ai-gateway.vercel.sh`), **Zuplo** (per-app URL), **RelayPlane** (local proxy). Each `ANTHROPIC_BASE_URL`/auth pattern verified against the gateway's own Claude Code docs (2026-06-22).
- The table **defers to the routers landscape** for the full license/pricing/breadth catalog; the two docs now cross-reference each other bidirectionally — landscape = authoritative catalog, config doc = CC setup only (DRY consolidation; the config doc previously didn't even link the landscape).

**Aider repo-map** (`aider-analysis.md`)
- Expanded the Codebase mapping section with the first-party mechanism: symbol extraction, PageRank-style graph ranking over the dependency graph, `--map-tokens` (default 1,000), dynamic auto-sizing. Sourced to `aider.chat/docs/repomap.html`.

## Validation

- `make check_docs` (markdownlint): 0 errors across 177 files
- `lychee` on changed docs: all **new** URLs pass; 2 timeouts (`api7.ai`, `requesty.ai`) are **pre-existing, unrelated** links in the landscape (slow-host flake — passed in earlier full-repo runs), not introduced here.

Frontmatter: `updated` bumped on all three; `validated_links` bumped only on the two fully re-verified docs (config + aider), left at 2026-06-16 on the landscape (one-line edit, links not re-validated).

This leaves only router-architecture *deep* consolidation as optional follow-up; the #304 gateway/Aider/stale-fact items are now done.

Generated with Claude <noreply@anthropic.com>