### PR TITLE
docs: point CONTRIBUTING to the knowledge-graph publish flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,10 +221,13 @@ make setup_all   # install lychee, Node.js (user-local), markdownlint-cli2
 make lint        # run lychee + markdownlint-cli2 over the full repo
 make autofix     # mechanical markdownlint --fix pass
 make test        # unit tests for src/ + .github/scripts/lib/ modules (stdlib unittest)
+make graph-page  # rebuild + restyle the knowledge graph into committed ui/graph.html (then commit to publish)
 make help        # list all recipes grouped by section
 ```
 
 Run `make lint` against any PR that touches docs before requesting review. `lychee` reads `lychee.toml`; `markdownlint-cli2` reads `.markdownlint.json`.
+
+**Knowledge graph:** the corpus knowledge graph is rebuilt on-demand via the `/graphify` skill (uses the session as the extraction model — no LLM key in CI), then `make graph-page` restyles it into the committed `ui/graph.html`; pushing that to `main` redeploys the Pages site. Full flow + rationale: [architecture.md §Knowledge Graph](docs/architecture.md#knowledge-graph-graphify).
 
 ## Commit & PR
 


### PR DESCRIPTION
Discoverability fix: adds `make graph-page` to the Local-development recipe list + a one-line cross-ref to `architecture.md` §Knowledge Graph, so the graphify → `ui/graph.html` → gh-pages flow is findable from the contributor entry point.

No workflow change — the key-free-CI design is intentional and already documented in architecture.md.

Generated with Claude <noreply@anthropic.com>