### PR TITLE
docs: add 5 agentic-AI sources (squid, multica, olmoCR, goose, Lenny's)

### DIFF
--- a/changelog.d/20260628_120000_docs_add_squid_multica_olmocr_goose_sources.md
+++ b/changelog.d/20260628_120000_docs_add_squid_multica_olmocr_goose_sources.md
@@ -1,0 +1,7 @@
+### Added
+
+- `docs/cc-community/CC-community-plugins-landscape.md`: **squid** plugin profile — iusztinpaul's Claude Code agentic-engineering pipeline (5 role subagents Product Architect → SWE → Tester → PR Reviewer → On-Call; ADRs as architectural memory + Tasks Plan as goal decomposition; `/scaffold` `/plan` `/implement-night` `/implement-task` `/review` slash commands; env vars: none documented).
+- `docs/non-cc/agent-frameworks-infrastructure-landscape.md` (§1): **multica** (multica-ai) — multi-agent orchestration platform routing issues to agents/squads across 11 agent CLIs; local daemon + autopilot scheduling, Go + Postgres/pgvector; `multica login` / `daemon start` / `issue create` (browser auth, no env vars).
+- `docs/non-cc/web-scraping-extraction-landscape.md` (Document-Specific Extraction): **olmOCR** (AllenAI) — GPU PDF/image → Markdown/Dolma OCR pipeline on a fine-tuned Qwen2.5-VL 7B; document-ingestion front-end for RAG/knowledge bases; install/CLI/flags captured leanly with upstream link (default model `allenai/olmOCR-2-7B-1025-FP8`).
+- `docs/non-cc/goose-analysis.md`: new **Install, CLI & Configuration** section — `goose session` / `configure` / `update`, install one-liners, and provider/runtime env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GOOSE_VERSION`, `CONFIGURE`); `validated_links` refreshed for the aaif-goose migration.
+- `docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md`: cited **Lenny's Newsletter (AI)** as a practitioner-perspective source on agentic adoption.

--- a/docs/cc-community/CC-community-plugins-landscape.md
+++ b/docs/cc-community/CC-community-plugins-landscape.md
@@ -4,8 +4,8 @@ description: Survey of community plugin catalogs — awesome-claude-code (curate
 category: landscape
 status: research
 created: 2026-03-13
-updated: 2026-06-16
-validated_links: 2026-04-23
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Research (informational)
@@ -224,6 +224,33 @@ The repo ships Node.js lifecycle hooks (`hooks/`), platform-specific markdown ru
 
 **Notable pattern**: Unusually high star count (~16.6k) for a code-quality plugin reflects broad cross-ecosystem appeal — the minimalism philosophy is platform-agnostic and the multi-platform distribution lowers the barrier for polyglot teams.
 
+## Notable Plugin Profile: squid (Agentic Engineering Pipeline)
+
+**Repo**: [iusztinpaul/squid][squid] | **Writeup**: [decodingai][squid-writeup] | **License**: Apache-2.0 | **Stars**: ~114 | **Category**: Workflow Orchestration
+
+An opinionated full-lifecycle engineering pipeline that mirrors a real team across five role subagents — `product-architect` → `software-engineer` → `tester` → `pr-reviewer` → `oncall-engineer` — plus an optional self-improve meta-agent. Core principle: *no agent both writes code and decides if it's correct*. Human gates sit at plan approval and final merge. Architectural memory is externalised to ADR files (`docs/adr/<NNNN>.md`) and a DDD `docs/glossary.md`; `/scaffold` generates `AGENTS.md` + folder skeletons for Python/TypeScript/Go.
+
+| Command | Purpose |
+|---------|---------|
+| `/scaffold` | Bootstrap stack + `AGENTS.md` + folder skeleton |
+| `/plan <spec>` | Groom a spec into a Tasks Plan; create branch + worktree |
+| `/implement-night <plan>` | Full 5-agent pipeline (async, ≤5 retry loops, 2 human gates) |
+| `/implement-task` | Single task — SWE ↔ Tester loop only |
+| `/review`, `/review-ci` | Acceptance/diff review + On-Call CI validation |
+
+**Install** (Claude Code plugin):
+
+```bash
+/plugin marketplace add iusztinpaul/squid
+/plugin install squid@iusztinpaul
+# or via the skills runner:
+npx skills add iusztinpaul/squid
+```
+
+**Env vars**: none documented — configuration is per-project via `AGENTS.md` + `.claude/settings.json`.
+
+**Notable pattern**: the ADR layer (architectural memory) and the Tasks Plan (explicit goal decomposition) make squid a worked example of memory + goal-tracking *inside* a CC pipeline — threads picked up in the deferred agentic-memory / goal-attribution research. Relevant to [CC-agent-teams-orchestration](../cc-native/agents-skills/CC-agent-teams-orchestration.md).
+
 ## Ecosystem Observations
 
 1. **Business-function plugins** (Sales, Marketing, Legal) exist only in the ccplugins registry — the awesome-claude-code list is developer-focused
@@ -244,8 +271,12 @@ The repo ships Node.js lifecycle hooks (`hooks/`), platform-specific markdown ru
 |---|---|
 | [awesome-claude-code][acc] | Curated resource list |
 | [awesome-claude-code-plugins][accp] | Installable plugin registry with marketplace format |
+| [squid][squid] | Agentic engineering pipeline plugin (5-agent; ADR memory + Tasks Plan goal decomposition) |
+| [squid writeup][squid-writeup] | Author's setup rationale (decodingai) |
 
 [ponytail]: https://github.com/DietrichGebert/ponytail
+[squid]: https://github.com/iusztinpaul/squid
+[squid-writeup]: https://www.decodingai.com/p/squid-my-agentic-coding-setup-may-2026
 [acc]: https://github.com/hesreallyhim/awesome-claude-code
 [accp]: https://github.com/ccplugins/awesome-claude-code-plugins
 [claude-seo]: https://github.com/AgriciDaniel/claude-seo

--- a/docs/non-cc/agent-frameworks-infrastructure-landscape.md
+++ b/docs/non-cc/agent-frameworks-infrastructure-landscape.md
@@ -4,8 +4,8 @@ purpose: Catalog of multi-agent orchestration frameworks, LLM-orchestration/rout
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-27
-validated_links: 2026-06-27
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Research (informational)
@@ -30,6 +30,7 @@ Catalog of agent frameworks and supporting infrastructure beyond Claude Code. Re
 - [DeerFlow (ByteDance)](https://github.com/bytedance/deer-flow) — LangGraph super-agent harness with Markdown skills + sandboxed execution. Full analysis: [deerflow-analysis.md](deerflow-analysis.md).
 - [DeepAgents (LangChain)](https://github.com/langchain-ai/deepagents) — planning + sub-agent harness. Full analysis: [deepagents-analysis.md](deepagents-analysis.md).
 - [Flue (Astro)](https://github.com/withastro/flue) — durable, sandboxed TypeScript agent framework from the Astro team; **1.0 Beta** (~2026-06-16, Apache-2.0, [flueframework.com](https://www.flueframework.com)). Harness-first model on the **Pi** agent loop (via `@flue/runtime`): **Durable Streams** record every prompt/tool-response/model-choice to an append-only log, so a fresh process resumes from the last checkpoint after a crash or provider timeout. Ships a **just-bash** in-memory sandbox (no Docker/VM) plus a `local()` sandbox; MCP-native and model-agnostic; **channels** ingest events from Slack/Teams/Discord/GitHub/Linear; on Cloudflare Workers each agent becomes a Durable Object (SQLite FS, `runFiber`/`stash`/`onFiberRecovered`). Supports **subagents / task delegation** (swarm-style coordination is not documented in first-party sources); `SuperagenticAI/pyflue` is a community Python port, not first-party.
+- [multica](https://github.com/multica-ai/multica) — open-source platform that turns coding-agent CLIs into managed teammates: create issues → assign to an agent or a squad, a local daemon executes and streams progress over WebSocket, with autopilot (cron/webhook) scheduling and a reusable skill library. Integrates 11 agent CLIs (Claude Code, Codex, Copilot CLI, OpenClaw, OpenCode, Hermes, Gemini, Pi, Cursor, Kimi, Kiro); Go + Postgres 17/pgvector backend, Next.js 16 UI (Apache-2.0). Install `brew install multica-ai/tap/multica` or the `install.sh` script (`--with-server` to self-host); CLI flows `multica login` → `multica daemon start` → `multica issue create` / `multica workspace switch`. Auth is browser-based via `multica login` — no API-key env vars documented.
 
 ## 2. LLM Orchestration & Routing
 

--- a/docs/non-cc/goose-analysis.md
+++ b/docs/non-cc/goose-analysis.md
@@ -3,8 +3,8 @@ title: Goose Analysis
 source: https://github.com/aaif-goose/goose
 purpose: Analysis of Goose as MCP co-creator, reference implementation, and AAIF founding project — architectural comparison with CC's MCP integration.
 created: 2026-04-05
-updated: 2026-06-11
-validated_links: 2026-06-11
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Assess (open-source, active, architecturally significant)
@@ -51,6 +51,23 @@ Goose implements ACP bidirectionally:
 
 This is comparable to CC's WebSocket IDE protocol but uses a different standard ([source][arch]).
 
+## Install, CLI & Configuration
+
+**Install** (see [Goose install docs][install]):
+
+```bash
+# Linux/macOS
+curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | bash
+# macOS (Homebrew)
+brew install block-goose-cli
+# non-interactive (CI): skip the interactive configure step
+curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+```
+
+**CLI**: `goose session` (interactive run), `goose configure` (providers + extensions), `goose update`; `goose acp` exposes the ACP server for IDEs (above).
+
+**Environment variables**: provider keys — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY` (other providers per the [docs][install]); `GOOSE_VERSION` pins a release for reproducible CI; `CONFIGURE=false` skips interactive setup at install time. Beyond keys, configuration (15+ providers, 70+ MCP extensions) lives in `goose configure`.
+
 ## Comparison with CC
 
 | Aspect | Claude Code | Goose |
@@ -80,6 +97,7 @@ This is comparable to CC's WebSocket IDE protocol but uses a different standard 
 | [AAIF announcement][aaif] | Linux Foundation founding with MCP + Goose + AGENTS.md |
 | [Goose moves to AAIF][goose-move] | April 2026 relocation from block/goose |
 | [MCP Apps blog][mcp-apps] | Goose as reference MCP Apps client |
+| [Goose install & CLI docs][install] | Install, CLI commands, provider env vars |
 
 [repo]: https://github.com/aaif-goose/goose
 [arch]: https://goose-docs.ai/
@@ -87,3 +105,4 @@ This is comparable to CC's WebSocket IDE protocol but uses a different standard 
 [aaif]: https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation
 [goose-move]: https://goose-docs.ai/blog/2026/04/07/goose-moves-to-aaif/
 [mcp-apps]: https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/
+[install]: https://goose-docs.ai/docs/getting-started/installation

--- a/docs/non-cc/web-scraping-extraction-landscape.md
+++ b/docs/non-cc/web-scraping-extraction-landscape.md
@@ -3,8 +3,8 @@ title: Web Scraping and Data Extraction — Tool Landscape
 source: https://github.com/qte77/polyfetch-scrape/blob/main/docs/scraping-landscape.md
 purpose: Single-source-of-truth catalog of scraping, crawling, and extraction tooling for agent/RAG pipelines across the qte77 ecosystem
 created: 2026-04-23
-updated: 2026-06-26
-validated_links: 2026-06-26
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Reference (informational catalog)
@@ -143,7 +143,11 @@ Cross-ref: [searxng-analysis.md](searxng-analysis.md) — deep-dive on self-host
 
 **Key insight**: government legislation portals and patent offices have official APIs that are easier than fighting their anti-bot. Use the API, not the PDF download page.
 
-## Browser-as-a-Service / Agent Platforms
+### Document OCR pipelines
+
+Distinct from the source-specific APIs above: general-purpose OCR/VLM tools that turn arbitrary PDFs and images into LLM-ready text — a document-ingestion front-end for RAG and knowledge bases.
+
+- [olmOCR (AllenAI)](https://github.com/allenai/olmocr) — GPU OCR pipeline converting PDF/PNG/JPEG → Markdown or Dolma JSON via a fine-tuned Qwen2.5-VL 7B model; handles equations, tables, handwriting, multi-column layout and reading-order recovery (<$200 / 1M pages, Apache-2.0). Install `pip install olmocr` (remote inference) or `pip install olmocr[gpu] --extra-index-url https://download.pytorch.org/whl/cu128` for local vLLM (Docker image `alleninstituteforai/olmocr:latest-with-model`). Run `olmocr <workspace> --pdfs … --markdown` — default model `allenai/olmOCR-2-7B-1025-FP8`; point at a remote endpoint with `--server`/`--api_key`, or read/write S3 via `--workspace_profile`/`--pdf_profile` (no env vars; the full ~25-flag reference is in the [repo README](https://github.com/allenai/olmocr)).
 
 | Platform | License/Pricing | Differentiator |
 |----------|----------------|----------------|

--- a/docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md
+++ b/docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md
@@ -3,8 +3,8 @@ title: Agentic Engineering Disciplines & Methodologies Landscape
 purpose: Credo-framed synthesis of the "-engineering" disciplines (prompt → spec) and "-driven development" methodologies (TDD → EDD → SDD) that make an agentic coding fleet compound instead of drift — with first-party coiners, a five-layer stack, and qte77's open-agentic-coding-harness as the reference implementation.
 category: landscape
 created: 2026-06-23
-updated: 2026-06-27
-validated_links: 2026-06-27
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Assess
@@ -122,6 +122,7 @@ qte77's sibling project [open-agentic-coding-harness][oach] implements the whole
 | Tobi Lütke / Karpathy (X, Jun 2025); Dave Farley (davefarley.net / courses.cd.training); Geoffrey Huntley Ralph loop (2025) | Attributions cited in prose (no stable/linkable URL) |
 | Zach Lloyd / Warp — *We are now factory engineers, not product engineers* (LinkedIn memo, 2026) | Industry framing of the "-engineering" shift: build the system that builds the product (LinkedIn — not link-checked) |
 | *Talking AI* podcast — agentic development & the future of engineering (Hatchworks, 2026) | Practitioner perspective on the agentic-engineering shift (LinkedIn — not link-checked) |
+| [Lenny's Newsletter — AI][lennys] | Practitioner essays on agentic adoption & AI-first product/eng workflows (e.g. "Not all AI agents are created equal") — perspective layer, not a technical reference |
 | [Startup CTO Handbook (Goldberg)][cto-handbook] · [qte77 mapping][cto-map] | Traditional engineering-leadership baseline — contrast to the agentic disciplines |
 
 [anthropic-ce]: https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents
@@ -134,6 +135,7 @@ qte77's sibling project [open-agentic-coding-harness][oach] implements the whole
 [react]: https://arxiv.org/abs/2210.11610
 [walkinglabs]: https://github.com/walkinglabs/learn-harness-engineering
 [cto-handbook]: https://github.com/ZachGoldberg/Startup-CTO-Handbook
+[lennys]: https://www.lennysnewsletter.com/t/ai
 [cto-map]: https://github.com/qte77/qte77/blob/main/docs/cto-handbook-mapping.md
 [bdd]: https://dannorth.net/blog/introducing-bdd/
 [husain-evals]: https://hamel.dev/blog/posts/evals/


### PR DESCRIPTION
## Summary

Sources-first pass adding five user-requested sources to the research corpus as **landscape rows / profile entries in existing docs** (no new files) with **lean url/env/CLI detail + upstream links** — matching the repo's "extend existing docs" convention (KISS/DRY/YAGNI).

## What changed

- **squid** → `docs/cc-community/CC-community-plugins-landscape.md`: new *Notable Plugin Profile* — CC agentic-pipeline plugin (5 role subagents; ADRs as architectural memory, Tasks Plan as goal decomposition); install + key slash commands + config files + env note (none documented).
- **multica** → `docs/non-cc/agent-frameworks-infrastructure-landscape.md` §1: multi-agent orchestration platform across 11 agent CLIs; install + key CLI + browser-auth/no-env note.
- **olmoCR** → `docs/non-cc/web-scraping-extraction-landscape.md` (new *Document OCR pipelines* subsection): AllenAI PDF/image → Markdown/Dolma OCR pipeline as a RAG/KB ingestion front-end; lean install/CLI/flags + upstream link.
- **goose** → `docs/non-cc/goose-analysis.md`: new **Install, CLI & Configuration** section (the prior gap) — `session`/`configure`/`update` + provider/runtime env vars; dates refreshed for the aaif-goose migration.
- **Lenny's Newsletter** → `docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md`: one practitioner-perspective Sources citation.
- `changelog.d/`: scriv fragment.

## Decisions

- Reconciled to landscape-rows (not 3 new standalone files) + lean detail (not mirrored README flag tables) per KISS/DRY pushback.
- Supporting docs: root README / architecture / roadmap / user-story intentionally **untouched** (no per-doc tables; roadmap SSOT = GitHub Issues). No index-count churn (no new files).

## Verification

- `make lint`: 2234 OK; **all 5 added URLs pass**. The single failure is a transient 502 on a pre-existing, untouched link (`github.com/restackio`) — verified valid via WebFetch; left as-is.

## Deferred (follow-up "subjects" pass)

New `goal-tracking-attribution` + `agentic-enterprise-os` landscapes; memory / graph-viz / ontology extensions; cross-subject connections synthesis; qte77-estate worked examples (goals.json, liminal-flux, ralph/learnings-ralphy, office-forge, polyforge).

Generated with Claude <noreply@anthropic.com>
