### PR TITLE
docs: fix stale subdir doc counts in cc-native README

### DIFF
--- a/changelog.d/20260622_cc-native-readme-counts.md
+++ b/changelog.d/20260622_cc-native-readme-counts.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `docs/cc-native/README.md`: corrected stale subdirectory doc counts — sessions 5→7, sandboxing 4→5, plugins-ecosystem 8→10 (verified against `git ls-files`).

--- a/docs/cc-native/README.md
+++ b/docs/cc-native/README.md
@@ -7,12 +7,12 @@ Deep-dive analyses of Anthropic-native Claude Code features and internals.
 | Directory | Coverage | Docs |
 |-----------|----------|------|
 | [agents-skills/](agents-skills/) | Agent teams, recursive spawning, skills adoption, Ralph, dynamic workflows | 8 |
-| [sessions/](sessions/) | Session lifecycle, cost analysis, keepalive, headless mode, error messages | 5 |
-| [sandboxing/](sandboxing/) | Filesystem/network sandbox, Codespaces friction, platform comparison, permission bypass | 4 |
+| [sessions/](sessions/) | Session lifecycle, cost analysis, keepalive, headless mode, error messages | 7 |
+| [sandboxing/](sandboxing/) | Filesystem/network sandbox, Codespaces friction, platform comparison, permission bypass | 5 |
 | [ci-remote/](ci-remote/) | GitHub Actions, cloud sessions, remote access/control, web auth, version pinning, monitoring | 8 |
 | [configuration/](configuration/) | Hooks, model/provider config, fast/bash mode, loop/cron, env vars, tools, binary + IDE/stream-json internals, models reference, changelog, visuals | 14 |
 | [context-memory/](context-memory/) | Extended context, memory system, llms.txt, prompt caching | 4 |
-| [plugins-ecosystem/](plugins-ecosystem/) | Official plugins, connectors, Cowork, packaging, web scraping | 8 |
+| [plugins-ecosystem/](plugins-ecosystem/) | Official plugins, connectors, Cowork, packaging, web scraping | 10 |
 | [model-internals/](model-internals/) | Emotion vectors, interpretability, safety classifiers, alignment steering, first-party research index | 2 |
 
 ## Reference


### PR DESCRIPTION
## What

Fixes stale subdirectory doc counts in `docs/cc-native/README.md`.

## Changes

- `sessions/` 5 → **7**, `sandboxing/` 4 → **5**, `plugins-ecosystem/` 8 → **10** — verified against `git ls-files`. The other five subdir counts (agents-skills 8, ci-remote 8, configuration 14, context-memory 4, model-internals 2) are already correct.

## Validation

- `markdownlint-cli2` — 0 errors; counts-only edit (no link changes).

Changelog fragment: `changelog.d/20260622_cc-native-readme-counts.md`.

Generated with Claude <noreply@anthropic.com>