### PR TITLE
docs: add requested sources + /deep-research cross-ref + CTO-handbook baseline

### DIFF
--- a/changelog.d/20260623_000000_add-requested-sources.md
+++ b/changelog.d/20260623_000000_add-requested-sources.md
@@ -1,0 +1,11 @@
+### Added
+
+- `docs/non-cc/agent-frameworks-infrastructure-landscape.md` (§1): expanded the **PydanticAI** entry with its new [capabilities system](https://pydantic.dev/articles/pydantic-ai-capabilities) (Jun 2026) — composable instructions + tools + model-settings bundles with **on-demand / deferred loading** (`defer_loading=True`) for token savings, capability-scoped hooks, and the Pydantic AI Gateway + Logfire companions. First-party source.
+- `docs/cc-native/agents-skills/CC-ralph-enhancement-research.md`: new **SantanderAI/ralph** entry under External Pattern Research — Banco Santander AI Lab's multi-CLI Ralph harness (Claude Code / Codex / Gemini / Devin; Apache-2.0, v0.1.0) with live `.ralph/.env` reload, token-exhaustion agent rotation, systemd RAM caps, and project-level distributed skills (`juez` / `maestro`); plus the `ralph-vault-skill` knowledge-vault companion.
+
+### Changed
+
+- `docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md`: cite the companion code repo [VILA-Lab/Dive-into-Claude-Code](https://github.com/VILA-Lab/Dive-into-Claude-Code) for the arXiv 2604.14228 design-space analysis.
+- `docs/cc-community/CC-vlm-screen-sharing-landscape.md`: refresh the **PixelRAG** entry (~3.3k★ → ~4.2k★, v0.3.0).
+- `docs/cc-community/CC-research-agents-landscape.md`: turn the bare `/deep-research` mention in the local-deep-research entry into an actual cross-ref to the bundled-workflow section (reuses the existing anchor).
+- `docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md`: cite the Startup CTO Handbook as the traditional engineering-leadership baseline the agentic disciplines diverge from (Cross-References + Sources), linking the qte77 estate mapping note.

--- a/docs/cc-community/CC-research-agents-landscape.md
+++ b/docs/cc-community/CC-research-agents-landscape.md
@@ -4,8 +4,8 @@ purpose: Catalog of autonomous research agents, scientific-domain models, and li
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-22
-validated_links: 2026-06-22
+updated: 2026-06-23
+validated_links: 2026-06-23
 ---
 
 **Status**: Research (informational)
@@ -31,7 +31,7 @@ Agents that conduct multi-step research and generate research outputs.
 - [OpenAI Deep Research][openai-deep-research] — agentic ChatGPT capability; API as `o3-deep-research` ($10/$40 per MTok, 200K ctx, MCP connectors), led HLE at launch.
 - [Gemini Deep Research][gemini-deep-research] — Gemini 3 Pro long-horizon agent via the Interactions API (`deep-research-pro-preview-12-2025`); 46.4% HLE, 66.1% DeepSearchQA, background execution + remote MCP.
 - [AutoScientists (mims-harvard)][autoscientists] — decentralized team of AI agents for long-running computational-science experiments, self-organizing around promising hypotheses; **packaged as Claude Code subagents** coordinating via a local ClawInstitute server (no central planner). BioML-Bench 74.4% mean leaderboard percentile (629★, Python) — the most direct CC-harness tie-in here.
-- [local-deep-research (LearningCircuit)][local-deep-research] — LLM-agnostic deep-research assistant: local (Ollama/LM Studio/llama.cpp) + cloud (Claude, OpenAI, Gemini, OpenRouter), LangGraph agent strategies, 20+ search sources (arXiv/PubMed/SearXNG/…), cited reports; 95.7% SimpleQA. MIT, 8.5k★, v1.7.0 (2026-06) — a close OSS parallel to CC's `/deep-research`.
+- [local-deep-research (LearningCircuit)][local-deep-research] — LLM-agnostic deep-research assistant: local (Ollama/LM Studio/llama.cpp) + cloud (Claude, OpenAI, Gemini, OpenRouter), LangGraph agent strategies, 20+ search sources (arXiv/PubMed/SearXNG/…), cited reports; 95.7% SimpleQA. MIT, 8.5k★, v1.7.0 (2026-06) — a close OSS parallel to CC's [`/deep-research`](../cc-native/agents-skills/CC-dynamic-workflows-analysis.md#bundled-workflow-deep-research).
 - [local-deep-researcher (langchain-ai)][local-deep-researcher] — **distinct from the above** despite the near-identical name: LangChain's minimal LangGraph *reference* implementation of the search→summarize→reflect loop (Ollama/LMStudio, local-only by default) — the canonical starting pattern, not a full assistant. MIT, ~9.2k★.
 - [dataroom (hanxiao / Jina)][dataroom] — self-hosted research *harness*: a local LLM (Qwen3.6 on a single GPU) runs the mechanical search/read/rerank via Jina CLI tools and emits a structured "dataroom" knowledge package for a frontier model to synthesize — the "cheap local gathering, expensive frontier reasoning" split. Pi-based (see [pi-analysis.md](../non-cc/pi-analysis.md)); ~168★, new.
 

--- a/docs/cc-community/CC-vlm-screen-sharing-landscape.md
+++ b/docs/cc-community/CC-vlm-screen-sharing-landscape.md
@@ -5,8 +5,8 @@ category: landscape
 status: research
 platform_scope: [claude-code]
 created: 2026-04-11
-updated: 2026-06-22
-validated_links: 2026-06-22
+updated: 2026-06-23
+validated_links: 2026-06-23
 ---
 
 **Status**: Assess
@@ -132,7 +132,7 @@ Using a router is orthogonal to the VLM landscape above — a Tier 2 workflow co
 ## Observed Implementations
 
 - [qte77/cc-voice-plugin-prototype][cc-voice] — plugin integration demonstrating a Tier 2 pipeline (local VLM → text) for a voice-driven CC workflow. See the repo's own docs and ADRs for the specific model / runtime / resize choices adopted there.
-- [StarTrail-org/PixelRAG][pixelrag] — **pixel-native RAG**: renders pages/PDFs to image tiles and retrieves by visual similarity with a fine-tuned [Qwen3-VL][qwen3-vl]-Embedding model, skipping text parsing entirely. Ships a Claude Code **`pixelbrowse`** plugin (`claude plugin install pixelbrowse@pixelrag-plugins`) — a skill calling `pixelshot` (Playwright/CDP) via a `/screenshot <url>` command; no MCP server or backend. A Tier 1 (CC-native plugin) visual-retrieval pattern, distinct from the Tier 2 local-VLM→text prototype above. ~3.3k★.
+- [StarTrail-org/PixelRAG][pixelrag] — **pixel-native RAG**: renders pages/PDFs to image tiles and retrieves by visual similarity with a fine-tuned [Qwen3-VL][qwen3-vl]-Embedding model, skipping text parsing entirely. Ships a Claude Code **`pixelbrowse`** plugin (`claude plugin install pixelbrowse@pixelrag-plugins`) — a skill calling `pixelshot` (Playwright/CDP) via a `/screenshot <url>` command; no MCP server or backend. A Tier 1 (CC-native plugin) visual-retrieval pattern, distinct from the Tier 2 local-VLM→text prototype above. ~4.2k★ (v0.3.0, 2026-06-23).
 
 ## Sources
 

--- a/docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md
+++ b/docs/cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md
@@ -5,8 +5,8 @@ purpose: Taxonomy of reusable harness-level patterns extracted from the Claude C
 category: analysis
 status: research
 created: 2026-04-06
-updated: 2026-06-22
-validated_links: 2026-06-22
+updated: 2026-06-23
+validated_links: 2026-06-23
 ---
 
 **Status**: Research (informational)
@@ -122,7 +122,7 @@ Pattern taxonomist by trade: Kubernetes patterns -> Camel patterns -> Prompt pat
 - [Kubernetes Patterns (O'Reilly)](https://k8spatterns.com/)
 - [Prompt Patterns catalog](https://www.promptpatterns.dev/)
 - [The Generative Programmer Substack](https://generativeprogrammer.com/)
-- ["Dive into Claude Code: The Design Space of Today's and Future AI Agent Systems" (arXiv 2604.14228)](https://arxiv.org/abs/2604.14228) — academic design-space analysis of CC's source (Liu et al., 2026)
+- ["Dive into Claude Code: The Design Space of Today's and Future AI Agent Systems" (arXiv 2604.14228)](https://arxiv.org/abs/2604.14228) — academic design-space analysis of CC's source (Liu et al., 2026); companion code: [VILA-Lab/Dive-into-Claude-Code](https://github.com/VILA-Lab/Dive-into-Claude-Code)
 
 ## Security-Domain Application: Defending Code Reference Harness
 

--- a/docs/cc-native/agents-skills/CC-ralph-enhancement-research.md
+++ b/docs/cc-native/agents-skills/CC-ralph-enhancement-research.md
@@ -3,8 +3,8 @@ title: Ralph Loop Enhancement Research
 source: ralph/scripts/ralph.sh, ralph/README.md, external Ralph pattern research (ralph/README.md is project-specific; see external references below for the general pattern)
 purpose: Identify actionable enhancements to autonomous headless CC development loops (Ralph pattern) based on gap analysis and external pattern research.
 created: 2026-03-07
-updated: 2026-06-19
-validated_links: 2026-06-19
+updated: 2026-06-23
+validated_links: 2026-06-23
 ---
 
 **Status**: Research (informational — feeds into iteration planning)
@@ -139,6 +139,14 @@ Community-published Ralph loop as a CC Skill. Uses `.claude/ralph-loop.local.md`
 
 **Relevance**: Validates that the Ralph loop can be packaged as a CC Skill or Plugin.
 
+### SantanderAI/ralph — Multi-CLI Loop Harness
+
+**Source**: Banco Santander AI Lab ([SantanderAI/ralph][santander-ralph], [ralph-vault-skill][santander-vault])
+
+A dependency-free, production-minded Ralph loop that drives **four** coding CLIs — Claude Code, Codex, Gemini CLI, Devin — with a fresh session per iteration and all continuity living in the workspace. Apache-2.0, v0.1.0 (2026-06-17), ~57★. Notable beyond the bash baseline: live `.ralph/.env` reload before each iteration; automatic agent rotation on token exhaustion (codex→claude→gemini→devin); systemd-enforced hard RAM caps (8 GB default, kernel OOM-kill); project-level **distributed skills** that travel with the repo (`juez` for task review, `maestro` for skill curation); a `stop.md` signal file for graceful shutdown; automatic log rotation. The companion [`ralph-vault-skill`][santander-vault] (~49★) generates progressive-disclosure knowledge vaults as the planning artifact a Ralph loop consumes.
+
+**Relevance**: A maintained multi-CLI harness whose agent-rotation and distributed-skills design extend the single-CLI bash baseline; the vault skill complements the LobeHub skill-packaging above.
+
 ## Actionable Enhancements
 
 ### Tier 1 — Fix Now (bugs, 15 min each)
@@ -171,6 +179,8 @@ Community-published Ralph loop as a CC Skill. Uses `.claude/ralph-loop.local.md`
 - [Ralph Wiggum plugin][ralph-official] — Official Anthropic plugin
 - [LinearB podcast][linearb] — Huntley on context rot and loop discipline
 - [Shipyard Ralph guide][shipyard] — Ralph loop pattern explanation
+- [SantanderAI/ralph][santander-ralph] — Banco Santander AI Lab multi-CLI Ralph harness (Apache-2.0, v0.1.0)
+- [ralph-vault-skill][santander-vault] — knowledge-vault generator companion to the loop
 
 [ralph-history-post]: https://www.hlyr.dev/blog/brief-history-of-ralph
 [effective-harnesses]: https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents
@@ -183,3 +193,5 @@ Community-published Ralph loop as a CC Skill. Uses `.claude/ralph-loop.local.md`
 [ralph-official]: https://github.com/anthropics/claude-plugins-official/tree/main/plugins/ralph-loop
 [linearb]: https://linearb.io/dev-interrupted/podcast/inventing-the-ralph-wiggum-loop
 [shipyard]: https://shipyard.build/blog/claude-code-ralph-loop/
+[santander-ralph]: https://github.com/SantanderAI/ralph
+[santander-vault]: https://github.com/SantanderAI/ralph-vault-skill

--- a/docs/non-cc/agent-frameworks-infrastructure-landscape.md
+++ b/docs/non-cc/agent-frameworks-infrastructure-landscape.md
@@ -4,8 +4,8 @@ purpose: Catalog of multi-agent orchestration frameworks, LLM-orchestration/rout
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-22
-validated_links: 2026-06-22
+updated: 2026-06-23
+validated_links: 2026-06-23
 ---
 
 **Status**: Research (informational)
@@ -17,7 +17,7 @@ Catalog of agent frameworks and supporting infrastructure beyond Claude Code. Re
 - [LangGraph](https://github.com/langchain-ai/langgraph) — graph-based stateful orchestration with checkpointing and conditional routing (MIT); the base for many harnesses below.
 - [CrewAI](https://github.com/crewAIInc/crewAI) — role-based crews with sequential/hierarchical/consensus execution (MIT).
 - [AutoGen / AG2](https://github.com/ag2ai/ag2) — conversational multi-agent framework with group chat and code execution (Apache-2.0).
-- [PydanticAI](https://github.com/pydantic/pydantic-ai) — type-safe agents on Pydantic v2 with durable execution + MCP/A2A; the framework this repo's evaluation work builds on.
+- [PydanticAI](https://github.com/pydantic/pydantic-ai) — type-safe agents on Pydantic v2 with durable execution + MCP/A2A; the framework this repo's evaluation work builds on. Its [capabilities system][pai-caps] (Jun 2026) bundles instructions + tools + model settings into composable units that support **on-demand / deferred loading** (`defer_loading=True`) — a capability's context is injected only when the agent requests it, trimming per-run tokens (PydanticAI's progressive-disclosure / "skills" answer); capability-scoped hooks fire only on load. Companion managed services: the Pydantic AI Gateway (routing) and [Logfire](../cc-community/CC-agent-observability-methods-analysis.md) observability.
 - [LlamaIndex Agents](https://github.com/run-llama/llama_index) — RAG-optimized agents over 100+ data sources.
 - [Letta](https://github.com/letta-ai/letta) — stateful agents with hierarchical self-editing memory, by the [MemGPT](https://arxiv.org/abs/2310.08560) authors (Apache-2.0).
 - [Agno](https://github.com/agno-agi/agno) — high-performance multi-agent runtime with built-in memory/session, FastAPI app, strong MCP support.
@@ -176,3 +176,4 @@ Validation is the post-generation sibling of retrieval (§7): enforcing that age
 
 [12fa-blog]: https://www.hlyr.dev/blog/12-factor-agents
 [12fa-gh]: https://github.com/humanlayer/12-factor-agents
+[pai-caps]: https://pydantic.dev/articles/pydantic-ai-capabilities

--- a/docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md
+++ b/docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md
@@ -96,6 +96,7 @@ qte77's sibling project [open-agentic-coding-harness][oach] implements the whole
 - [agent-frameworks-infrastructure-landscape.md][frameworks] — orchestration frameworks, RAG, §8 output validation
 - [agentic-sdlc-patterns.md][sdlc-patterns] — the ADLC this stack instantiates
 - [CC-ralph-enhancement-research.md][ralph] — the Ralph loop in this repo's tooling
+- [Startup CTO Handbook → qte77 mapping][cto-map] — the traditional human-team engineering-leadership baseline these agentic disciplines diverge from
 
 ## Sources
 
@@ -113,6 +114,7 @@ qte77's sibling project [open-agentic-coding-harness][oach] implements the whole
 | [GitHub Spec-Kit][spec-kit] · [OpenSpec][openspec] · [BMAD-METHOD][bmad] · [Kiro specs][kiro] | SDD frameworks |
 | [qte77/open-agentic-coding-harness][oach] | Reference implementation (sibling repo) |
 | Tobi Lütke / Karpathy (X, Jun 2025); Dave Farley (davefarley.net / courses.cd.training); Geoffrey Huntley Ralph loop (2025) | Attributions cited in prose (no stable/linkable URL) |
+| [Startup CTO Handbook (Goldberg)][cto-handbook] · [qte77 mapping][cto-map] | Traditional engineering-leadership baseline — contrast to the agentic disciplines |
 
 [anthropic-ce]: https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents
 [anthropic-bea]: https://www.anthropic.com/research/building-effective-agents
@@ -120,6 +122,8 @@ qte77's sibling project [open-agentic-coding-harness][oach] implements the whole
 [alphacodium]: https://arxiv.org/abs/2401.08500
 [react]: https://arxiv.org/abs/2210.11610
 [walkinglabs]: https://github.com/walkinglabs/learn-harness-engineering
+[cto-handbook]: https://github.com/ZachGoldberg/Startup-CTO-Handbook
+[cto-map]: https://github.com/qte77/qte77/blob/main/docs/cto-handbook-mapping.md
 [bdd]: https://dannorth.net/blog/introducing-bdd/
 [husain-evals]: https://hamel.dev/blog/posts/evals/
 [fowler-sdd]: https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html


### PR DESCRIPTION
## What

Two topics (one commit each):

### Added requested sources
- **agent-frameworks landscape (§1)** — expanded the PydanticAI entry with the new
  on-demand / **deferred capabilities** system (`defer_loading=True`), capability
  hooks, and the Gateway/Logfire companions (first-party [article](https://pydantic.dev/articles/pydantic-ai-capabilities)).
- **CC-ralph-enhancement-research** — added `SantanderAI/ralph` (multi-CLI Ralph
  loop: Claude Code / Codex / Gemini / Devin) + `ralph-vault-skill` companion.
- **CC-agentic-harness-patterns** — cited the companion code repo
  [VILA-Lab/Dive-into-Claude-Code](https://github.com/VILA-Lab/Dive-into-Claude-Code)
  for arXiv 2604.14228 (already analyzed in the doc).
- **CC-vlm-screen-sharing** — refreshed the PixelRAG entry (~3.3k★ → ~4.2k★, v0.3.0).
- `changelog.d/` fragment.

### Cross-ref + baseline
- **CC-research-agents-landscape** — turned the bare `/deep-research` mention into
  a real cross-ref to the bundled-workflow section (reuses the existing anchor).
- **agentic-engineering-disciplines** — cited the *Startup CTO Handbook* as the
  traditional engineering-leadership baseline the agentic disciplines diverge from,
  linking the qte77 estate mapping note ([qte77#133](https://github.com/qte77/qte77/pull/133), already merged).

## Notes

- All `updated:` / `validated_links:` bumped to 2026-06-23.
- Out-of-scope sources from the same batch were **not** added: the Baidu Unlimited-OCR
  paper (cs.CV) was routed to polyfetch-scrape ([#63](https://github.com/qte77/polyfetch-scrape/issues/63)); `hanxiao/dataroom` was already documented.
- markdownlint + lychee clean locally.

Generated with Claude <noreply@anthropic.com>
