### PR TITLE
docs: move SaaS PR-review products to a non-CC landscape (#326)

### DIFF
--- a/changelog.d/20260627_move-code-review-products.md
+++ b/changelog.d/20260627_move-code-review-products.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `docs/cc-community/CC-code-tooling-landscape.md` → `docs/non-cc/code-review-products-landscape.md`: moved the standalone SaaS PR-review roundup (CodeRabbit, Greptile, Ellipsis, Sourcery, Qodo Merge/PR-Agent, Graphite Diamond, Cursor Bugbot, Cubic, Bito, Korbit) to a non-CC landscape — they are multi-platform products, not CC integrations. Qodo (`open-aware` MCP + cross-repo review) and Code-Review-Graph stay in the cc-community doc. Closes #326.

--- a/docs/cc-community/CC-code-tooling-landscape.md
+++ b/docs/cc-community/CC-code-tooling-landscape.md
@@ -4,8 +4,8 @@ purpose: Code-understanding tools that integrate with Claude Code — knowledge 
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-26
-validated_links: 2026-06-26
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Research (informational)
@@ -120,27 +120,6 @@ Code-Review-Graph (above) computes structural blast radius **within one repo**; 
 **Risks**: open-aware's free tier indexes only pre-indexed *public* repos — private-repo coverage and cross-repo review are paid/enterprise. Star/adoption figures not independently verified here.
 
 Cross-ref: [CC-official-plugins-landscape.md](../cc-native/plugins-ecosystem/CC-official-plugins-landscape.md) — the first-party `/code-review` plugin
-
----
-
-## AI PR-review agents (SaaS)
-
-> **⚠ Placement — flagged for repositioning.** These are standalone SaaS code-review *products*, not community Claude Code integrations, so they do not fit this `cc-community` doc; queued for a move to a non-CC home (e.g. a `docs/non-cc/` code-review-products landscape) — tracked in [#326](https://github.com/qte77/ai-agents-research/issues/326). Retained here for now alongside the Qodo entry. Classification criteria: [CONTRIBUTING.md](../../CONTRIBUTING.md#classification-cc-community-vs-non-cc).
-
-Adjacent to Qodo and Code-Review-Graph: hosted bots that review pull requests with whole-codebase context. Unlike the AST/graph tools above (which you run locally and an agent queries), these are GitHub/GitLab-app SaaS that comment on PRs directly; most also expose IDE or agent hooks.
-
-- [CodeRabbit](https://www.coderabbit.ai/) — GitHub/GitLab/Azure/Bitbucket app + IDE (VS Code/Cursor/Windsurf) + CLI; bills itself "the most installed AI app on GitHub" (SaaS).
-- [Greptile](https://www.greptile.com/) — a swarm of agents builds a codebase graph index, then reviews PRs in parallel; GitHub/GitLab, API, **MCP**, and a Claude Code plugin; SaaS or self-hosted in AWS.
-- [Ellipsis](https://www.ellipsis.dev/) — GitHub-app code review plus automated bug fixes, Q&A, and changelogs (SaaS; free for public repos).
-- [Sourcery](https://sourcery.ai/) — review focused on security and AI-generated-code defects; GitHub/GitLab, VS Code/JetBrains, fixes via coding agents (SaaS).
-- [Qodo Merge / PR-Agent](https://github.com/qodo-ai/pr-agent) — the original open-source PR reviewer (Apache-2.0) behind Qodo; `/review` `/improve` `/describe` `/ask` via CLI, GitHub Action, Docker, or webhooks; GitHub/GitLab/Bitbucket/Azure/Gitea.
-- [Graphite Diamond](https://graphite.com/) — AI reviewer bundled with Graphite's PR-stacking workflow; GitHub app, tuned for low false positives (SaaS).
-- [Cursor Bugbot](https://cursor.com/bugbot) — Cursor's PR-review agent; comments on GitHub PRs and pushes fixes into the Cursor editor or a Background Agent; usage-based billing (SaaS).
-- [Cubic](https://www.cubic.dev/) — YC-backed AI review plus whole-codebase bug scanning; GitHub app + IDE, one-click fixes, custom rules (SaaS).
-- [Bito](https://bito.ai/) — codebase-aware AI Code Review Agent for GitHub/GitLab/Bitbucket (SaaS).
-- [Korbit](https://www.korbit.ai/) — AI review across GitHub/GitLab/Bitbucket with bug explanations and auto-generated PR descriptions (SaaS).
-
-These overlap heavily; the differentiators are codebase-context depth (Greptile's graph index), OSS vs SaaS (PR-Agent is the lone Apache-2.0 option), and agent/MCP reach (Greptile, CodeRabbit, Sourcery). Structural/AST counterpart: Code-Review-Graph above; cross-repo review: Qodo above.
 
 ---
 
@@ -277,6 +256,7 @@ Rust CLI that renders a codebase into a single prompt with a source tree, Handle
 
 - [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) — full cross-tool comparison + the rest of the CC tooling landscape
 - [CC-repo-to-docs-tools-landscape.md](CC-repo-to-docs-tools-landscape.md) — repo-to-docs generators
+- [code-review-products-landscape.md](../non-cc/code-review-products-landscape.md) — standalone SaaS PR-review products (CodeRabbit, Greptile, Ellipsis, …) moved out of this doc per #326
 
 [graphify]: https://github.com/safishamsi/graphify
 [code-review-graph]: https://github.com/tirth8205/code-review-graph

--- a/docs/non-cc/README.md
+++ b/docs/non-cc/README.md
@@ -81,6 +81,7 @@ Terminal/CLI agents and agentic IDEs beyond Claude Code — the former "Planned"
 | [goclaw-analysis.md](goclaw-analysis.md) | GoClaw (multi-tenant agent gateway, Go, 7 channels) | Yes | Yes (CC BY-NC 4.0) |
 | [searxng-analysis.md](searxng-analysis.md) | SearXNG (self-hostable metasearch for agent web-search) | Yes | Yes (AGPL-3.0) |
 | [web-scraping-extraction-landscape.md](web-scraping-extraction-landscape.md) | Scraping / crawling / extraction tool catalog (SSOT; HTTP clients, browser automation, AI-native scrapers, search APIs, managed platforms, doc extraction, anti-bot) | — | Mixed |
+| [code-review-products-landscape.md](code-review-products-landscape.md) | Standalone SaaS PR-review products (CodeRabbit, Greptile, Ellipsis, Sourcery, Qodo Merge, Graphite, Cursor Bugbot, Cubic, Bito, Korbit); multi-platform, not CC-specific | — | Mixed |
 | [llm-routers-gateways-landscape.md](llm-routers-gateways-landscape.md) | LLM routers / gateways / aggregators catalog (29 tools: OpenRouter, LiteLLM, Portkey, Bifrost, Vercel/Cloudflare AI Gateway, OpenRouter Fusion) | — | Mixed |
 | [semantic-layers-data-catalog-landscape.md](semantic-layers-data-catalog-landscape.md) | Semantic-layer + data-catalog substrate for agentic data access (Cube, dbt MetricFlow, Malloy, AtScale, DataHub, OpenMetadata, Unity Catalog, Atlas, Dataplex) — MCP/SDK agent surfaces; cross-refs Genie Ontology + OKF | — | Mixed |
 

--- a/docs/non-cc/code-review-products-landscape.md
+++ b/docs/non-cc/code-review-products-landscape.md
@@ -1,0 +1,49 @@
+---
+title: AI PR-Review Products — Tool Landscape
+purpose: Catalog of standalone SaaS PR-review products (multi-platform GitHub/GitLab review bots), distinct from Claude Code-integrated review tooling.
+category: landscape
+created: 2026-06-27
+updated: 2026-06-27
+validated_links: 2026-06-27
+---
+
+**Status**: Research (informational)
+
+## What It Is
+
+Standalone **SaaS PR-review products**: hosted bots that review pull requests with
+whole-codebase context. They install as GitHub/GitLab/Bitbucket/Azure apps and
+comment on PRs directly; most also expose IDE or agent hooks. They are
+multi-platform, **not** Claude Code-specific — any CC integration is incidental,
+which is why they live here rather than in the cc-community tooling docs.
+
+For CC-*integrated* code-review tooling — Qodo's `open-aware` MCP server +
+cross-repo review, and the Code-Review-Graph AST/blast-radius MCP tool — see
+[CC-code-tooling-landscape.md](../cc-community/CC-code-tooling-landscape.md).
+
+## Products
+
+- [CodeRabbit](https://www.coderabbit.ai/) — GitHub/GitLab/Azure/Bitbucket app + IDE (VS Code/Cursor/Windsurf) + CLI; bills itself "the most installed AI app on GitHub" (SaaS).
+- [Greptile](https://www.greptile.com/) — a swarm of agents builds a codebase graph index, then reviews PRs in parallel; GitHub/GitLab, API, **MCP**, and a Claude Code plugin; SaaS or self-hosted in AWS.
+- [Ellipsis](https://www.ellipsis.dev/) — GitHub-app code review plus automated bug fixes, Q&A, and changelogs (SaaS; free for public repos).
+- [Sourcery](https://sourcery.ai/) — review focused on security and AI-generated-code defects; GitHub/GitLab, VS Code/JetBrains, fixes via coding agents (SaaS).
+- [Qodo Merge / PR-Agent](https://github.com/qodo-ai/pr-agent) — the original open-source PR reviewer (Apache-2.0) behind Qodo; `/review` `/improve` `/describe` `/ask` via CLI, GitHub Action, Docker, or webhooks; GitHub/GitLab/Bitbucket/Azure/Gitea.
+- [Graphite Diamond](https://graphite.com/) — AI reviewer bundled with Graphite's PR-stacking workflow; GitHub app, tuned for low false positives (SaaS).
+- [Cursor Bugbot](https://cursor.com/bugbot) — Cursor's PR-review agent; comments on GitHub PRs and pushes fixes into the Cursor editor or a Background Agent; usage-based billing (SaaS).
+- [Cubic](https://www.cubic.dev/) — YC-backed AI review plus whole-codebase bug scanning; GitHub app + IDE, one-click fixes, custom rules (SaaS).
+- [Bito](https://bito.ai/) — codebase-aware AI Code Review Agent for GitHub/GitLab/Bitbucket (SaaS).
+- [Korbit](https://www.korbit.ai/) — AI review across GitHub/GitLab/Bitbucket with bug explanations and auto-generated PR descriptions (SaaS).
+
+These overlap heavily; the differentiators are codebase-context depth (Greptile's graph index), OSS vs SaaS (PR-Agent is the lone Apache-2.0 option), and agent/MCP reach (Greptile, CodeRabbit, Sourcery). The structural/AST counterpart (Code-Review-Graph) and cross-repo review (Qodo) are CC-integrated tooling — see Cross-References.
+
+## Cross-References
+
+- [CC-code-tooling-landscape.md](../cc-community/CC-code-tooling-landscape.md) — CC-integrated code-review tooling: Qodo (`open-aware` MCP + cross-repo review) and Code-Review-Graph (AST blast-radius MCP)
+- [CC-official-plugins-landscape.md](../cc-native/plugins-ecosystem/CC-official-plugins-landscape.md) — the first-party `/code-review` plugin
+
+## Sources
+
+Each product links to its first-party page inline in the list above. Moved here from
+[CC-code-tooling-landscape.md](../cc-community/CC-code-tooling-landscape.md) on
+2026-06-27 (tracked in [#326](https://github.com/qte77/ai-agents-research/issues/326)),
+where the roundup was flagged as out-of-scope for a `cc-community` doc.


### PR DESCRIPTION
Executes #326. Moves the standalone SaaS PR-review roundup out of the cc-community `CC-code-tooling-landscape.md` into a new `docs/non-cc/code-review-products-landscape.md`.

**Why:** the 10 products (CodeRabbit, Greptile, Ellipsis, Sourcery, Qodo Merge/PR-Agent, Graphite Diamond, Cursor Bugbot, Cubic, Bito, Korbit) are multi-platform GitHub/GitLab review bots — their CC integration is incidental, so per the [cc-community-vs-non-cc criterion](../blob/main/CONTRIBUTING.md#classification-cc-community-vs-non-cc) they don't belong in a `cc-community` doc.

**Kept in cc-community** (genuine CC surface): **Qodo** (`open-aware` MCP + cross-repo review) and **Code-Review-Graph** (AST blast-radius MCP).

**Changes:** new non-cc landscape (intro rewritten for the new context; 10 bullets verbatim; differentiators paragraph re-pointed via cross-refs); removed the `## AI PR-review agents (SaaS)` section + its `⚠ Placement` callout; added a pointer + the non-cc README row; scriv fragment; bumped dates → 2026-06-27.

Docs-only. `make check_docs` clean; no dangling refs (`git grep` verified).

Closes #326.

Generated with Claude <noreply@anthropic.com>