### PR TITLE
docs: spec-driven-frameworks landscape + context-eng cite (#321 top-2)

### DIFF
--- a/changelog.d/20260627_spec-frameworks-and-context-cite.md
+++ b/changelog.d/20260627_spec-frameworks-and-context-cite.md
@@ -1,0 +1,4 @@
+### Added
+
+- `docs/non-cc/spec-driven-frameworks-landscape.md`: standalone SDD-framework comparison (spec-kit 115.9K / OpenSpec 57.1K / BMAD 49.8K / Agent-OS / Kiro / Tessl; gh-verified stars) — the deep-dive promoted from the §3 stub in the agentic-engineering disciplines landscape. Part of #321.
+- `docs/cc-native/context-memory/CC-memory-system-analysis.md`: added Anthropic's first-party "Effective Context Engineering for AI Agents" (Sept 2025) canonical anchor to the ACE-FCA section (write/select/compress/isolate). Part of #321.

--- a/docs/cc-native/context-memory/CC-memory-system-analysis.md
+++ b/docs/cc-native/context-memory/CC-memory-system-analysis.md
@@ -323,7 +323,7 @@ For CLAUDE.md size, import chains, path-scoped rules, auto memory deduplication,
 
 ## Context Engineering Workflow (ACE-FCA)
 
-The ACE-FCA (Advanced Context Engineering — Frequent Compaction Architecture) methodology was introduced by [Dex at hlyr.dev][hlyr-ace] (2025-08-29) as a structured approach to preventing context degradation in long agentic sessions. This repo's [.claude/rules/context-management.md](../../../.claude/rules/context-management.md) encodes this framework — the 40–60% utilization target and the context-quality ranking originate from the hlyr.dev source.
+The ACE-FCA (Advanced Context Engineering — Frequent Compaction Architecture) methodology was introduced by [Dex at hlyr.dev][hlyr-ace] (2025-08-29) as a structured approach to preventing context degradation in long agentic sessions. This repo's [.claude/rules/context-management.md](../../../.claude/rules/context-management.md) encodes this framework — the 40–60% utilization target and the context-quality ranking originate from the hlyr.dev source. It converges with **Anthropic's** canonical first-party framework ([Effective Context Engineering for AI Agents][anthropic-ce], Sept 2025): *write / select / compress / isolate* — this repo's compaction maps to *compress*, subagent isolation to *isolate*.
 
 ### Three-Phase Workflow with Human-Review Gates
 
@@ -383,6 +383,7 @@ Better to have less correct information than more information with errors.
 [piebald-dream]: https://github.com/Piebald-AI/claude-code-system-prompts/blob/main/system-prompts/agent-prompt-dream-memory-consolidation.md
 [hlyr-claude-md]: https://www.hlyr.dev/blog/stop-claude-from-ignoring-your-claude-md
 [hlyr-ace]: https://www.hlyr.dev/blog/advanced-context-engineering
+[anthropic-ce]: https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents
 [cc-reverse-eng]: ../../cc-community/CC-reverse-engineering-landscape.md
 [cc-skills-landscape]: ../../cc-community/CC-community-skills-landscape.md
 [cc-harness-patterns]: ../agents-skills/CC-agentic-harness-patterns-analysis.md

--- a/docs/non-cc/README.md
+++ b/docs/non-cc/README.md
@@ -99,6 +99,7 @@ Terminal/CLI agents and agentic IDEs beyond Claude Code — the former "Planned"
 | [openharness-analysis.md](openharness-analysis.md) | HKUDS/OpenHarness (open Python agent harness; 10 subsystems, CC-convention compatible, multi-provider) | Yes | Yes (MIT) |
 | [agent-frameworks-infrastructure-landscape.md](agent-frameworks-infrastructure-landscape.md) | Landscape catalog: orchestration frameworks, LLM routing, memory infrastructure, agent models | — | Mixed |
 | [workflow-frameworks-landscape.md](workflow-frameworks-landscape.md) | Agentic workflow frameworks: Anthropic's 5 patterns, durable execution (Temporal/Inngest/Restate), 8 anti-patterns; the workflows-vs-agents distinction | — | Mixed |
+| [spec-driven-frameworks-landscape.md](spec-driven-frameworks-landscape.md) | Spec-driven development frameworks (spec-kit, OpenSpec, BMAD, Agent-OS, Kiro, Tessl); standalone deep-dive behind the disciplines §3 synthesis | — | Mixed |
 | [openai-swarm-analysis.md](openai-swarm-analysis.md) | OpenAI Swarm (deprecated educational multi-agent; superseded by Agents SDK) | Yes | Yes (MIT) |
 | [openai-agents-sdk-analysis.md](openai-agents-sdk-analysis.md) | OpenAI Agents SDK (multi-agent: handoffs, guardrails, sessions, tracing; GA successor to Swarm) | Yes | Yes (MIT) |
 

--- a/docs/non-cc/spec-driven-frameworks-landscape.md
+++ b/docs/non-cc/spec-driven-frameworks-landscape.md
@@ -1,0 +1,56 @@
+---
+title: Spec-Driven Frameworks — Landscape
+purpose: Comparison of spec-driven development (SDD) frameworks — GitHub Spec-Kit, OpenSpec, BMAD-METHOD, Agent-OS, Kiro, Tessl — the standalone deep-dive behind the synthesis entry in the agentic-engineering disciplines landscape.
+category: landscape
+created: 2026-06-27
+updated: 2026-06-27
+validated_links: 2026-06-27
+---
+
+**Status**: Research (informational)
+
+## What It Is
+
+By 2026 every major coding tool shipped a **spec-driven development (SDD)** flavor: a machine-readable spec becomes the agent's source of truth, and human review shifts from reviewing code to reviewing the spec. This is the standalone comparison behind the synthesis-level §3 table in [agentic-engineering-disciplines-landscape.md](../sdlc-lcm/agentic-engineering-disciplines-landscape.md). Stars via `gh api`, 2026-06-27.
+
+## Frameworks
+
+| Framework | Stars | License | Loop | Distinctive |
+|---|---|---|---|---|
+| [github/spec-kit][spec-kit] | 115.9K | MIT | Spec → Plan → Tasks → Implement | 30+ agent integrations, 70+ extensions; "intent is the source of truth" |
+| [Fission-AI/OpenSpec][openspec] | 57.1K | MIT | Proposal → Apply → Archive | change-proposal centric; no MCP/keys required |
+| [bmadcode/BMAD-METHOD][bmad] | 49.8K | custom | multi-agent planning → context-engineered dev | role agents (Analyst / PM / Architect) author the spec |
+| [buildermethods/agent-os][agent-os] | 5.0K | MIT | MCP context-injection layer | composes with any SDD framework rather than replacing it |
+| [kirodotdev/Kiro][kiro-repo] | 3.9K | proprietary | requirements → design → tasks "waves" | full IDE; spec phase is mandatory — see [kiro-analysis.md](kiro-analysis.md) |
+| Tessl (`tile`) | ~41 | MIT | "spec-as-source" | the spec, not the code, is the maintained artifact; main framework closed-beta |
+
+## How they differ
+
+- **Spec-Kit / OpenSpec** are the two large OSS frameworks — Spec-Kit is the broadest (multi-agent, extension ecosystem), OpenSpec is leaner (proposal → apply → archive, no keys).
+- **BMAD** front-loads multi-agent *planning* (role agents draft the spec) before context-engineered execution.
+- **Agent-OS** is a *layer*, not a framework — an MCP context-injection shim that pairs with the others.
+- **Kiro** bakes SDD into a full IDE (the spec phase is mandatory) — covered in depth in its own analysis.
+- **Tessl** pushes "spec-as-source" furthest (the spec is the maintained artifact, code is regenerated), but the main framework is closed-beta.
+
+## Where SDD sits
+
+SDD is the *what* (machine-readable spec → plan → tasks → implement); **EDD** (eval-driven development) is the *how-to-verify*. Together they bound a non-deterministic agent — SDD constrains the input, EDD constrains the output. See the disciplines landscape for the full "-engineering" / "-driven-development" stack.
+
+## Cross-References
+
+- [agentic-engineering-disciplines-landscape.md](../sdlc-lcm/agentic-engineering-disciplines-landscape.md) — the §3 synthesis entry this doc expands; the full disciplines + methodologies stack
+- [kiro-analysis.md](kiro-analysis.md) — Kiro's spec-driven IDE in depth
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [github/spec-kit][spec-kit] · [OpenSpec][openspec] · [BMAD-METHOD][bmad] · [agent-os][agent-os] · [Kiro][kiro-repo] | SDD frameworks (stars via `gh api`, 2026-06-27) |
+| [Martin Fowler — SDD tools][fowler-sdd] | Spec-driven development survey |
+
+[spec-kit]: https://github.com/github/spec-kit
+[openspec]: https://github.com/Fission-AI/OpenSpec
+[bmad]: https://github.com/bmadcode/BMAD-METHOD
+[agent-os]: https://github.com/buildermethods/agent-os
+[kiro-repo]: https://github.com/kirodotdev/Kiro
+[fowler-sdd]: https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html


### PR DESCRIPTION
Lands the two highest-value items from #321 (the tracker stays open for the rest).

1. **New `docs/non-cc/spec-driven-frameworks-landscape.md`** — standalone SDD comparison (spec-kit 115.9K / OpenSpec 57.1K / BMAD 49.8K / Agent-OS 5.0K / Kiro 3.9K / Tessl; stars via `gh api` 2026-06-27), promoted from the §3 stub in the agentic-engineering disciplines landscape. Covers how they differ (framework vs layer vs IDE vs spec-as-source) and where SDD sits vs EDD.
2. **Anthropic context-engineering canonical cite** — added the first-party [Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) (Sept 2025) anchor to `CC-memory-system-analysis.md` §ACE-FCA (the previously-missing first-party anchor; write/select/compress/isolate).

**Deferred** (left on #321): Flow/Harness/Ralph adds, EDD-as-methodology, 8 observability items.

Docs-only; `make check_docs` + `make check_links` clean locally (0 errors).

Generated with Claude <noreply@anthropic.com>