### PR TITLE
docs: add CC output-verification guide (#320)

### DIFF
--- a/changelog.d/20260627_output-verification-guide.md
+++ b/changelog.d/20260627_output-verification-guide.md
@@ -1,0 +1,3 @@
+### Added
+
+- `docs/cc-native/agents-skills/CC-output-verification-analysis.md`: a first-party guide to verifying Claude Code's own agentic outputs — per-mechanism matrix (workflow / team / subagent / plan / memory), hooks as the deterministic backbone (with the non-uniform `exit 2` semantics), `--json-schema` structured-output validation + the `error_max_structured_output_retries` fail signal, the CLAUDE.md-as-user-message memory gotcha, and the DIY (no first-party eval runner) pattern. Closes #320.

--- a/docs/cc-native/README.md
+++ b/docs/cc-native/README.md
@@ -6,7 +6,7 @@ Deep-dive analyses of Anthropic-native Claude Code features and internals.
 
 | Directory | Coverage | Docs |
 |-----------|----------|------|
-| [agents-skills/](agents-skills/) | Agent teams, recursive spawning, skills adoption, Ralph, dynamic workflows | 8 |
+| [agents-skills/](agents-skills/) | Agent teams, recursive spawning, skills adoption, Ralph, dynamic workflows, output verification | 9 |
 | [sessions/](sessions/) | Session lifecycle, cost analysis, keepalive, headless mode, error messages | 7 |
 | [sandboxing/](sandboxing/) | Filesystem/network sandbox, Codespaces friction, platform comparison, permission bypass | 5 |
 | [ci-remote/](ci-remote/) | GitHub Actions, cloud sessions, remote access/control, web auth, version pinning, monitoring | 8 |

--- a/docs/cc-native/agents-skills/CC-output-verification-analysis.md
+++ b/docs/cc-native/agents-skills/CC-output-verification-analysis.md
@@ -1,0 +1,111 @@
+---
+title: CC Output Verification Methods
+purpose: How to verify/validate Claude Code's own agentic outputs — across dynamic workflows, agent teams, subagents, plan mode, and memory — using hooks, structured-output schemas, and headless asserts.
+category: analysis
+created: 2026-06-27
+updated: 2026-06-27
+validated_links: 2026-06-27
+---
+
+**Status**: Adopt
+
+## What It Is
+
+The repo has evaluation *landscapes* (metrics, tools) but no guide on verifying Claude Code's **own mechanism outputs**. This doc maps each CC agentic mechanism to its verification surface. Three through-lines:
+
+- **Hooks are the deterministic backbone** — they run regardless of what the model decides.
+- **Structured output schema-validates the final result** — a programmatic pass/fail signal.
+- **There is no first-party eval runner** — verification is DIY (headless pipe + your own asserts, optionally an adversarial re-check).
+
+All mechanism facts below are first-party verified against the CC hooks / agent-teams / CLI / Agent-SDK / memory docs (2026-06-27).
+
+## Verify matrix (mechanism → surface)
+
+| Mechanism | Primary verification surface | Note |
+|---|---|---|
+| **Dynamic workflow** | Script-level adversarial-verify stage; `/deep-research` per-claim voting | The workflow script can spawn skeptic subagents per finding |
+| **Agent team** | `TaskCompleted` / `TeammateIdle` hooks (block incomplete work); a reviewer teammate | Team hooks gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` |
+| **Subagent** | Structured-output schema (`--json-schema` / SDK `outputFormat`) + `SubagentStop` hook | `SubagentStop` exit 2 keeps the subagent working |
+| **Plan** | Human approval at the plan-mode UI gate (**not** a hook) | Programmatic gating → intercept `Stop` + parse the transcript |
+| **Memory** | `/memory` audit; `PreToolUse` hook for must-always rules | `CLAUDE.md` loads as a *user message* — context, not enforced |
+
+## Hooks: the deterministic backbone
+
+Block-capable hook events feed your stderr back to the model and stop the action on **exit 2**:
+
+- **`Stop`** — fires when the main turn ends; exit 2 prevents stopping and forces another turn (the re-verify gate). A JSON `additionalContext` path can feed context back *without* framing it as an error.
+- **`SubagentStop`** — fires when a subagent finishes; exit 2 keeps it running with your feedback (verify a subagent's result before it returns).
+- **`TaskCreated` / `TaskCompleted` / `TeammateIdle`** — agent-team gates (experimental flag): exit 2 rolls back a task creation, blocks a premature "complete", or keeps an idle teammate working. *(The `team_name` payload field is deprecated as of v2.1.178 — it now carries a session-derived name.)*
+
+**Exit 2 is not uniform** — assert this precisely:
+
+| Hook class | Exit 2 |
+|---|---|
+| Blocking (`Stop`, `SubagentStop`, `PreToolUse`, `TaskCompleted`, `TeammateIdle`, `TaskCreated`) | Blocks the action + stderr → model |
+| `PostToolUse` | Does **not** block; stderr → model |
+| Info-only (`SessionStart`, `Notification`, `CwdChanged`, …) | Does **not** block; stderr → **user only** |
+| `PostToolUseFailure`, `StopFailure`, `WorktreeRemove` | Exit code + output **ignored** |
+
+Cross-ref: [CC-hooks-system-analysis.md](../configuration/CC-hooks-system-analysis.md) for the full event table; [CC-ralph-enhancement-research.md](CC-ralph-enhancement-research.md) for the Stop-hook re-verify pattern; [CC-agent-teams-orchestration.md](CC-agent-teams-orchestration.md) for the team gates.
+
+## Structured output: schema-validate the result
+
+Headless schema validation is the **`--json-schema`** flag — *not* `--output-format json` (which only serializes turn messages; the two are unrelated):
+
+```bash
+claude -p --json-schema '{"type":"object","properties":{...}}' "query"   # validated final output, print mode
+```
+
+SDK equivalents: TS `outputFormat: { type: "json_schema", schema: {...} }`; Python `output_format={"type":"json_schema","schema":{...}}`.
+
+**The programmatic fail signal** is the result-message **`subtype`**: `success` vs **`error_max_structured_output_retries`** (no schema-valid output after the retry limit). Check `msg.subtype` directly — this is your deterministic "the agent's output is invalid" assertion.
+
+Cross-ref: [CC-cli-reference.md](../configuration/CC-cli-reference.md) (`--json-schema`, print-mode only).
+
+## Plan mode
+
+The verification point is the **interactive approval gate** when Claude presents the plan (auto / accept-edits / review manually / keep planning). There is **no `ExitPlanMode` hook event** — plan approval is a TUI interaction, not a lifecycle hook. To gate plan *content* programmatically, intercept `Stop` (the planning turn's end) and parse the transcript; there is no dedicated plan-approval hook. Entry points: `/plan` prefix and `--permission-mode plan`.
+
+## Memory
+
+`CLAUDE.md` is delivered as a **user message after the system prompt** — Claude reads and tries to follow it, but "there's no guarantee of strict compliance." So:
+
+- **Must-always rules** → a **`PreToolUse` hook** (blocks the action regardless of what the model decides), *not* a CLAUDE.md line.
+- System-prompt-level injection → `--append-system-prompt` per invocation (does **not** persist — script-oriented).
+- Audit what's loaded with `/memory`.
+
+## No first-party eval runner → DIY
+
+There is **no built-in general eval runner** and no native promptfoo / DeepEval / Inspect integration (skill-creator's "run evals" is skill-specific). The documented pattern is DIY:
+
+1. Pipe `claude -p` headless output into your own assertion scripts.
+2. Use `--json-schema` (or SDK `outputFormat`) for a schema-validatable result + the `error_max_structured_output_retries` fail signal.
+3. Add an **adversarial review step** — spawn a second session to critique the first's output (per CC best practices).
+
+**Deterministic asserts and hooks beat LLM-judge** wherever the property is checkable. Report gaps via `/feedback`.
+
+## Cross-References
+
+- [CC-dynamic-workflows-analysis.md](CC-dynamic-workflows-analysis.md) — workflow-script verify stages + `/deep-research` claim voting
+- [CC-agent-teams-orchestration.md](CC-agent-teams-orchestration.md) — `TaskCompleted` / `TeammateIdle` quality gates
+- [CC-hooks-system-analysis.md](../configuration/CC-hooks-system-analysis.md) — hook events + exit-code semantics
+- [agent-evaluation-metrics-landscape.md](../../sdlc-lcm/agent-evaluation-metrics-landscape.md) · [evaluation-data-resources-landscape.md](../../sdlc-lcm/evaluation-data-resources-landscape.md) — the metrics/tooling layer this CC-mechanism guide sits above
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [CC hooks reference][cc-hooks] | Hook events; non-uniform `exit 2` semantics |
+| [CC agent teams][cc-teams] | `TaskCreated`/`TaskCompleted`/`TeammateIdle` gates; experimental flag |
+| [CC CLI reference][cc-cli] | `--json-schema` (print-mode validated output) |
+| [Agent SDK — structured outputs][cc-sdk-struct] | `outputFormat` + `error_max_structured_output_retries` subtype |
+| [CC memory][cc-memory] | CLAUDE.md as user message; `PreToolUse` for enforcement |
+| [CC best practices][cc-bp] | Adversarial-review step (DIY verification) |
+| CC mechanism facts, claude-code-guide verification, 2026-06-27 | First-party confirmation (no URL) |
+
+[cc-hooks]: https://code.claude.com/docs/en/hooks
+[cc-teams]: https://code.claude.com/docs/en/agent-teams
+[cc-cli]: https://code.claude.com/docs/en/cli-reference
+[cc-sdk-struct]: https://code.claude.com/docs/en/agent-sdk/structured-outputs
+[cc-memory]: https://code.claude.com/docs/en/memory
+[cc-bp]: https://code.claude.com/docs/en/best-practices

--- a/docs/cc-native/agents-skills/README.md
+++ b/docs/cc-native/agents-skills/README.md
@@ -12,3 +12,4 @@ CC agent teams, recursive spawning, skills system, and autonomous loop patterns.
 | [CC-cli-anything-analysis.md](CC-cli-anything-analysis.md) | CC CLI invocation patterns and capabilities |
 | [CC-agentic-harness-patterns-analysis.md](CC-agentic-harness-patterns-analysis.md) | 12 agentic harness patterns (Bilgin Ibryam): memory, orchestration, tools, automation |
 | [CC-dynamic-workflows-analysis.md](CC-dynamic-workflows-analysis.md) | Dynamic workflow orchestration tool + script API, ultracode effort, bundled /deep-research |
+| [CC-output-verification-analysis.md](CC-output-verification-analysis.md) | Verifying CC's own outputs: per-mechanism matrix, hooks backbone (Stop/SubagentStop/TaskCompleted), `--json-schema` validation, DIY headless asserts |


### PR DESCRIPTION
Closes #320. New `docs/cc-native/agents-skills/CC-output-verification-analysis.md` — the repo has eval *landscapes* but no guide on verifying CC's **own** mechanism outputs.

Covers: a per-mechanism **verify matrix** (workflow / team / subagent / plan / memory); **hooks as the deterministic backbone** (Stop / SubagentStop / TaskCompleted / TeammateIdle) with the **non-uniform `exit 2` semantics** table; **structured-output validation** (`--json-schema`, *not* `--output-format json`) + the `error_max_structured_output_retries` result-subtype fail signal; the **CLAUDE.md-as-user-message** memory gotcha (use `PreToolUse` for enforcement); and the **DIY pattern** (no first-party eval runner; headless pipe + adversarial review).

All CC mechanism facts **first-party verified** (claude-code-guide, 2026-06-27) — this corrected several would-be errors (e.g. there is no `ExitPlanMode` hook; `--json-schema` ≠ `--output-format json`). Cross-refs the hooks/teams/dynamic-workflows docs rather than duplicating them.

Docs-only; `make check_docs` + `make check_links` clean locally (0 errors).

Generated with Claude <noreply@anthropic.com>