### PR TITLE
docs: link repositioning marker to #326; fix #325 date off-by-one

### DIFF
--- a/changelog.d/20260626_marker-326-datefix.md
+++ b/changelog.d/20260626_marker-326-datefix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Landscape docs: corrected `updated`/`validated_links` to 2026-06-26 (stamped a day early in #325) and cross-linked the AI PR-review "to be repositioned" marker to #326.

--- a/docs/cc-community/CC-code-tooling-landscape.md
+++ b/docs/cc-community/CC-code-tooling-landscape.md
@@ -4,8 +4,8 @@ purpose: Code-understanding tools that integrate with Claude Code — knowledge 
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-25
-validated_links: 2026-06-25
+updated: 2026-06-26
+validated_links: 2026-06-26
 ---
 
 **Status**: Research (informational)
@@ -125,7 +125,7 @@ Cross-ref: [CC-official-plugins-landscape.md](../cc-native/plugins-ecosystem/CC-
 
 ## AI PR-review agents (SaaS)
 
-> **⚠ Placement — flagged for repositioning.** These are standalone SaaS code-review *products*, not community Claude Code integrations, so they do not fit this `cc-community` doc; queued for a move to a non-CC home (e.g. a `docs/non-cc/` code-review-products landscape). Retained here for now alongside the Qodo entry. Classification criteria: [CONTRIBUTING.md](../../CONTRIBUTING.md#classification-cc-community-vs-non-cc).
+> **⚠ Placement — flagged for repositioning.** These are standalone SaaS code-review *products*, not community Claude Code integrations, so they do not fit this `cc-community` doc; queued for a move to a non-CC home (e.g. a `docs/non-cc/` code-review-products landscape) — tracked in [#326](https://github.com/qte77/ai-agents-research/issues/326). Retained here for now alongside the Qodo entry. Classification criteria: [CONTRIBUTING.md](../../CONTRIBUTING.md#classification-cc-community-vs-non-cc).
 
 Adjacent to Qodo and Code-Review-Graph: hosted bots that review pull requests with whole-codebase context. Unlike the AST/graph tools above (which you run locally and an agent queries), these are GitHub/GitLab-app SaaS that comment on PRs directly; most also expose IDE or agent hooks.
 

--- a/docs/cc-community/CC-community-tooling-landscape.md
+++ b/docs/cc-community/CC-community-tooling-landscape.md
@@ -5,8 +5,8 @@ category: landscape
 status: research
 platform_scope: [claude-code, cursor, codex, gemini-cli, opencode, windsurf, zed, antigravity]
 created: 2026-03-13
-updated: 2026-06-25
-validated_links: 2026-06-25
+updated: 2026-06-26
+validated_links: 2026-06-26
 ---
 
 **Status**: Research (informational)

--- a/docs/cc-community/CC-memory-tooling-landscape.md
+++ b/docs/cc-community/CC-memory-tooling-landscape.md
@@ -4,8 +4,8 @@ purpose: Persistent cross-session memory tools that integrate with Claude Code â
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-25
-validated_links: 2026-06-25
+updated: 2026-06-26
+validated_links: 2026-06-26
 ---
 
 **Status**: Research (informational)

--- a/docs/cc-community/CC-vlm-screen-sharing-landscape.md
+++ b/docs/cc-community/CC-vlm-screen-sharing-landscape.md
@@ -5,8 +5,8 @@ category: landscape
 status: research
 platform_scope: [claude-code]
 created: 2026-04-11
-updated: 2026-06-25
-validated_links: 2026-06-25
+updated: 2026-06-26
+validated_links: 2026-06-26
 ---
 
 **Status**: Assess

--- a/docs/non-cc/agent-frameworks-infrastructure-landscape.md
+++ b/docs/non-cc/agent-frameworks-infrastructure-landscape.md
@@ -4,8 +4,8 @@ purpose: Catalog of multi-agent orchestration frameworks, LLM-orchestration/rout
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-25
-validated_links: 2026-06-25
+updated: 2026-06-26
+validated_links: 2026-06-26
 ---
 
 **Status**: Research (informational)

--- a/docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md
+++ b/docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md
@@ -3,8 +3,8 @@ title: Agentic Engineering Disciplines & Methodologies Landscape
 purpose: Credo-framed synthesis of the "-engineering" disciplines (prompt → spec) and "-driven development" methodologies (TDD → EDD → SDD) that make an agentic coding fleet compound instead of drift — with first-party coiners, a five-layer stack, and qte77's open-agentic-coding-harness as the reference implementation.
 category: landscape
 created: 2026-06-23
-updated: 2026-06-25
-validated_links: 2026-06-25
+updated: 2026-06-26
+validated_links: 2026-06-26
 ---
 
 **Status**: Assess


### PR DESCRIPTION
Follow-up to #325.

- Cross-links the AI PR-review "to be repositioned" marker in `CC-code-tooling-landscape.md` to #326 (the tracking issue for the actual move).
- Corrects `updated` / `validated_links` from `2026-06-25` → `2026-06-26` on the six landscape docs touched in #325 (they were stamped a day early).

Docs-only; `make lint` clean (lychee 0 errors, markdownlint 0 errors). #326 stays open for the actual repositioning.

Generated with Claude <noreply@anthropic.com>
