### PR TITLE
docs: add observability & tracing to CC dynamic-workflows

### DIFF
--- a/changelog.d/20260622_cc-workflows-observability.md
+++ b/changelog.d/20260622_cc-workflows-observability.md
@@ -1,0 +1,3 @@
+### Added
+
+- `docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md`: new **Observability & tracing** section — workflow/subagent execution emits OpenTelemetry (metrics + logs GA; traces beta via `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA`). Per-subagent `claude_code.llm_request` / `claude_code.tool` spans **nest under the parent Agent-tool span** (`agent_id` / `parent_agent_id`) → a real agent-trajectory trace; partial `gen_ai.*` GenAI conventions. Any OTLP backend (Arize Phoenix, Pydantic Logfire, Datadog, Tempo) ingests it **generically — none has a CC-specific integration**. Cross-refs `CC-agent-observability-methods-analysis.md`. First-party: code.claude.com/docs/en/monitoring-usage.

--- a/docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md
+++ b/docs/cc-native/agents-skills/CC-dynamic-workflows-analysis.md
@@ -96,6 +96,14 @@ Dynamic workflows run on **every** Claude Code surface — interactive CLI, Desk
 
 **Bottom line:** workflows work in the SDK, headless `-p`, *and* interactive — the only headless caveats are that background agents are awaited (10-min default cap) and `--bare` requires passing skills/hooks/MCP explicitly.
 
+## Observability & tracing
+
+Workflow and subagent execution is observable via Claude Code's OpenTelemetry export (opt-in: `CLAUDE_CODE_ENABLE_TELEMETRY=1`) — **metrics** and **log events** are GA; **traces (spans)** are **beta** (`CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` + `OTEL_TRACES_EXPORTER`) ([monitoring][cc-monitoring]).
+
+- **Per-subagent spans.** With beta traces on, a spawned subagent's `claude_code.llm_request` and `claude_code.tool` spans **nest under the parent `claude_code.tool` (Agent tool) span**, carrying `agent_id` / `parent_agent_id` — a real agent-trajectory trace, not just session metrics. There is **no dedicated "workflow phase" span**; structure is inferred from Agent-tool nesting. Without beta traces you still get per-subagent attribution on metrics/log events (`query_source` = `main`/`subagent`/`auxiliary`, `agent.name`, token/cost) but no span waterfall.
+- **GenAI conventions (partial):** spans carry `gen_ai.system`, `gen_ai.request.model`, `gen_ai.response.*`, `gen_ai.tool.call.id`, but CC uses its own `claude_code.*` span namespace (not the `invoke_agent` naming). The in-session `/workflows` progress view is a **TUI**, not OTel export.
+- **Backends:** the output is standard **OTLP**, so any OTLP backend ingests it — Arize Phoenix, Pydantic Logfire, Grafana/Tempo, Honeycomb, Datadog, Langfuse. **None has a CC-specific integration** — it's generic OTLP, so you get the span waterfall but not bespoke CC topology rendering. Datadog's GenAI-convention support (v1.37+) parses the `gen_ai.*` attributes closest to CC-aware; Phoenix lacks OpenInference tags natively; Logfire's "zero-config CC" path is CC→Logfire-as-MCP-server, not Logfire parsing CC's OTel. Full platform + OTel-attribute detail: [CC-agent-observability-methods-analysis.md](../../cc-community/CC-agent-observability-methods-analysis.md).
+
 ## Disabling
 
 Workflows run in the CLI, Desktop, IDE extensions, headless (`claude -p`), and the [Agent SDK][cc-agent-sdk]. Disable via *Dynamic workflows* off in `/config`, `"disableWorkflows": true` in settings, or `CLAUDE_CODE_DISABLE_WORKFLOWS=1`. When disabled, bundled workflow commands are unavailable, the `ultracode` keyword stops triggering, and `ultracode` is removed from the `/effort` menu ([workflows][cc-workflows]).
@@ -127,6 +135,7 @@ Workflows run in the CLI, Desktop, IDE extensions, headless (`claude -p`), and t
 | [Run agents in parallel][cc-agents] | Subagents vs skills vs teams vs workflows |
 | [Agent SDK overview][cc-agent-sdk] | Workflows on the SDK surface |
 | [Headless mode][cc-headless] | `-p` skills/subagents/hooks behavior, `--bare`, background-agent wait cap |
+| [Monitoring usage][cc-monitoring] | OTel signals (metrics/logs GA, traces beta), per-subagent span nesting, `gen_ai.*` attributes |
 | [Tools reference — WebSearch][cc-tools-ref] | `/deep-research` dependency |
 
 [cc-workflows]: https://code.claude.com/docs/en/workflows
@@ -138,4 +147,5 @@ Workflows run in the CLI, Desktop, IDE extensions, headless (`claude -p`), and t
 [cc-agents]: https://code.claude.com/docs/en/agents
 [cc-agent-sdk]: https://code.claude.com/docs/en/agent-sdk/overview
 [cc-headless]: https://code.claude.com/docs/en/headless
+[cc-monitoring]: https://code.claude.com/docs/en/monitoring-usage
 [cc-tools-ref]: https://code.claude.com/docs/en/tools-reference#websearch-tool-behavior


### PR DESCRIPTION
## What

Answers "for CC workflows specifically — evaluation/tracking/observation/tracing, do they use OTel? do Arize / Pydantic Logfire / other OTel tools support it?" with a new **Observability & tracing** section in `CC-dynamic-workflows-analysis.md`.

## Added (first-party: code.claude.com/docs/en/monitoring-usage)

- CC emits OTel — **metrics + logs GA, traces beta** (`CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` + `OTEL_TRACES_EXPORTER`).
- **Per-subagent spans** nest under the parent Agent-tool span (`agent_id`/`parent_agent_id`) → real agent-trajectory trace; no dedicated workflow-phase span. Without beta traces: per-subagent attribution on metrics/logs only.
- **Partial GenAI conventions** (`gen_ai.*` on spans; CC's own `claude_code.*` namespace, not `invoke_agent`).
- **Arize Phoenix / Pydantic Logfire / Datadog / Tempo** ingest via **generic OTLP — none has a CC-specific integration** (Datadog closest via GenAI conventions; Phoenix lacks OpenInference tags natively; Logfire's zero-config path is CC→Logfire-as-MCP-server). Cross-refs the general observability doc.

## Validation

- `markdownlint-cli2` — 0 errors
- `lychee` — 20/20 links OK (incl. new monitoring URL + cross-ref)

Changelog fragment included.

Generated with Claude <noreply@anthropic.com>