### PR TITLE
fix: corpus-wide license/count corrections + lychee retry bump

### DIFF
--- a/docs/cc-community/CC-code-tooling-landscape.md
+++ b/docs/cc-community/CC-code-tooling-landscape.md
@@ -4,8 +4,8 @@ purpose: Code-understanding tools that integrate with Claude Code — knowledge 
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-27
-validated_links: 2026-06-27
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Research (informational)
@@ -125,7 +125,7 @@ Cross-ref: [CC-official-plugins-landscape.md](../cc-native/plugins-ecosystem/CC-
 
 ## codebase-memory-mcp (DeusData)
 
-**Repo**: [DeusData/codebase-memory-mcp][codebase-memory-mcp] | **Docs**: [deusdata.github.io][codebase-memory-mcp-docs] | **Stars**: 6.8K | **License**: MIT | **Version**: v0.8.1 (2026-06-12)
+**Repo**: [DeusData/codebase-memory-mcp][codebase-memory-mcp] | **Docs**: [deusdata.github.io][codebase-memory-mcp-docs] | **Stars**: ~19K (2026-06-28) | **License**: MIT | **Version**: v0.8.1 (2026-06-12)
 
 Single static binary that builds a persistent code knowledge graph for agents — no runtime dependencies, no external API. Combines 159 vendored tree-sitter grammars (syntactic parse), a clean-room hybrid-LSP type-resolution layer (Python, TS/JS, PHP, C#, Go, C/C++), and bundled `nomic-embed-code` embeddings (semantic search) into a SQLite-backed graph of typed nodes (Function, Class, Route) and edges (CALLS, IMPORTS, HTTP_CALLS).
 

--- a/docs/cc-community/CC-community-reimplementations-landscape.md
+++ b/docs/cc-community/CC-community-reimplementations-landscape.md
@@ -4,8 +4,8 @@ description: Survey of community reimplementations and educational deconstructio
 category: landscape
 status: research
 created: 2026-04-04
-updated: 2026-06-16
-validated_links: 2026-06-10
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Research (informational)
@@ -171,7 +171,7 @@ Cross-ref: [CC-reverse-engineering-landscape.md](CC-reverse-engineering-landscap
 | [Kuberwastaken/claude-code][claurst] | Spec-derived Rust reimplementation (CLAURST) |
 | [shareAI-lab/learn-claude-code][learn] | Educational harness engineering course |
 | [Gitlawb/openclaude][openclaude] | Multi-provider CLI (leak-derived) |
-| [coder/claudecode.nvim][nvim] | Cleanroom Neovim IDE integration (Lua, Apache-2.0) |
+| [coder/claudecode.nvim][nvim] | Cleanroom Neovim IDE integration (Lua, MIT) |
 | [agentforce314/clawcodex][clawcodex] | Cleanroom Python reimplementation; SWE-bench results, tool inventory, multi-LLM support |
 | leaked-claude-code/leaked-claude-code *(archived — repo deleted/DMCA'd)* | Alleged proprietary source (excluded from analysis) |
 | zackautocracy/claude-code *(account removed/404)* | Source snapshot powering ccunpacked.dev (leak-derived) |

--- a/docs/cc-community/CC-community-tooling-landscape.md
+++ b/docs/cc-community/CC-community-tooling-landscape.md
@@ -5,8 +5,8 @@ category: landscape
 status: research
 platform_scope: [claude-code, cursor, codex, gemini-cli, opencode, windsurf, zed, antigravity]
 created: 2026-03-13
-updated: 2026-06-27
-validated_links: 2026-06-27
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Research (informational)
@@ -220,7 +220,7 @@ Design-systems / format tooling (awesome-design-md, Google Labs DESIGN.md spec +
 | **MemPalace** | Persistent memory | MCP server + plugin marketplace | Verbatim palace-metaphor memory | Active (33.6K stars, v3.0.0) |
 | **MemSearch** | Persistent memory (cross-agent) | Plugin (hooks + skill, no MCP) | Markdown source-of-truth + Milvus hybrid search | Active (~2K stars, v0.4.7) |
 | **Code-Review-Graph** | Structural code analysis | MCP server (22 tools, auto-config) | AST-based blast radius for reviews | Active (7.1K stars) |
-| **codebase-memory-mcp** | Code→graph + LSP + embeddings | MCP (14 tools) + PreToolUse hook + auto-config | Single-binary knowledge graph | Active (3.2K stars, v0.7.0) |
+| **codebase-memory-mcp** | Code→graph + LSP + embeddings | MCP (14 tools) + PreToolUse hook + auto-config | Single-binary knowledge graph | Active (~19K stars, v0.8.1) |
 | **Serena** | Semantic code (live LSP) | MCP server (20+ tools) | Symbol-level retrieve/edit/refactor | Active (25.2K stars, v1.5.3) |
 | **ast-grep MCP** | Structural search/rewrite | MCP server (4 tools) | tree-sitter AST patterns | Experimental (419 stars, no release) |
 | **Repomix** | Repo→single-file context export | MCP server + official CC plugins | tree-sitter compression + token counts | Stable (26.2K stars, v1.14.1) |

--- a/docs/cc-community/CC-memory-tooling-landscape.md
+++ b/docs/cc-community/CC-memory-tooling-landscape.md
@@ -4,8 +4,8 @@ purpose: Persistent cross-session memory tools that integrate with Claude Code �
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-26
-validated_links: 2026-06-26
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Research (informational)
@@ -66,7 +66,7 @@ Cross-ref: [CC-memory-system-analysis.md](../cc-native/context-memory/CC-memory-
 
 ## Claude-Mem (thedotmack / Alex Newman)
 
-**Repo**: [thedotmack/claude-mem][claude-mem] | **Stars**: 45.2K | **License**: AGPL-3.0 | **Version**: 6.5.0
+**Repo**: [thedotmack/claude-mem][claude-mem] | **Stars**: 45.2K | **License**: Apache-2.0 | **Version**: 6.5.0
 
 Persistent memory compression system for Claude Code. Automatically captures everything Claude does during coding sessions, compresses it with AI, and injects relevant context back into future sessions for continuity.
 
@@ -120,7 +120,7 @@ A dedicated observer AI watches each session in real-time, generating searchable
 
 **Strengths**: Largest community memory solution (45.2K stars), progressive disclosure saves tokens, hybrid search (FTS5 + vector), multi-platform (CC + Gemini CLI), web UI for browsing history, [dedicated docs site][claude-mem-docs].
 
-**Risks**: AGPL-3.0 (copyleft — commercial use requires compliance). Ragtime subdirectory under separate PolyForm Noncommercial License. Heavy dependencies (Bun + uv + Chroma). Overlaps with CC's built-in memory system and ByteRover.
+**Risks**: Heavy dependencies (Bun + uv + Chroma). Overlaps with CC's built-in memory system and ByteRover.
 
 Cross-ref: [CC-memory-system-analysis.md](../cc-native/context-memory/CC-memory-system-analysis.md) — CC's native memory for comparison
 

--- a/docs/non-cc/README.md
+++ b/docs/non-cc/README.md
@@ -7,7 +7,7 @@ Standalone analyses of coding agents and orchestration tools beyond Claude Code.
 | Document | Type | Headless | Open Source |
 |---|---|---|---|
 | [air-analysis.md](air-analysis.md) | JetBrains Air (GUI) | No | No |
-| [deerflow-analysis.md](deerflow-analysis.md) | ByteDance DeerFlow (LangGraph) | Yes | Yes (Apache 2.0) |
+| [deerflow-analysis.md](deerflow-analysis.md) | ByteDance DeerFlow (LangGraph) | Yes | Yes (MIT) |
 | [devteam-analysis.md](devteam-analysis.md) | agent-era/devteam (TUI) | No | Yes (MIT) |
 | [omnigent-analysis.md](omnigent-analysis.md) | Omnigent (Databricks/Neon meta-harness; unifies Claude Code, Codex, Pi, custom agents) | Yes | Yes (Apache-2.0) |
 

--- a/docs/non-cc/agent-frameworks-infrastructure-landscape.md
+++ b/docs/non-cc/agent-frameworks-infrastructure-landscape.md
@@ -60,7 +60,7 @@ The field has reframed memory as **context engineering** — assembling persiste
 - [Graphiti (Zep)](https://github.com/getzep/graphiti) — real-time temporal knowledge-graph engine; P95 ~300ms hybrid (vector + BM25 + graph) retrieval, MCP server, Apache-2.0.
 - [Zep](https://github.com/getzep/zep) — memory platform on Graphiti; temporal KG, multi-language SDKs ([paper](https://arxiv.org/abs/2501.13956)).
 - [Mem0](https://github.com/mem0ai/mem0) — universal memory layer; claims +26% vs OpenAI Memory, 90% lower tokens on LOCOMO ([paper](https://arxiv.org/abs/2504.19413)), Apache-2.0.
-- [Cognee](https://github.com/topoteretes/cognee) — open-source KG memory engine, 30+ data types, MCP server; raised $7.5M seed (Feb 2026).
+- [Cognee](https://github.com/topoteretes/cognee) — Apache-2.0 KG memory engine, 30+ data types, MCP server; raised $7.5M seed (Feb 2026).
 - [A-MEM](https://github.com/agiresearch/A-mem) — Zettelkasten-style agentic memory with dynamic linking ([paper](https://arxiv.org/abs/2502.12110)).
 - [LangMem](https://github.com/langchain-ai/langmem) — LangGraph-native semantic/episodic/procedural memory (MIT).
 - [MemoryOS](https://github.com/BAI-LAB/MemoryOS) — hierarchical short/mid/long-term memory OS for personalized agents; +49.11% F1 over baselines on LoCoMo (self-reported), EMNLP 2025 Oral (Apache-2.0).

--- a/docs/non-cc/deerflow-analysis.md
+++ b/docs/non-cc/deerflow-analysis.md
@@ -3,10 +3,11 @@ title: ByteDance DeerFlow Analysis
 source: https://github.com/bytedance/deer-flow
 purpose: Analysis of DeerFlow as an open-source super agent harness for research, coding, and content creation.
 created: 2026-03-25
-updated: 2026-03-25
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
-**Status**: Open-source (Apache 2.0), active development by ByteDance
+**Status**: Open-source (MIT), active development by ByteDance
 
 ## What It Is
 
@@ -67,7 +68,7 @@ tool definitions.
 | Sandboxing | Docker/K8s/local | Filesystem + network | Worktrees/Docker |
 | Multi-agent | Sub-agent spawning | Agent teams | Multi-agent parallel |
 | MCP support | Yes (tools) | Yes (servers) | Planned (ACP) |
-| Open source | Yes (Apache 2.0) | Yes (consumer license) | No |
+| Open source | Yes (MIT) | Yes (consumer license) | No |
 
 ## Action Items
 

--- a/docs/non-cc/goclaw-analysis.md
+++ b/docs/non-cc/goclaw-analysis.md
@@ -4,11 +4,11 @@ source: https://github.com/nextlevelbuilder/goclaw
 purpose: Analysis of GoClaw as a multi-tenant AI agent platform with 8-stage execution pipeline and multi-channel messaging.
 platform_scope: [telegram, discord, slack, zalo, feishu, whatsapp]
 created: 2026-04-09
-updated: 2026-04-09
-validated_links: 2026-04-09
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
-**Status**: Open-source (CC BY-NC 4.0), active development
+**Status**: Source-available (CC BY-NC 4.0 — non-commercial), active development
 
 ## What It Is
 

--- a/docs/non-cc/hermes-agent-analysis.md
+++ b/docs/non-cc/hermes-agent-analysis.md
@@ -4,18 +4,18 @@ source: https://github.com/nousresearch/hermes-agent
 purpose: Analysis of Hermes as a self-improving autonomous agent by Nous Research with multi-platform presence and skill creation.
 platform_scope: [cli, telegram, discord, slack, whatsapp, signal, email, simplex]
 created: 2026-04-09
-updated: 2026-06-27
-validated_links: 2026-06-27
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
-**Status**: Open-source (MIT), active development by [Nous Research][nous] | **Version**: v0.8.0
+**Status**: Open-source (MIT), active development by [Nous Research][nous] | **Version**: v0.17.0
 
 ## What It Is
 
 Hermes is a **self-improving AI agent** by Nous Research that operates
 autonomously across multiple platforms. It features a built-in learning loop for
 autonomous skill creation, persistent user models, and cross-session conversation
-search. Largest agent project in this survey by star count (43.2K).
+search. Largest agent project in this survey by star count (205K+, as of 2026-06-28).
 
 **Key distinction**: Unlike coding-focused agents (CC, Goose) or research agents
 (Feynman), Hermes is a **general-purpose autonomous agent** with multi-platform
@@ -85,10 +85,10 @@ parallel workstreams in isolated contexts.
 | **Self-improvement** | Autonomous skill creation and refinement |
 | **Platforms** | CLI + 6 messaging channels |
 | **Compute** | 6 terminal backends (local → serverless) |
-| **Maturity** | Active (43.2K stars, 5.5K forks, v0.8.0) |
+| **Maturity** | Active (205K+ stars, v0.17.0, 2026-06-19) |
 | **License** | MIT |
 
-**Strengths**: Largest community (43.2K stars). Self-improving skill loop is
+**Strengths**: Largest community (205K+ stars). Self-improving skill loop is
 unique in this survey. Broadest platform coverage (7 channels). 6 compute
 backends from local to serverless. MIT licensed. [Skills Hub][skills-hub] for
 community skill sharing.

--- a/docs/non-cc/omnigent-analysis.md
+++ b/docs/non-cc/omnigent-analysis.md
@@ -67,7 +67,7 @@ Real-time session sharing via URL with comment and steering capabilities for co-
 
 **Technical facts (GitHub, 2026-06-16):**
 
-- Stars: 1.9k
+- Stars: ~5.3k (2026-06-28)
 - Primary language: Python (83.1%), TypeScript (16.2%)
 - Requires Python 3.12+
 - Install: `uv tool install omnigent` or `brew install omnigent-ai/tap/omnigent`

--- a/docs/non-cc/semantic-layers-data-catalog-landscape.md
+++ b/docs/non-cc/semantic-layers-data-catalog-landscape.md
@@ -3,8 +3,8 @@ title: Semantic Layers & Data Catalogs — Agentic Data Access Landscape
 source: https://cube.dev/docs/product/apis-integrations/mcp-server
 purpose: The semantic-layer (consistent metrics) and data-catalog (discovery, lineage, governance) substrate that grounds agentic data access — what each tool exposes to an agent (MCP / SDK / NL query), and how it relates to the agent-native context layers (Databricks Genie Ontology, Open Knowledge Format). Reference catalog verified 2026-06-22.
 created: 2026-06-22
-updated: 2026-06-22
-validated_links: 2026-06-22
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Assess
@@ -26,7 +26,7 @@ Define metrics/dimensions once; query consistently across clients.
 |---|---|---|---|
 | [Cube][cube] | Apache-2.0 (~20k★) | **MCP server** (hosted, OAuth PKCE) + outbound MCP connectors | Most agent-ready of the group; `claude mcp add` documented |
 | [dbt MetricFlow / Semantic Layer][metricflow] | Apache-2.0 (~1.6k★) | JDBC/GraphQL API; community MCP wrappers only | Engine behind dbt Cloud's Semantic Layer; part of the Open Semantic Interchange effort |
-| [Malloy][malloy] | OSS (Google; ~2.5k★) | None official (one community MCP wrapper) | Semantic *query language* compiling to SQL; VS Code-first |
+| [Malloy][malloy] | MIT (Google; ~2.5k★) | None official (one community MCP wrapper) | Semantic *query language* compiling to SQL; VS Code-first |
 | [AtScale][atscale] | Proprietary | Partner [MQO-MCP][atscale-mqo] (typed query grammar) | MQO validates every reference against a live catalog snapshot to block hallucinated SQL — notable agent-safety pattern (early/reference impl) |
 
 ## Catalogs / Metadata / Governance

--- a/docs/non-cc/spec-driven-frameworks-landscape.md
+++ b/docs/non-cc/spec-driven-frameworks-landscape.md
@@ -3,8 +3,8 @@ title: Spec-Driven Frameworks — Landscape
 purpose: Comparison of spec-driven development (SDD) frameworks — GitHub Spec-Kit, OpenSpec, BMAD-METHOD, Agent-OS, Kiro, Tessl — the standalone deep-dive behind the synthesis entry in the agentic-engineering disciplines landscape.
 category: landscape
 created: 2026-06-27
-updated: 2026-06-27
-validated_links: 2026-06-27
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Research (informational)
@@ -19,7 +19,7 @@ By 2026 every major coding tool shipped a **spec-driven development (SDD)** flav
 |---|---|---|---|---|
 | [github/spec-kit][spec-kit] | 115.9K | MIT | Spec → Plan → Tasks → Implement | 30+ agent integrations, 70+ extensions; "intent is the source of truth" |
 | [Fission-AI/OpenSpec][openspec] | 57.1K | MIT | Proposal → Apply → Archive | change-proposal centric; no MCP/keys required |
-| [bmadcode/BMAD-METHOD][bmad] | 49.8K | custom | multi-agent planning → context-engineered dev | role agents (Analyst / PM / Architect) author the spec |
+| [bmadcode/BMAD-METHOD][bmad] | 49.8K | MIT | multi-agent planning → context-engineered dev | role agents (Analyst / PM / Architect) author the spec |
 | [buildermethods/agent-os][agent-os] | 5.0K | MIT | MCP context-injection layer | composes with any SDD framework rather than replacing it |
 | [kirodotdev/Kiro][kiro-repo] | 3.9K | proprietary | requirements → design → tasks "waves" | full IDE; spec phase is mandatory — see [kiro-analysis.md](kiro-analysis.md) |
 | Tessl (`tile`) | ~41 | MIT | "spec-as-source" | the spec, not the code, is the maintained artifact; main framework closed-beta |

--- a/docs/non-cc/web-scraping-extraction-landscape.md
+++ b/docs/non-cc/web-scraping-extraction-landscape.md
@@ -151,7 +151,7 @@ Distinct from the source-specific APIs above: general-purpose OCR/VLM tools that
 
 | Platform | License/Pricing | Differentiator |
 |----------|----------------|----------------|
-| [Steel](https://steel.dev/) | MIT (core); cloud from $29/mo | Sub-second sessions, 24h persistence, anti-bot + CAPTCHA |
+| [Steel](https://steel.dev/) | Apache-2.0 (core); cloud from $29/mo | Sub-second sessions, 24h persistence, anti-bot + CAPTCHA |
 | [Hyperbrowser](https://www.hyperbrowser.ai/) | HyperAgent OSS; cloud from $99/mo | Three-tier API (ai/perform/extract), 10K+ concurrent browsers |
 | [TinyFish](https://www.tinyfish.ai/) | SaaS from $15/mo | Unified search + fetch + browser + agent under one API key |
 | GoWatch | SaaS (YC W25) | AI agent-based web monitoring; pivoting — site down as of 2026-04 |

--- a/docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md
+++ b/docs/sdlc-lcm/agentic-engineering-disciplines-landscape.md
@@ -80,7 +80,7 @@ By 2026 every major coding tool shipped an SDD flavor. Stars verified via `gh ap
 |---|---|---|---|
 | [github/spec-kit][spec-kit] | 114,808 | MIT | Spec → Plan → Tasks → Implement; 30+ agent integrations, 70+ extensions ("intent is the source of truth") |
 | [Fission-AI/OpenSpec][openspec] | 56,043 | MIT | Proposal → Apply → Archive; no MCP/keys required |
-| [bmadcode/BMAD-METHOD][bmad] | 49,513 | NOASSERTION | multi-agent planning (Analyst/PM/Architect) → context-engineered dev |
+| [bmadcode/BMAD-METHOD][bmad] | 49,513 | MIT | multi-agent planning (Analyst/PM/Architect) → context-engineered dev |
 | buildermethods/agent-os | 4,936 | MIT | MCP context-injection layer; pairs with any SDD framework |
 | kirodotdev/Kiro | 3,912 | Proprietary | requirements→design→tasks "waves"; full IDE — see [kiro-analysis.md][kiro-doc] |
 | Tessl (tile) | 41 | MIT | "spec-as-source" (spec is the maintained artifact); main framework closed-beta |

--- a/docs/sdlc-lcm/evaluation-data-resources-landscape.md
+++ b/docs/sdlc-lcm/evaluation-data-resources-landscape.md
@@ -4,8 +4,8 @@ purpose: Catalog of agent/LLM evaluation frameworks, agentic benchmarks, and eva
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-27
-validated_links: 2026-06-27
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Research (informational)
@@ -20,7 +20,7 @@ Observability-first platforms with strong eval features — **LangWatch, Evident
 |---|---|---|---|
 | RAGAs | [github](https://github.com/explodinggradients/ragas) | RAG eval: context precision/recall, faithfulness | — |
 | TruLens | [github](https://github.com/truera/trulens) | RAG Triad + agent feedback functions | — |
-| DeepEval | [github](https://github.com/confident-ai/deepeval) | Pytest-like LLM testing, 14+ metrics | 14+ research-backed metrics |
+| DeepEval | [github](https://github.com/confident-ai/deepeval) | Pytest-like LLM testing, 30+ metrics | 30+ research-backed metrics |
 | Confident AI | [site](https://www.confident-ai.com/) | Enterprise eval platform (DeepEval cloud) | 30+ judge metrics, HIPAA/SOC2 |
 | Giskard | [site](https://www.giskard.ai/) | AI red-teaming / vulnerability detection | — |
 | Patronus AI | [site](https://www.patronus.ai/) | Hallucination detection, custom evaluators | +18% vs OpenAI LLM-judges |

--- a/docs/sdlc-lcm/oss-alm-landscape.md
+++ b/docs/sdlc-lcm/oss-alm-landscape.md
@@ -2,6 +2,7 @@
 title: OSS ALM Landscape
 purpose: Comparison of open-source Application Lifecycle Management tools for potential Phase 3 adoption.
 created: 2026-03-24
+updated: 2026-06-28
 sources:
   - https://www.tuleap.com/alm/
   - https://www.tuleap.com/comparisons/
@@ -19,11 +20,11 @@ Python + docs; Phase 3 may need a UI dashboard or multi-user access.
 
 | Tool | License | Weight | ALM Coverage | CI/CD | Test Mgmt | API |
 |------|---------|--------|-------------|-------|-----------|-----|
-| **Tuleap CE** | GPL | Heavy (PHP) | Full | Jenkins | Built-in | Yes |
-| **OpenProject** | GPL | Heavy (Rails) | Partial (PM) | Limited | Plugins | Yes |
-| **Redmine** | Open | Light (Ruby) | Minimal | Plugins | Plugins | Yes |
+| **Tuleap CE** | GPL-2.0 | Heavy (PHP) | Full | Jenkins | Built-in | Yes |
+| **OpenProject** | GPL-3.0 | Heavy (Rails) | Partial (PM) | Limited | Plugins | Yes |
+| **Redmine** | GPL-2.0 | Light (Ruby) | Minimal | Plugins | Plugins | Yes |
 | **GitLab CE** | MIT | Heavy (Rails) | Partial (DevOps) | Built-in | Limited | Yes |
-| **Zentao** | Open | Medium (PHP) | Good | Limited | Built-in | Yes |
+| **Zentao** | AGPL-3.0 / ZPL-1.2 (non-OSI) | Medium (PHP) | Good | Limited | Built-in | Yes |
 
 ## Fit Assessment
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -13,8 +13,11 @@ exclude_path = ["triage/", "docs/archive/", "docs/research/rxiv-agentic-papers.m
 accept = [200, 204, 429, 405, 418, 202, 415]
 
 # Retry transient failures (GitHub 502s, network blips) — see AGENT_LEARNINGS.md
-max_retries = 3
-retry_wait_time = 2
+# Bumped 3->5 retries / 2->3s wait (2026-06-28): GitHub 5xx windows recurred and
+# blocked PRs even with 3 retries. NOT accepting 502 as success — that would mask
+# real outages; a sustained outage still needs a CI re-run.
+max_retries = 5
+retry_wait_time = 3
 
 # Per-link timeout in seconds (lychee default: 20). Several genuinely-slow hosts
 # (apmdigest.com, techsy.io, qa.allen.ai, e2b.dev, finance.biggo.com, …) time out


### PR DESCRIPTION
## Summary

Corpus-wide license/count audit (5 Sonnet subagents over docs/), with the surprising/contradicting claims re-verified by me against first-party LICENSE/README before applying. The multica slop (#343) was not unique — found and fixed similar mislabels across the corpus.

## Wrong licenses fixed (first-party verified)

| Tool | Doc | Was | Now |
|---|---|---|---|
| **DeerFlow** | deerflow-analysis + non-cc/README | Apache 2.0 | **MIT** |
| **claude-mem** | CC-memory-tooling | AGPL-3.0 (+ false ragtime/PolyForm note) | **Apache-2.0** |
| **Steel** | web-scraping | MIT (core) | **Apache-2.0 (core)** |
| **claudecode.nvim** | reimplementations (Sources) | Apache-2.0 | **MIT** (matched the doc's own overview table) |
| **Malloy** | semantic-layers | OSS | **MIT** |
| **BMAD-METHOD** | spec-driven + disciplines | `custom` / `NOASSERTION` | **MIT** (×2 docs) |
| **Cognee** | agent-frameworks | "open-source" | **Apache-2.0** |
| **GoClaw** | goclaw badge | Open-source (CC BY-NC 4.0) | **Source-available** (CC BY-NC is non-OSI) |
| **Redmine / Zentao / OpenProject / Tuleap** | oss-alm | `Open` / `GPL` | **GPL-2.0 / AGPL-3.0+ZPL / GPL-3.0 / GPL-2.0** |

## Drifted counts fixed

- **Hermes Agent**: 43.2K→**205K** stars, v0.8.0→**v0.17.0** (verified).
- **codebase-memory-mcp**: 6.8K & 3.2K (two docs disagreed) → **~19K**, v0.7.0→v0.8.1.
- **omnigent**: 1.9k→~5.3k. **DeepEval**: 14+→30+ metrics.

## Not changed (deliberately)
- **Magnitude** browser-agent license: monorepo has no findable root LICENSE; left as-is rather than regress a possibly-correct label. Flagged for a package-level check.

## Plus
- `lychee.toml`: bumped retries 3→5 / wait 2→3s for transient GitHub 5xx (no `accept=502` — that would mask real outages).

## Verification
`make lint` → **0 lychee errors, 0 markdownlint errors**.

Generated with Claude <noreply@anthropic.com>
