### PR TITLE
docs: add agentic workflow-frameworks landscape (#319)

### DIFF
--- a/changelog.d/20260627_workflow-frameworks-landscape.md
+++ b/changelog.d/20260627_workflow-frameworks-landscape.md
@@ -1,0 +1,3 @@
+### Added
+
+- `docs/non-cc/workflow-frameworks-landscape.md`: agentic workflow framework landscape — Anthropic's 5 "Building Effective Agents" patterns (workflows-vs-agents), a control-flow/durability framework table (gh-verified stars), the durable-execution layer (Temporal / Inngest / Restate, with `(workflow_id, step_id)` idempotency), and an 8-item S0–S2 anti-pattern taxonomy + best-practices checklist. Cross-refs the CC Workflow tool and the agent-frameworks catalog rather than duplicating them. Closes #319.

--- a/docs/non-cc/README.md
+++ b/docs/non-cc/README.md
@@ -98,6 +98,7 @@ Terminal/CLI agents and agentic IDEs beyond Claude Code — the former "Planned"
 | [deepagents-analysis.md](deepagents-analysis.md) | langchain-ai/deepagents (deep-agents: planning + subagents + virtual FS, on LangGraph) | Yes | Yes (MIT) |
 | [openharness-analysis.md](openharness-analysis.md) | HKUDS/OpenHarness (open Python agent harness; 10 subsystems, CC-convention compatible, multi-provider) | Yes | Yes (MIT) |
 | [agent-frameworks-infrastructure-landscape.md](agent-frameworks-infrastructure-landscape.md) | Landscape catalog: orchestration frameworks, LLM routing, memory infrastructure, agent models | — | Mixed |
+| [workflow-frameworks-landscape.md](workflow-frameworks-landscape.md) | Agentic workflow frameworks: Anthropic's 5 patterns, durable execution (Temporal/Inngest/Restate), 8 anti-patterns; the workflows-vs-agents distinction | — | Mixed |
 | [openai-swarm-analysis.md](openai-swarm-analysis.md) | OpenAI Swarm (deprecated educational multi-agent; superseded by Agents SDK) | Yes | Yes (MIT) |
 | [openai-agents-sdk-analysis.md](openai-agents-sdk-analysis.md) | OpenAI Agents SDK (multi-agent: handoffs, guardrails, sessions, tracing; GA successor to Swarm) | Yes | Yes (MIT) |
 

--- a/docs/non-cc/workflow-frameworks-landscape.md
+++ b/docs/non-cc/workflow-frameworks-landscape.md
@@ -1,0 +1,95 @@
+---
+title: Agentic Workflow Frameworks — Landscape
+purpose: The workflows-vs-agents distinction (Anthropic's 5 patterns), the agentic-workflow framework landscape, durable-execution engines, and production anti-patterns — beyond Claude Code's own workflow tool.
+category: landscape
+created: 2026-06-27
+updated: 2026-06-27
+validated_links: 2026-06-27
+---
+
+**Status**: Research (informational)
+
+## What It Is
+
+The external agentic-**workflow** framework landscape plus the workflows-vs-agents distinction. It complements Claude Code's own [Workflow tool](../cc-native/agents-skills/CC-dynamic-workflows-analysis.md) and the broader [agent-frameworks catalog](agent-frameworks-infrastructure-landscape.md) (which lists the orchestration frameworks). What this doc adds: the **pattern vocabulary**, the **durable-execution** layer, and an **anti-pattern taxonomy**.
+
+## Workflows vs agents (Anthropic's 5 patterns)
+
+Per [Anthropic — Building Effective Agents][anthropic-bea]: **workflows** orchestrate LLMs + tools through *predefined code paths*; **agents** let the LLM direct its own process. The guiding rule — "find the simplest solution, and add complexity only when it demonstrably improves outcomes." The five composable workflow patterns:
+
+1. **Prompt chaining** — a fixed sequence of steps (each output feeds the next), with optional gates between.
+2. **Routing** — classify the input, dispatch to a specialized follow-up.
+3. **Parallelization** — *sectioning* (independent subtasks at once) or *voting* (same task N times, aggregate).
+4. **Orchestrator–workers** — a lead LLM decomposes + delegates to workers dynamically, then synthesizes.
+5. **Evaluator–optimizer** — one LLM generates, another critiques, in a loop until a bar is met.
+
+Claude Code's own Workflow tool implements these in a deterministic JS script — see the cross-ref.
+
+## Framework landscape
+
+The orchestration frameworks themselves are catalogued in [agent-frameworks-infrastructure-landscape.md §1](agent-frameworks-infrastructure-landscape.md) (LangGraph, CrewAI, AutoGen, …); this table adds the axis that matters for *workflows* — **deterministic-DAG vs agentic** control flow, and whether execution is **durable** (survives a crash/restart). Stars via `gh api`, 2026-06-27.
+
+| Framework | Stars | Control flow | Durable? |
+|---|---|---|---|
+| [LangGraph][langgraph] | 35.9K | graph (DAG + agentic) | checkpointers |
+| [CrewAI][crewai] | 54.5K | roles + flows | app-level only |
+| [Langflow][langflow] | 150.1K | visual DAG builder | no |
+| [Mastra][mastra] | 25.5K | TS workflows + agents | suspend/resume |
+| [Burr][burr] | 2.5K | explicit state-machine DAG | persisters |
+| [Conductor (OSS)][conductor] | 32.0K | server-orchestrated DAG | yes (server-side) |
+
+LangGraph/CrewAI detail lives in the catalog — cross-referenced, not duplicated.
+
+## Durable execution (the layer the catalog omits)
+
+When a workflow must survive process crashes, provider timeouts, or human-in-the-loop pauses lasting hours, **durable-execution engines** persist each step so a fresh process resumes from the last checkpoint. The pattern mainstreamed across AWS / Cloudflare / Vercel in late 2025.
+
+| Engine | Stars | Model |
+|---|---|---|
+| [Temporal][temporal] | 21.3K (MIT) | workflows-as-code; deterministic replay from an event history |
+| [Inngest][inngest] | 5.5K | event-driven durable functions with built-in flow control |
+| [Restate][restate] | 4.1K | durable execution + virtual objects; low-latency |
+
+The core primitive is idempotency on a stable **`(workflow_id, step_id)`** key — so a replayed step is a no-op, not a duplicated side-effect.
+
+## Anti-patterns (severity-tiered)
+
+| Tier | Anti-pattern | Why it bites |
+|---|---|---|
+| **S0** | Hidden state across steps | non-reproducible runs; can't replay/debug |
+| **S0** | Over-broad tool grants | one bad step → wide blast radius |
+| **S0** | Unbounded loops | runaway cost; no termination |
+| **S1** | Races on shared state | lost updates, nondeterminism |
+| **S1** | Missing idempotency | retries duplicate side-effects |
+| **S1** | Naive retry (no backoff/cap) | thundering-herd; infinite retry |
+| **S2** | Synchronous blocking | one slow step stalls the pipeline |
+| **S2** | Orchestrator bottleneck | a single lead serializes everything |
+
+**Best-practices checklist:** bound every loop; make each side-effecting step idempotent on a stable key; scope tools per step; keep state explicit (no hidden globals); backoff + retry caps; parallelize independent sections; checkpoint long / HITL workflows on a durable engine.
+
+**Real-world signal:** the "framework graveyard" of abandoned 2023–24 agent frameworks, and production write-ups (e.g. Replit's Agent 3), point the same way — *fewer, simpler, durable* patterns beat elaborate orchestration.
+
+## Cross-References
+
+- [CC-dynamic-workflows-analysis.md](../cc-native/agents-skills/CC-dynamic-workflows-analysis.md) — Claude Code's own Workflow tool (these patterns in a deterministic JS script)
+- [agent-frameworks-infrastructure-landscape.md](agent-frameworks-infrastructure-landscape.md) — §1 orchestration frameworks, §8 output validation / guardrails
+- [agentic-engineering-disciplines-landscape.md](../sdlc-lcm/agentic-engineering-disciplines-landscape.md) — flow / loop engineering as disciplines
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [Anthropic — Building Effective Agents][anthropic-bea] | Workflows-vs-agents; the 5 composable patterns |
+| [Temporal][temporal] · [Inngest][inngest] · [Restate][restate] | Durable-execution engines |
+| [LangGraph][langgraph] · [CrewAI][crewai] · [Langflow][langflow] · [Mastra][mastra] · [Burr][burr] · [Conductor (OSS)][conductor] | Workflow / orchestration frameworks (stars via `gh api`, 2026-06-27) |
+
+[anthropic-bea]: https://www.anthropic.com/research/building-effective-agents
+[temporal]: https://github.com/temporalio/temporal
+[inngest]: https://github.com/inngest/inngest
+[restate]: https://github.com/restatedev/restate
+[langgraph]: https://github.com/langchain-ai/langgraph
+[crewai]: https://github.com/crewAIInc/crewAI
+[langflow]: https://github.com/langflow-ai/langflow
+[mastra]: https://github.com/mastra-ai/mastra
+[burr]: https://github.com/DAGWorks-Inc/burr
+[conductor]: https://github.com/conductor-oss/conductor


### PR DESCRIPTION
Closes #319. New `docs/non-cc/workflow-frameworks-landscape.md`.

Adds the **workflows-vs-agents** vocabulary and the layers the existing catalog omits:
- **Anthropic's 5 patterns** (prompt-chaining / routing / parallelization / orchestrator-workers / evaluator-optimizer).
- A **control-flow + durability** framework table (gh-verified stars 2026-06-27): LangGraph, CrewAI, Langflow, Mastra, Burr, Conductor.
- **Durable execution** — Temporal / Inngest / Restate, with the `(workflow_id, step_id)` idempotency primitive (Temporal was absent from the repo).
- **8 anti-patterns** with S0–S2 severity tiers + a best-practices checklist.

Cross-refs `CC-dynamic-workflows-analysis.md` (CC's own Workflow tool) and `agent-frameworks-infrastructure-landscape.md` (§1/§8) rather than re-listing LangGraph/CrewAI. Named without the `CC-` prefix per the non-cc convention.

Docs-only; `make check_docs` + `make check_links` clean locally (0 errors).

Generated with Claude <noreply@anthropic.com>