### PR TITLE
docs: stamp updated/validated_links 2026-06-27 on #329-relocated docs

### DIFF
--- a/changelog.d/20260627_bump-relocated-dates.md
+++ b/changelog.d/20260627_bump-relocated-dates.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Stamped `updated`/`validated_links` → 2026-06-27 on the 9 docs relocated by #329 (the 6 MAS docs now in `sdlc-lcm/`, plus `research-agents-landscape`, `repo-to-docs-tools-landscape`, and `agent-observability-methods-analysis` in `non-cc/`) — they were edited and lychee-re-validated on the 27th.

--- a/docs/non-cc/agent-observability-methods-analysis.md
+++ b/docs/non-cc/agent-observability-methods-analysis.md
@@ -2,8 +2,8 @@
 title: "Agent Observability Methods Analysis"
 purpose: Technical analysis of 18 observability platforms and five primary tracing patterns for AI agent behavior.
 created: 2025-08-24
-updated: 2026-06-14
-validated_links: 2026-04-24
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Assess

--- a/docs/non-cc/repo-to-docs-tools-landscape.md
+++ b/docs/non-cc/repo-to-docs-tools-landscape.md
@@ -5,8 +5,8 @@ purpose: Survey of AI-powered tools that generate documentation from GitHub repo
 category: landscape
 status: research
 created: 2026-04-06
-updated: 2026-06-16
-validated_links: 2026-04-06
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Research (informational)

--- a/docs/non-cc/research-agents-landscape.md
+++ b/docs/non-cc/research-agents-landscape.md
@@ -4,8 +4,8 @@ purpose: Catalog of autonomous research agents, scientific-domain models, and li
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-23
-validated_links: 2026-06-23
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Research (informational)

--- a/docs/sdlc-lcm/agent-evaluation-metrics-landscape.md
+++ b/docs/sdlc-lcm/agent-evaluation-metrics-landscape.md
@@ -2,8 +2,8 @@
 title: "Agent Evaluation Metrics Landscape"
 purpose: Survey of agent evaluation metrics and methodologies — task completion, reasoning quality, tool use, safety.
 created: 2025-10-05
-updated: 2026-06-14
-validated_links: 2026-04-23
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Assess

--- a/docs/sdlc-lcm/ai-security-governance-analysis.md
+++ b/docs/sdlc-lcm/ai-security-governance-analysis.md
@@ -2,8 +2,8 @@
 title: "AI Security & Governance Frameworks Analysis"
 purpose: Analysis of four AI security and governance frameworks (NIST AI RMF, EU AI Act, OWASP LLM Top 10, ISO 42001) applicable to multi-agent systems.
 created: 2026-03-01
-updated: 2026-06-14
-validated_links: 2026-04-23
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Assess

--- a/docs/sdlc-lcm/evaluation-data-resources-landscape.md
+++ b/docs/sdlc-lcm/evaluation-data-resources-landscape.md
@@ -4,8 +4,8 @@ purpose: Catalog of agent/LLM evaluation frameworks, agentic benchmarks, and eva
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-14
-validated_links: 2026-03-12
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Research (informational)

--- a/docs/sdlc-lcm/mas-benchmarking-best-practices.md
+++ b/docs/sdlc-lcm/mas-benchmarking-best-practices.md
@@ -2,8 +2,8 @@
 title: "Multi-Agent Systems & Benchmarking Best Practices"
 purpose: Production best practices for multi-agent system development and benchmarking, covering infrastructure, training, and evaluation.
 created: 2026-01-13
-updated: 2026-04-23
-validated_links: 2026-04-23
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Assess

--- a/docs/sdlc-lcm/mas-design-principles.md
+++ b/docs/sdlc-lcm/mas-design-principles.md
@@ -2,8 +2,8 @@
 title: "Multi-Agent System Design Principles"
 purpose: Core design principles for multi-agent systems synthesized from 12-Factor Agents, Anthropic Effective Harnesses, and PydanticAI.
 created: 2026-02-09
-updated: 2026-06-19
-validated_links: 2026-06-19
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Adopt

--- a/docs/sdlc-lcm/mas-security-framework.md
+++ b/docs/sdlc-lcm/mas-security-framework.md
@@ -2,8 +2,8 @@
 title: "Multi-Agent System Security Framework"
 purpose: OWASP MAESTRO v1.0 threat modeling framework for multi-agent systems — 7 security layers with concrete controls.
 created: 2026-02-09
-updated: 2026-04-23
-validated_links: 2026-04-23
+updated: 2026-06-27
+validated_links: 2026-06-27
 ---
 
 **Status**: Assess


### PR DESCRIPTION
Bumps `updated` + `validated_links` → 2026-06-27 on the 9 docs relocated by #329 (the 6 MAS docs now in `sdlc-lcm/`; `research-agents-landscape`, `repo-to-docs-tools-landscape`, `agent-observability-methods-analysis` in `non-cc/`).

**Justification for the `validated_links` stamp:** these docs' links were checked by lychee on 2026-06-27 — PR #334 CI + a local `make check_links` run, both 0 errors — and this PR's CI re-runs lychee over them today. Per CONTRIBUTING's maintenance table, `validated_links` bumps when lychee re-runs on the file. (Caveat: lychee skips `lychee.toml`-excluded hosts and checks reachability, not content freshness.)

Metadata-only; `make check_docs` clean.

Generated with Claude <noreply@anthropic.com>