### PR TITLE
docs: accept ## References + backfill Sources sections (#308)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ See the [monitoring docs][monitoring] for OTel configuration.
 
 ### 5. Sources Section (End)
 
-Every doc ends with a `## Sources` table linking all references used:
+Every doc ends with a `## Sources` table (a `## References` section is accepted as equivalent) linking all references used:
 
 ```markdown
 ## Sources
@@ -182,7 +182,7 @@ This prevents misreading a `cc-community` placement as "CC-exclusive."
 - `sources:` in YAML frontmatter — use Sources section instead
 - Bare URLs in prose — use reference-style links
 - Duplicating content across docs — cross-reference the authoritative doc
-- Missing Sources section — every doc must cite its sources
+- Missing Sources section — every doc must cite its sources (a `## Sources` table, or an equivalent `## References` section)
 - Stale `validated_links` dates — re-check URLs when updating findings
 
 ## Auto-generated content

--- a/changelog.d/20260627_sources-convention-backfill.md
+++ b/changelog.d/20260627_sources-convention-backfill.md
@@ -1,0 +1,7 @@
+### Changed
+
+- `CONTRIBUTING.md`: a `## References` section is now accepted as equivalent to `## Sources` (the convention allows either heading).
+
+### Added
+
+- Backfilled a `## Sources` section into the 9 convention-named docs that had neither heading: `CC-code-tooling-landscape`, `CC-usage-tooling-landscape`, `agent-frameworks-infrastructure-landscape`, `agent-observability-methods-analysis`, `deerflow-analysis`, `opensrc-analysis`, `agent-evaluation-metrics-landscape`, `evaluation-data-resources-landscape`, `oss-alm-landscape`. Closes #308.

--- a/docs/cc-community/CC-code-tooling-landscape.md
+++ b/docs/cc-community/CC-code-tooling-landscape.md
@@ -271,3 +271,7 @@ Rust CLI that renders a codebase into a single prompt with a source tree, Handle
 [qodo-agents]: https://github.com/qodo-ai/agents
 [qodo-aware]: https://github.com/qodo-ai/open-aware
 [qodo-crr]: https://docs.qodo.ai/governance/cross-repo-code-review
+
+## Sources
+
+Each tool cites its repository/docs inline via the reference-style link definitions above (Graphify, Code-Review-Graph, Qodo, codebase-memory-mcp, Serena, ast-grep MCP, Repomix, code2prompt).

--- a/docs/cc-community/CC-usage-tooling-landscape.md
+++ b/docs/cc-community/CC-usage-tooling-landscape.md
@@ -183,3 +183,7 @@ Cross-ref: [CC-session-cost-analysis.md](../cc-native/sessions/CC-session-cost-a
 [codeburn-optimize]: https://github.com/getagentseal/codeburn/blob/main/src/optimize.ts
 [ccusage]: https://github.com/ryoppippi/ccusage
 [claude-monitor]: https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor
+
+## Sources
+
+Each tool cites its repo inline via the reference-style link definitions above ([CodeBurn][codeburn], [ccusage][ccusage], [Claude-Code-Usage-Monitor][claude-monitor]).

--- a/docs/non-cc/agent-frameworks-infrastructure-landscape.md
+++ b/docs/non-cc/agent-frameworks-infrastructure-landscape.md
@@ -181,3 +181,7 @@ Validation is the post-generation sibling of retrieval (§7): enforcing that age
 [12fa-blog]: https://www.hlyr.dev/blog/12-factor-agents
 [12fa-gh]: https://github.com/humanlayer/12-factor-agents
 [pai-caps]: https://pydantic.dev/articles/pydantic-ai-capabilities
+
+## Sources
+
+Each framework / tool entry cites its repo or docs inline (reference-style and inline links above); framework stars were `gh api`-verified at the snapshot dates noted in the relevant sections.

--- a/docs/non-cc/agent-observability-methods-analysis.md
+++ b/docs/non-cc/agent-observability-methods-analysis.md
@@ -612,3 +612,7 @@ The 2026 landscape shows significant maturation with 89% of organizations implem
 ### Future Outlook
 
 The observability landscape continues rapid evolution toward standardization (OpenTelemetry), specialization (multi-agent coordination), and integration (development-to-production workflows). Framework-specific semantic conventions completion expected through 2026 will further unify agent observability across diverse technical stacks, while multi-agent capabilities will become standard rather than specialized features as agentic systems scale in production environments.
+
+## Sources
+
+Each of the 18 platforms cites its official docs/repo inline across the five tracing-pattern sections above. Claude Code's own first-party OTel telemetry is documented separately in [CC-monitoring-telemetry-analysis.md](../cc-native/configuration/CC-monitoring-telemetry-analysis.md).

--- a/docs/non-cc/deerflow-analysis.md
+++ b/docs/non-cc/deerflow-analysis.md
@@ -73,3 +73,9 @@ tool definitions.
 
 - [ ] Track skill format evolution — compare with CC SKILL.md for convergence
 - [ ] Monitor MCP tool registry for reusable tool definitions
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [ByteDance/deer-flow](https://github.com/bytedance/deer-flow) | DeerFlow — LangGraph super-agent harness (repo) |

--- a/docs/non-cc/opensrc-analysis.md
+++ b/docs/non-cc/opensrc-analysis.md
@@ -51,3 +51,9 @@ Complements the context-management stack from a different angle: source-fetchers
 
 - [agent-frameworks-infrastructure-landscape.md](agent-frameworks-infrastructure-landscape.md) — agent context/memory infrastructure
 - [CC-community-tooling-landscape.md](../cc-community/CC-community-tooling-landscape.md) — the CC dev-tooling stack (RTK, Boucle) opensrc complements
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [vercel-labs/opensrc](https://github.com/vercel-labs/opensrc) | Fetches npm package source code for agent context (repo) |

--- a/docs/sdlc-lcm/agent-evaluation-metrics-landscape.md
+++ b/docs/sdlc-lcm/agent-evaluation-metrics-landscape.md
@@ -440,3 +440,7 @@ Metrics derived from production evaluation frameworks and competition benchmarks
 ## Additional Resources
 
 [Framework implementations and practical guidance on using these metrics](evaluation-data-resources-landscape.md)
+
+## Sources
+
+Metric definitions are sourced from the research papers and tool docs cited inline throughout; the implementing frameworks, benchmarks, and datasets are catalogued in [evaluation-data-resources-landscape.md](evaluation-data-resources-landscape.md).

--- a/docs/sdlc-lcm/evaluation-data-resources-landscape.md
+++ b/docs/sdlc-lcm/evaluation-data-resources-landscape.md
@@ -89,3 +89,7 @@ Observability-first platforms with strong eval features — **LangWatch, Evident
 - [agent-observability-methods-analysis.md](../non-cc/agent-observability-methods-analysis.md) — tracing/observability platforms (LangWatch, Evidently, Braintrust full entries)
 - [research-agents-landscape.md](../non-cc/research-agents-landscape.md) — research/discovery agents
 - [agent-frameworks-infrastructure-landscape.md](../non-cc/agent-frameworks-infrastructure-landscape.md) — agent frameworks & memory infrastructure
+
+## Sources
+
+Each framework, benchmark, and dataset links to its first-party page (repo / Hugging Face / arXiv) inline in the tables above.

--- a/docs/sdlc-lcm/oss-alm-landscape.md
+++ b/docs/sdlc-lcm/oss-alm-landscape.md
@@ -47,3 +47,7 @@ not agent-driven pipelines where state is inferred from repo artifacts.
 - RAPID cockpit needs a persistent UI beyond CLI/TUI — *note: RAPID is legacy (archived 2026-04-26, superseded by [qte77/qte77](https://github.com/qte77/qte77))*
 
 **If triggered:** Tuleap CE via REST API integration with sdlc-lcm-manager.
+
+## Sources
+
+The OSS ALM tools compared (Tuleap, OpenProject, Redmine, GitLab) link to their projects inline in the sections above.


### PR DESCRIPTION
Closes #308 — the minimal, reconciled scope (no CI harness).

- **CONTRIBUTING** now accepts a `## References` section as equivalent to `## Sources` (additive — both headings are valid). This makes the ~29 docs that already use `## References` compliant by definition.
- **Backfilled** a `## Sources` section into the **9** convention-named docs that had *neither* heading: `CC-code-tooling-landscape`, `CC-usage-tooling-landscape` (cc-community); `agent-frameworks-infrastructure-landscape`, `agent-observability-methods-analysis`, `deerflow-analysis`, `opensrc-analysis` (non-cc); `agent-evaluation-metrics-landscape`, `evaluation-data-resources-landscape`, `oss-alm-landscape` (sdlc-lcm). Inline-linked landscapes get a brief Sources note; the analysis docs get a small table.

Per the KISS/YAGNI reconciliation we agreed, the self-enforcing CI check was dropped (9 docs doesn't justify a test harness).

Docs-only; `make check_docs` + `make check_links` clean locally (0 errors); all 9 now carry a Sources section.

Generated with Claude <noreply@anthropic.com>