### PR TITLE
docs: move agent-consumable design formats to a non-CC landscape (#329)

### DIFF
--- a/changelog.d/20260627_move-design-formats.md
+++ b/changelog.d/20260627_move-design-formats.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `docs/cc-community/CC-community-tooling-landscape.md` → `docs/non-cc/agent-design-formats-landscape.md`: moved the agent-consumable design-format cluster (awesome-design-md corpus, Google Labs DESIGN.md spec + CLI, and the Figma Dev Mode MCP / W3C token chain) to a non-CC landscape — they are multi-agent formats, not CC integrations. Refreshed stale figures (awesome-design-md 21.8K→93.8K stars; design.md license open→Apache-2.0, 22.1K stars). Claude Code's Figma surface stays cross-referenced via the first-party Figma MCP plugin. Part of #329.

--- a/docs/cc-community/CC-community-tooling-landscape.md
+++ b/docs/cc-community/CC-community-tooling-landscape.md
@@ -1,12 +1,12 @@
 ---
 title: CC Community Tooling Landscape
-purpose: Survey of community developer tools that integrate with or enhance Claude Code — context compression, meta-prompting, spec-driven development, agent frameworks, file-read deduplication, source enrichment, provider management, design systems. Memory, code-analysis, and usage-observability tools live in linked topic docs; this doc keeps the cross-tool comparison.
+purpose: Survey of community developer tools that integrate with or enhance Claude Code — context compression, meta-prompting, spec-driven development, agent frameworks, file-read deduplication, source enrichment, provider management. Memory, code-analysis, and usage-observability tools live in linked topic docs; this doc keeps the cross-tool comparison.
 category: landscape
 status: research
 platform_scope: [claude-code, cursor, codex, gemini-cli, opencode, windsurf, zed, antigravity]
 created: 2026-03-13
-updated: 2026-06-26
-validated_links: 2026-06-26
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Research (informational)
@@ -267,61 +267,6 @@ Complements the context management stack from a different angle: RTK **reduces**
 
 ---
 
-## awesome-design-md (VoltAgent)
-
-**Repo**: [VoltAgent/awesome-design-md][awesome-design-md] | **Stars**: 21,849 | **License**: MIT
-
-Curated collection of **58 DESIGN.md files** capturing design systems from popular websites in LLM-consumable Markdown. Each file includes color palettes, typography rules, component styles, layout principles, responsive behavior, and an explicit **Agent Prompt Guide** section. Format designed for Google Stitch and general-purpose coding agents.
-
-### DESIGN.md Format (9 Sections)
-
-1. Visual Theme & Atmosphere — mood, density, design philosophy
-2. Color Palette & Roles — semantic names with hex codes (40+ per file)
-3. Typography Rules — font families, 16-role hierarchy with px/weight/line-height
-4. Component Stylings — buttons (5 variants), cards, inputs, navigation
-5. Layout Principles — spacing scale (8px base), grid widths, border-radius (7 levels)
-6. Depth & Elevation — 5-level system with exact CSS shadow values
-7. Do's and Don'ts — design guardrails and anti-patterns
-8. Responsive Behavior — 5 breakpoints, collapsing strategies, touch targets (44x44px min)
-9. Agent Prompt Guide — color reference table, 4 example component prompts, 7 iteration principles
-
-### 58 Design Systems (7 Categories)
-
-AI & ML (12): Claude, Mistral AI, Replicate, xAI, ElevenLabs. Developer Tools (14): Cursor, Linear, PostHog, Sentry, Vercel. Infrastructure (6): Stripe, MongoDB, HashiCorp. Design & Productivity (10): Figma, Notion, Framer, Miro. Fintech (4): Coinbase, Revolut, Wise. Enterprise (7): Airbnb, Apple, IBM, SpaceX, Spotify. Car Brands (5): BMW, Ferrari, Tesla.
-
-### Key Differentiator
-
-A new artifact type: design systems encoded for LLM consumption rather than human developers or design tool plugins. The Agent Prompt Guide section is a novel contribution — ready-to-use component prompts with iteration instructions. Files capture publicly visible CSS values, not proprietary design tokens. 21.8K stars in 6 days (riding Google Stitch launch wave).
-
-**Who is VoltAgent**: Open-source [TypeScript AI Agent Framework](https://voltagent.dev) for enterprise multi-agent systems (tool calling, persistent memory, supervisor orchestration, 40+ integrations). The awesome-design-md repo is a community/marketing project.
-
-**Gap**: No public tooling for generating DESIGN.md from arbitrary sites — extraction appears manual/internal.
-
-Cross-ref: [CC-domain-claudemd-showcase.md](CC-domain-claudemd-showcase.md) — CLAUDE.md as domain controller, analogous pattern
-
----
-
-## DESIGN.md format spec + CLI (Google Labs)
-
-**Repo**: [google-labs-code/design.md][google-design-md] | **License**: open source (alpha)
-
-Google Labs' canonical **format specification + CLI** for the artifact awesome-design-md collects by hand: a `DESIGN.md` encodes a visual identity for coding agents as YAML front matter (machine-readable design tokens — color, typography, spacing, components) plus prose rationale (the *why* behind each decision), giving agents a persistent, structured design system instead of scattered Figma links. The `@google/design.md` CLI adds the validation/generation tooling the awesome-design-md "Gap" note flags as missing:
-
-- **Lint / validate** — broken token references, contrast violations, structural issues
-- **Diff** — compare design versions to catch regressions
-- **Export** — tokens → Tailwind, CSS, or W3C Design Token format
-- **Structured JSON output** — for programmatic agent consumption
-
-### Key Differentiator
-
-awesome-design-md is a *corpus* of 58 hand-authored DESIGN.md files; Google Labs `design.md` is the *spec + toolchain* that makes the format machine-checkable (lint/diff/export). The two are complementary — the spec defines the contract, the corpus demonstrates it. Format is **alpha**; expect changes.
-
-### Related: design source + token standard
-
-DESIGN.md sits downstream of two adjacent pieces. **Source of truth:** the [Figma Dev Mode MCP server][figma-mcp] (beta) feeds AI coding agents structured design context — components, variables, layout — straight from Figma files (and can write frames/variables back to the canvas), supported in Claude Code, Copilot/VS Code, Cursor, and Windsurf. **Token format:** the [W3C Design Tokens (DTCG) format][dtcg] (`$value`/`$type`; first stable spec Oct 2025) is the interchange standard that Amazon's [Style Dictionary][style-dictionary] (v4+) emits — the same token shape DESIGN.md's CLI exports. The chain: Figma MCP supplies live design context to the agent → DTCG/Style Dictionary standardizes the tokens → DESIGN.md packages them as agent-readable Markdown.
-
----
-
 ## Detailed Tool Landscapes
 
 Per-tool entries for three categories have moved to focused topic docs; the cross-tool comparison below still covers all of them:
@@ -329,6 +274,10 @@ Per-tool entries for three categories have moved to focused topic docs; the cros
 - [CC-memory-tooling-landscape.md](CC-memory-tooling-landscape.md) — persistent memory: ByteRover, Claude-Mem, MemPalace, MemSearch
 - [CC-code-tooling-landscape.md](CC-code-tooling-landscape.md) — code analysis: Graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP, Repomix, code2prompt
 - [CC-usage-tooling-landscape.md](CC-usage-tooling-landscape.md) — usage observability: CodeBurn, ccusage, Claude-Code-Usage-Monitor
+
+Design-systems / format tooling (awesome-design-md, Google Labs DESIGN.md spec + CLI) has moved to a non-CC home — multi-agent, not CC-specific:
+
+- [agent-design-formats-landscape.md](../non-cc/agent-design-formats-landscape.md) — agent-consumable design formats (incl. the CC-supported Figma Dev Mode MCP context)
 
 ## Comparison
 
@@ -343,7 +292,6 @@ Per-tool entries for three categories have moved to focused topic docs; the cros
 | **Claude-Mem** | Persistent memory + compression | Hooks + MCP + plugin | AI-compressed observations, progressive search | Active (45.2K stars, v6.5.0) |
 | **CC Switch** | Multi-CLI provider management | Desktop app (GUI) | Unified config across 5 AI CLIs | Active (38.9K stars, 1,376 commits) |
 | **opensrc** | Source code enrichment | CLI (npx) | Fetch npm package sources for agent context | Early (1.5K stars) |
-| **awesome-design-md** | Agent-consumable design systems | Markdown files (drop-in) | 58 DESIGN.md files for UI generation | Viral (21.8K stars in 6 days) |
 | **Graphify** | Code→knowledge graph | Hooks + slash commands + MCP + CLAUDE.md | Semantic knowledge graphs from repos | Active (16.5K stars) |
 | **MemPalace** | Persistent memory | MCP server + plugin marketplace | Verbatim palace-metaphor memory | Active (33.6K stars, v3.0.0) |
 | **MemSearch** | Persistent memory (cross-agent) | Plugin (hooks + skill, no MCP) | Markdown source-of-truth + Milvus hybrid search | Active (~2K stars, v0.4.7) |
@@ -357,7 +305,7 @@ Per-tool entries for three categories have moved to focused topic docs; the cros
 | **ccusage** | Token-usage observability (CC/Codex) | CLI + MCP server + statusline | JSONL analyzer, cache-token split, offline mode | Stable (13.4K stars, v18.0.11) |
 | **Claude-Code-Usage-Monitor** | Predictive usage monitoring | Real-time TUI | P90-based limit prediction, burn-rate analytics, plan-aware | Active (7.8K stars, v3.1.0) |
 
-All twenty-two address different layers of the agent stack — complementary, not competing. The five code-analysis tools (graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP) split along precompute-a-graph vs. live-LSP vs. on-demand-structural-search; the two repo packers (Repomix, code2prompt) are one-shot context export rather than a live server. Full per-tool entries for the memory, code-analysis, and usage-observability rows are in the topic docs linked above.
+All twenty-one address different layers of the agent stack — complementary, not competing. The five code-analysis tools (graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP) split along precompute-a-graph vs. live-LSP vs. on-demand-structural-search; the two repo packers (Repomix, code2prompt) are one-shot context export rather than a live server. Full per-tool entries for the memory, code-analysis, and usage-observability rows are in the topic docs linked above.
 
 Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-extended-context-analysis.md) — CC's built-in context compaction
 
@@ -376,10 +324,6 @@ Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-exte
 | [Claude-Mem][claude-mem] | Persistent memory compression system (45.2K stars) |
 | [CC Switch][cc-switch] | Cross-platform multi-CLI provider management (38.9K stars) |
 | [opensrc][opensrc] | npm package source fetcher for agent context (1.5K stars) |
-| [awesome-design-md][awesome-design-md] | 58 DESIGN.md files for agent-consumable UI generation (21.8K stars) |
-| [google-labs-code/design.md][google-design-md] | Canonical DESIGN.md format spec + `@google/design.md` CLI (lint/diff/export to Tailwind/CSS/W3C tokens); alpha |
-| [Figma Dev Mode MCP server][figma-mcp] | Feeds Figma design context to coding agents (Claude Code/Copilot/Cursor/Windsurf); beta |
-| [W3C Design Tokens (DTCG)][dtcg] · [Style Dictionary][style-dictionary] | Design-token interchange standard (first stable spec Oct 2025) + Amazon's token transformer (v4 DTCG support) |
 | [Graphify][graphify] | Code→knowledge graph via slash commands, hooks, MCP (16.5K stars) |
 | [MemPalace][mempalace] | Local-first AI memory with palace metaphor, 96.6% LongMemEval (33.6K stars) |
 | [MemSearch][memsearch] | Markdown + Milvus persistent memory for CC/OpenCode/Codex, hooks+skill (no MCP), hybrid vector+BM25 (~2K stars, MIT) |
@@ -397,11 +341,6 @@ Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-exte
 | [Selective Context][selective-context] | Self-information prompt pruning; arXiv:2310.06201 (423 stars, MIT; unmaintained since 2024) |
 | [semantic-router][semantic-router] | Aurelio Labs semantic routing/decision layer — skips LLM calls for recognized intents (3.6K stars, MIT) |
 
-[awesome-design-md]: https://github.com/VoltAgent/awesome-design-md
-[google-design-md]: https://github.com/google-labs-code/design.md
-[figma-mcp]: https://www.figma.com/blog/introducing-figma-mcp-server/
-[dtcg]: https://www.w3.org/community/design-tokens/
-[style-dictionary]: https://styledictionary.com/
 [graphify]: https://github.com/safishamsi/graphify
 [mempalace]: https://github.com/MemPalace/mempalace
 [memsearch]: https://github.com/zilliztech/memsearch

--- a/docs/cc-community/README.md
+++ b/docs/cc-community/README.md
@@ -8,7 +8,7 @@ Community-built skills, plugins, tooling, workflows, and patterns for Claude Cod
 |----------|----------|
 | [CC-community-skills-landscape.md](CC-community-skills-landscape.md) | Skill libraries: gstack, pm-skills, claude-code-best-practice, BHIL, claude-howto, dispatch, superpowers, agent-skills, caveman, last30days, agent-native |
 | [CC-community-plugins-landscape.md](CC-community-plugins-landscape.md) | Plugin catalogs: awesome-claude-code, awesome-claude-code-plugins |
-| [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) | Dev tooling + cross-tool comparison: RTK, GSD, everything-claude-code, Boucle, OpenHarness, CC Switch, opensrc, awesome-design-md; token-waste reduction stack |
+| [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) | Dev tooling + cross-tool comparison: RTK, GSD, everything-claude-code, Boucle, OpenHarness, CC Switch, opensrc; token-waste reduction stack |
 | [CC-memory-tooling-landscape.md](CC-memory-tooling-landscape.md) | Persistent memory: ByteRover, Claude-Mem, MemPalace, MemSearch |
 | [CC-code-tooling-landscape.md](CC-code-tooling-landscape.md) | Code analysis: Graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP, Repomix, code2prompt |
 | [CC-usage-tooling-landscape.md](CC-usage-tooling-landscape.md) | Usage observability: CodeBurn, ccusage, Claude-Code-Usage-Monitor |

--- a/docs/non-cc/README.md
+++ b/docs/non-cc/README.md
@@ -82,6 +82,7 @@ Terminal/CLI agents and agentic IDEs beyond Claude Code — the former "Planned"
 | [searxng-analysis.md](searxng-analysis.md) | SearXNG (self-hostable metasearch for agent web-search) | Yes | Yes (AGPL-3.0) |
 | [web-scraping-extraction-landscape.md](web-scraping-extraction-landscape.md) | Scraping / crawling / extraction tool catalog (SSOT; HTTP clients, browser automation, AI-native scrapers, search APIs, managed platforms, doc extraction, anti-bot) | — | Mixed |
 | [code-review-products-landscape.md](code-review-products-landscape.md) | Standalone SaaS PR-review products (CodeRabbit, Greptile, Ellipsis, Sourcery, Qodo Merge, Graphite, Cursor Bugbot, Cubic, Bito, Korbit); multi-platform, not CC-specific | — | Mixed |
+| [agent-design-formats-landscape.md](agent-design-formats-landscape.md) | Agent-consumable design formats (awesome-design-md corpus; Google Labs DESIGN.md spec + CLI; Figma/W3C token chain); multi-platform, not CC-specific | — | Mixed |
 | [llm-routers-gateways-landscape.md](llm-routers-gateways-landscape.md) | LLM routers / gateways / aggregators catalog (29 tools: OpenRouter, LiteLLM, Portkey, Bifrost, Vercel/Cloudflare AI Gateway, OpenRouter Fusion) | — | Mixed |
 | [semantic-layers-data-catalog-landscape.md](semantic-layers-data-catalog-landscape.md) | Semantic-layer + data-catalog substrate for agentic data access (Cube, dbt MetricFlow, Malloy, AtScale, DataHub, OpenMetadata, Unity Catalog, Atlas, Dataplex) — MCP/SDK agent surfaces; cross-refs Genie Ontology + OKF | — | Mixed |
 

--- a/docs/non-cc/agent-design-formats-landscape.md
+++ b/docs/non-cc/agent-design-formats-landscape.md
@@ -1,0 +1,97 @@
+---
+title: Agent-Consumable Design Formats — Tool Landscape
+purpose: Catalog of agent-consumable design-system formats and tooling (the DESIGN.md corpus + Google Labs format spec/CLI; the upstream Figma/W3C token chain) — multi-agent, not Claude Code-specific.
+category: landscape
+created: 2026-06-27
+updated: 2026-06-27
+validated_links: 2026-06-27
+---
+
+**Status**: Research (informational)
+
+## What It Is
+
+A small but coherent category: **design systems encoded for coding agents** — a
+visual identity (colors, typography, spacing, components) captured as
+LLM-consumable Markdown/tokens so any coding agent can apply it consistently.
+These are **agent-agnostic** (Google Stitch, Cursor, Copilot, Claude Code, …), not
+CC-specific, which is why they live here rather than in the cc-community tooling
+docs. Two complementary pieces — a hand-authored **corpus** (awesome-design-md) and
+a **format spec + CLI** (Google Labs `design.md`) — plus the upstream Figma → W3C
+token chain that feeds them.
+
+For Claude Code's own design surface, see the first-party
+[Figma MCP plugin](../cc-native/plugins-ecosystem/CC-official-plugins-landscape.md#figma-mcp).
+
+## awesome-design-md (VoltAgent)
+
+**Repo**: [VoltAgent/awesome-design-md][awesome-design-md] | **Stars**: 93.8K | **License**: MIT
+
+Curated collection of **58 DESIGN.md files** capturing design systems from popular websites in LLM-consumable Markdown. Each file includes color palettes, typography rules, component styles, layout principles, responsive behavior, and an explicit **Agent Prompt Guide** section. Format designed for Google Stitch and general-purpose coding agents.
+
+### DESIGN.md Format (9 Sections)
+
+1. Visual Theme & Atmosphere — mood, density, design philosophy
+2. Color Palette & Roles — semantic names with hex codes (40+ per file)
+3. Typography Rules — font families, 16-role hierarchy with px/weight/line-height
+4. Component Stylings — buttons (5 variants), cards, inputs, navigation
+5. Layout Principles — spacing scale (8px base), grid widths, border-radius (7 levels)
+6. Depth & Elevation — 5-level system with exact CSS shadow values
+7. Do's and Don'ts — design guardrails and anti-patterns
+8. Responsive Behavior — 5 breakpoints, collapsing strategies, touch targets (44x44px min)
+9. Agent Prompt Guide — color reference table, 4 example component prompts, 7 iteration principles
+
+### 58 Design Systems (7 Categories)
+
+AI & ML (12): Claude, Mistral AI, Replicate, xAI, ElevenLabs. Developer Tools (14): Cursor, Linear, PostHog, Sentry, Vercel. Infrastructure (6): Stripe, MongoDB, HashiCorp. Design & Productivity (10): Figma, Notion, Framer, Miro. Fintech (4): Coinbase, Revolut, Wise. Enterprise (7): Airbnb, Apple, IBM, SpaceX, Spotify. Car Brands (5): BMW, Ferrari, Tesla.
+
+### Key Differentiator
+
+A new artifact type: design systems encoded for LLM consumption rather than human developers or design tool plugins. The Agent Prompt Guide section is a novel contribution — ready-to-use component prompts with iteration instructions. Files capture publicly visible CSS values, not proprietary design tokens. 93.8K stars (21.8K in its first 6 days, riding the Google Stitch launch wave).
+
+**Who is VoltAgent**: Open-source [TypeScript AI Agent Framework](https://voltagent.dev) for enterprise multi-agent systems (tool calling, persistent memory, supervisor orchestration, 40+ integrations). The awesome-design-md repo is a community/marketing project.
+
+**Gap**: No public tooling for generating DESIGN.md from arbitrary sites — extraction appears manual/internal.
+
+Cross-ref: [CC-domain-claudemd-showcase.md](../cc-community/CC-domain-claudemd-showcase.md) — CLAUDE.md as domain controller, analogous pattern
+
+## DESIGN.md format spec + CLI (Google Labs)
+
+**Repo**: [google-labs-code/design.md][google-design-md] | **Stars**: 22.1K | **License**: Apache-2.0 (alpha)
+
+Google Labs' canonical **format specification + CLI** for the artifact awesome-design-md collects by hand: a `DESIGN.md` encodes a visual identity for coding agents as YAML front matter (machine-readable design tokens — color, typography, spacing, components) plus prose rationale (the *why* behind each decision), giving agents a persistent, structured design system instead of scattered Figma links. The `@google/design.md` CLI adds the validation/generation tooling the awesome-design-md "Gap" note flags as missing:
+
+- **Lint / validate** — broken token references, contrast violations, structural issues
+- **Diff** — compare design versions to catch regressions
+- **Export** — tokens → Tailwind, CSS, or W3C Design Token format
+- **Structured JSON output** — for programmatic agent consumption
+
+### Key Differentiator
+
+awesome-design-md is a *corpus* of 58 hand-authored DESIGN.md files; Google Labs `design.md` is the *spec + toolchain* that makes the format machine-checkable (lint/diff/export). The two are complementary — the spec defines the contract, the corpus demonstrates it. Format is **alpha**; expect changes.
+
+### Related: design source + token standard
+
+DESIGN.md sits downstream of two adjacent pieces. **Source of truth:** the [Figma Dev Mode MCP server][figma-mcp] (beta) feeds AI coding agents structured design context — components, variables, layout — straight from Figma files (and can write frames/variables back to the canvas), supported in Claude Code, Copilot/VS Code, Cursor, and Windsurf. **Token format:** the [W3C Design Tokens (DTCG) format][dtcg] (`$value`/`$type`; first stable spec Oct 2025) is the interchange standard that Amazon's [Style Dictionary][style-dictionary] (v4+) emits — the same token shape DESIGN.md's CLI exports. The chain: Figma MCP supplies live design context to the agent → DTCG/Style Dictionary standardizes the tokens → DESIGN.md packages them as agent-readable Markdown.
+
+## Cross-References
+
+- [CC-community-tooling-landscape.md](../cc-community/CC-community-tooling-landscape.md) — the CC dev-tooling landscape this cluster moved out of
+- [CC-official-plugins-landscape.md](../cc-native/plugins-ecosystem/CC-official-plugins-landscape.md#figma-mcp) — Claude Code's first-party Figma MCP plugin (design-to-code)
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [VoltAgent/awesome-design-md][awesome-design-md] | 58 DESIGN.md files for agent-consumable UI generation (93.8K stars, MIT) |
+| [google-labs-code/design.md][google-design-md] | Canonical DESIGN.md format spec + `@google/design.md` CLI (lint/diff/export to Tailwind/CSS/W3C tokens); 22.1K stars, Apache-2.0, alpha |
+| [Figma Dev Mode MCP server][figma-mcp] | Feeds Figma design context to coding agents (Claude Code/Copilot/Cursor/Windsurf); beta |
+| [W3C Design Tokens (DTCG)][dtcg] · [Style Dictionary][style-dictionary] | Design-token interchange standard (first stable spec Oct 2025) + Amazon's token transformer (v4 DTCG support) |
+
+Moved here from [CC-community-tooling-landscape.md](../cc-community/CC-community-tooling-landscape.md) on 2026-06-27 (tracked in [#329](https://github.com/qte77/ai-agents-research/issues/329)) — agent-consumable design formats are multi-agent, not CC-specific.
+
+[awesome-design-md]: https://github.com/VoltAgent/awesome-design-md
+[google-design-md]: https://github.com/google-labs-code/design.md
+[figma-mcp]: https://www.figma.com/blog/introducing-figma-mcp-server/
+[dtcg]: https://www.w3.org/community/design-tokens/
+[style-dictionary]: https://styledictionary.com/


### PR DESCRIPTION
Part of #329 (classification-hygiene; **PR B**). Moves the design-format cluster out of cc-community `CC-community-tooling-landscape.md` into a new `docs/non-cc/agent-design-formats-landscape.md`.

**Why:** `awesome-design-md` (corpus) and Google Labs `design.md` (format spec + CLI) are **agent-agnostic** (Google Stitch, Cursor, Copilot, CC, …) — no CC-specific integration surface, so per the [criterion](../blob/main/CONTRIBUTING.md#classification-cc-community-vs-non-cc) they don't belong in a cc-community doc.

**Claude Code's design surface stays covered:** the cluster cross-refs the first-party [Figma MCP plugin](../blob/main/docs/cc-native/plugins-ecosystem/CC-official-plugins-landscape.md#figma-mcp) (already in cc-native), and cc-community keeps a pointer to the new doc.

**Changes:** new non-cc landscape (both sections moved verbatim + the Figma/DTCG/Style-Dictionary chain); removed the two sections, the comparison-table row (22→21 tools), the Sources rows, and link-defs from the source doc; updated both READMEs; scriv fragment. **Refreshed stale facts** (first-party `gh api`): awesome-design-md 21,849→**93.8K** stars; design.md `open source`→**Apache-2.0**, **22.1K** stars.

Docs-only; `make check_docs` clean (180 files); no dangling refs (`git grep` verified — only inbound ref was the cc-community README index line, updated).

Generated with Claude <noreply@anthropic.com>