### PR TITLE
docs: add Scrape.do to scraping SSOT; repoint OCR cross-refs to SSOT

### DIFF
--- a/changelog.d/20260626_scrapedo-ssot-xref.md
+++ b/changelog.d/20260626_scrapedo-ssot-xref.md
@@ -1,0 +1,7 @@
+### Added
+
+- `docs/non-cc/web-scraping-extraction-landscape.md`: Scrape.do (managed scraping platform — 110M+ proxies, HTML/JSON/XML/MD output, low-cost).
+
+### Fixed
+
+- `docs/cc-community/CC-vlm-screen-sharing-landscape.md`: repoint the Unlimited-OCR / MinerU document-extraction cross-refs from `polyfetch-scrape` to the in-repo scraping/extraction single-source-of-truth (`web-scraping-extraction-landscape.md`).

--- a/docs/cc-community/CC-vlm-screen-sharing-landscape.md
+++ b/docs/cc-community/CC-vlm-screen-sharing-landscape.md
@@ -34,7 +34,7 @@ The following models are the main candidates for local-VLM workflows on develope
 
 Licenses differ — LFM2-VL-3B in particular uses Liquid AI's own "LFM Open License v1.0", not Apache-2.0. Verify license terms on the model card before production use.
 
-**Long-document OCR / document parsing (edge of scope).** [baidu/Unlimited-OCR][unlimited-ocr] (MIT) targets *one-shot long-horizon parsing* — multi-page documents and PDFs in a single inference pass (32K-token context; `gundam`/`base` modes; HF Transformers + SGLang; OpenAI-compatible streaming), building on DeepSeek-OCR. [opendatalab/MinerU][mineru] (MinerU Open Source License, Apache-2.0-based) is the broader sibling — PDFs/DOCX/PPTX/XLSX/images → LLM-ready Markdown/JSON *for agentic workflows* (dual VLM + OCR engines, 109 languages, formulas→LaTeX, tables→HTML), shipping an MCP server usable from Claude Desktop/Cursor plus LangChain/LlamaIndex integrations. Both are document-parsing tools rather than screen-context VLMs, so they sit at the edge of this doc's scope — noted here for the visual-OCR-subagent routing pattern below. Deeper OCR / document-extraction tooling is deferred to the `polyfetch-scrape` repo's `docs/scraping-landscape.md` per cross-repo routing; for adjacent in-repo coverage see [web-scraping-extraction-landscape.md](../non-cc/web-scraping-extraction-landscape.md).
+**Long-document OCR / document parsing (edge of scope).** [baidu/Unlimited-OCR][unlimited-ocr] (MIT) targets *one-shot long-horizon parsing* — multi-page documents and PDFs in a single inference pass (32K-token context; `gundam`/`base` modes; HF Transformers + SGLang; OpenAI-compatible streaming), building on DeepSeek-OCR. [opendatalab/MinerU][mineru] (MinerU Open Source License, Apache-2.0-based) is the broader sibling — PDFs/DOCX/PPTX/XLSX/images → LLM-ready Markdown/JSON *for agentic workflows* (dual VLM + OCR engines, 109 languages, formulas→LaTeX, tables→HTML), shipping an MCP server usable from Claude Desktop/Cursor plus LangChain/LlamaIndex integrations. Both are document-parsing tools rather than screen-context VLMs, so they sit at the edge of this doc's scope — noted here for the visual-OCR-subagent routing pattern below. Deeper scraping / document-extraction tooling lives in this repo's single-source-of-truth catalog, [web-scraping-extraction-landscape.md](../non-cc/web-scraping-extraction-landscape.md).
 
 ## Local VLM Runtimes
 
@@ -142,8 +142,8 @@ Using a router is orthogonal to the VLM landscape above — a Tier 2 workflow co
 | ------ | ------- |
 | [Anthropic vision documentation][anthropic-vision] | Token formula, resize thresholds, format support, recommended sizes, cost tables |
 | Model cards listed in the Small VLM Landscape table above | Parameter counts, licenses, release dates, benchmark scores |
-| [baidu/Unlimited-OCR][unlimited-ocr] | Long-document OCR VLM — one-shot multi-page/PDF parsing (MIT); deferred to polyfetch-scrape for depth |
-| [opendatalab/MinerU][mineru] | Document (PDF/Office/image)→Markdown/JSON extraction for agentic workflows; MCP server (Claude Desktop/Cursor); deferred to polyfetch-scrape for depth |
+| [baidu/Unlimited-OCR][unlimited-ocr] | Long-document OCR VLM — one-shot multi-page/PDF parsing (MIT) |
+| [opendatalab/MinerU][mineru] | Document (PDF/Office/image)→Markdown/JSON extraction for agentic workflows; MCP server (Claude Desktop/Cursor) |
 | [llama.cpp][llamacpp], [llama-cpp-python][llamacpp-py], [Ollama][ollama], [MLX][mlx] | Runtime capability and VLM support |
 | [python-mss][python-mss], [Peekaboo][peekaboo] | Screen capture primitives |
 | [anthropics/claude-code#22903][cc-22903], [anthropics/claude-code#38698][cc-38698] | First-party feature-request status |

--- a/docs/non-cc/web-scraping-extraction-landscape.md
+++ b/docs/non-cc/web-scraping-extraction-landscape.md
@@ -3,8 +3,8 @@ title: Web Scraping and Data Extraction — Tool Landscape
 source: https://github.com/qte77/polyfetch-scrape/blob/main/docs/scraping-landscape.md
 purpose: Single-source-of-truth catalog of scraping, crawling, and extraction tooling for agent/RAG pipelines across the qte77 ecosystem
 created: 2026-04-23
-updated: 2026-06-20
-validated_links: 2026-04-23
+updated: 2026-06-26
+validated_links: 2026-06-26
 ---
 
 **Status**: Reference (informational catalog)
@@ -123,6 +123,7 @@ Cross-ref: [searxng-analysis.md](searxng-analysis.md) — deep-dive on self-host
 | [Zyte](https://www.zyte.com/) | Free trial ($200) | No | AI-powered unblock + extraction API |
 | [ScraperAPI](https://www.scraperapi.com/) | Free tier; paid | No | Proxy-rotation + JS rendering API at scale |
 | [Decodo](https://decodo.com/) | Free tier; from $0.09/1K | No | 125M+ IP network; formerly Smartproxy |
+| [Scrape.do](https://scrape.do/) | ~$0.60/1K req | No | 110M+ proxies; HTML/JSON/XML/MD output, JS render; ~98.6% success at low cost |
 
 ## Document-Specific Extraction
 


### PR DESCRIPTION
Applies the confirmed SSOT model: adds Scrape.do to the scraping SSOT (`web-scraping-extraction-landscape.md`, Managed Scraping Platforms) and repoints the MinerU / Unlimited-OCR "depth" cross-refs from polyfetch-scrape to that in-repo SSOT. Docs-only; `make lint` clean.

Generated with Claude <noreply@anthropic.com>