### PR TITLE
docs: add SPECTER2 + sqlite-vec to RAG/retrieval landscape (§7)

### DIFF
--- a/changelog.d/20260622_rag-embeddings-sqlitevec.md
+++ b/changelog.d/20260622_rag-embeddings-sqlitevec.md
@@ -1,0 +1,3 @@
+### Added
+
+- `docs/non-cc/agent-frameworks-infrastructure-landscape.md` (§7 RAG & Retrieval): new **Embedding models** subsection ([SPECTER2](https://huggingface.co/allenai/specter2) scholarly-document embeddings + SciNCL; general-purpose note) and **[sqlite-vec](https://github.com/asg017/sqlite-vec)** in Vector databases (single-file SQLite extension, WASM/in-browser KNN so precomputed embeddings ship inside a static site). Fills the §7 embeddings gap and the static-serverless vector-search angle; provenance for the paperverse semantic-"near" roadmap.

--- a/docs/non-cc/agent-frameworks-infrastructure-landscape.md
+++ b/docs/non-cc/agent-frameworks-infrastructure-landscape.md
@@ -104,6 +104,11 @@ Retrieval is the sibling of memory (§4): §4 persists evolving agent *state*; t
 - [Cohere Rerank](https://cohere.com/rerank) — cross-encoder rerank API (rerank-v4.0 pro/fast, 100+ languages); commercial.
 - **Cross-encoders** — joint query+document forward pass (via sentence-transformers); higher accuracy than bi-encoders at O(n) per-candidate cost; run as a second stage after ANN retrieval. ColBERT (above) is the late-interaction middle ground.
 
+### Embedding models
+
+- [SPECTER2](https://huggingface.co/allenai/specter2) — scientific-document embeddings (AllenAI; citation-proximity-trained, task-adaptive adapters), a strong default for scholarly-paper similarity where general-purpose embeddings underperform (Apache-2.0). SciNCL is a citation-neighbour-sampled alternative.
+- General-purpose text embeddings (sentence-transformers bi-encoders, BAAI **bge**, **nomic-embed**) cover cross-domain corpora; prefer a domain-tuned model when the corpus is narrow (e.g. SPECTER2 for papers).
+
 ### Vector databases
 
 - [Qdrant](https://github.com/qdrant/qdrant) — dense + sparse + multi-vector (ColBERT), built-in RRF/DBSF hybrid fusion, quantization (Apache-2.0, Rust).
@@ -113,6 +118,7 @@ Retrieval is the sibling of memory (§4): §4 persists evolving agent *state*; t
 - [pgvector](https://github.com/pgvector/pgvector) — vectors inside Postgres: ACID, JOINs, no separate system (PostgreSQL License).
 - [Pinecone](https://www.pinecone.io/) — fully managed serverless ANN; no self-hosted option (proprietary).
 - [LanceDB](https://github.com/lancedb/lancedb) — embedded, multimodal, Lance columnar format, zero-copy + versioning (Apache-2.0).
+- [sqlite-vec](https://github.com/asg017/sqlite-vec) — vector search as a single-file **SQLite extension**; runs in-process and compiles to **WASM** for in-browser KNN, so precomputed embeddings can ship inside a static site with no server (Apache-2.0). Brute-force (no ANN index yet, pre-1.0) — fine at small/medium corpus sizes.
 
 ### RAG evaluation
 


### PR DESCRIPTION
## What

Adds **SPECTER2** + **sqlite-vec** to §7 (RAG & Retrieval) of the agent-frameworks landscape — filling the embeddings gap and the static-serverless vector-search angle.

## Changes

- New **Embedding models** subsection: [SPECTER2](https://huggingface.co/allenai/specter2) (scholarly-document embeddings, citation-trained, Apache-2.0) + SciNCL; a general-purpose embeddings note.
- **[sqlite-vec](https://github.com/asg017/sqlite-vec)** added to Vector databases: single-file SQLite extension, runs in-process and compiles to **WASM** for in-browser KNN → precomputed embeddings ship inside a static site with no server (Apache-2.0; brute-force, pre-1.0).

## Why

§7 had **no embeddings subsection** at all. These two also serve as documented provenance for the **paperverse** semantic-"near" roadmap (issues to follow that reference this section).

## Validation

- `markdownlint-cli2` — 0 errors
- `lychee` — the two new links resolve OK; the single timeout is the **pre-existing** `cohere.com/rerank` (line 104, Rerankers subsection — untouched by this diff; known slow-host flake).

Changelog fragment: `changelog.d/20260622_rag-embeddings-sqlitevec.md`.

Generated with Claude <noreply@anthropic.com>
