### PR TITLE
docs: add goal-tracking & attribution landscape (sdlc-lcm)

### DIFF
--- a/changelog.d/20260628_130000_docs_goal_tracking_attribution_landscape.md
+++ b/changelog.d/20260628_130000_docs_goal_tracking_attribution_landscape.md
@@ -1,0 +1,3 @@
+### Added
+
+- `docs/sdlc-lcm/goal-tracking-attribution-landscape.md`: NEW landscape — the top-down goal→spec→build→learning attribution loop, with the qte77 estate as the worked reference (`qte77/qte77` `goals.json` OKR schema + `cto-handbook-mapping.md`; `liminal-flux-gh-acc` per-run `performance-log.jsonl` tracing + cost gates; `research-ralphy` research→PRD attribution; ralph-loop `prd.json` story tracking) and the commercial OKR/PM baseline (Jira Align, WorkBoard/Quantive, Tability, Productboard, LinearB) it diverges from — none agent-native despite the 2026 MCP-access layer. Status: Assess.

--- a/docs/sdlc-lcm/README.md
+++ b/docs/sdlc-lcm/README.md
@@ -27,6 +27,7 @@ Lifecycle management specs for the qte77 coding agent ecosystem.
 | [oss-alm-landscape.md](oss-alm-landscape.md) | OSS ALM tool comparison (Tuleap, OpenProject, Redmine, GitLab) |
 | [agentic-sdlc-patterns.md](agentic-sdlc-patterns.md) | Emerging patterns: ADLC, Agentic SDLC, Spec-Driven Development |
 | [agentic-engineering-disciplines-landscape.md](agentic-engineering-disciplines-landscape.md) | Synthesis: "-engineering" disciplines (prompt→spec) + "-driven-dev" methodologies (TDD→EDD→SDD) in a five-layer credo stack |
+| [goal-tracking-attribution-landscape.md](goal-tracking-attribution-landscape.md) | Top-down goals → bottom-up attribution: the goal→spec→build→learning loop, qte77-estate worked examples, and the commercial OKR/PM baseline |
 | [multi-agent-onboarding-outlook.md](multi-agent-onboarding-outlook.md) | Multi-agent support: CC, Kiro, Cursor, Gemini CLI, AGENTS.md convergence |
 | [mas-design-principles.md](mas-design-principles.md) | MAS design principles from 12-Factor Agents, Anthropic harnesses, PydanticAI |
 | [mas-benchmarking-best-practices.md](mas-benchmarking-best-practices.md) | Production best practices for MAS development and benchmarking |

--- a/docs/sdlc-lcm/goal-tracking-attribution-landscape.md
+++ b/docs/sdlc-lcm/goal-tracking-attribution-landscape.md
@@ -1,0 +1,112 @@
+---
+title: Goal Tracking & Attribution Landscape
+purpose: How an agentic coding fleet ties work back to stated goals — the top-down goal→spec→build→learning cascade and the bottom-up attribution of every feature, PR, and agent run to the goal that motivated it — with the qte77 estate as the worked reference and the commercial OKR/PM tooling baseline it diverges from.
+category: landscape
+created: 2026-06-28
+updated: 2026-06-28
+validated_links: 2026-06-28
+---
+
+**Status**: Assess
+
+## What It Is
+
+A map of how an agentic coding fleet connects day-to-day work back to stated goals: the **top-down** `goal → spec → build → learning` cascade, and the **bottom-up attribution** that traces every feature, PR, and agent run to the goal that motivated it. Where the [agentic-engineering-disciplines landscape][disciplines] frames *goals, specs, builds, and learnings compound instead of drift* as a credo, this doc is the **goals anchor** of that credo made concrete: what a machine-writable goal store looks like, how runs are attributed to goals, and how the loop closes.
+
+**Status Assess** because the estate implementations are early (v0.x schemas, some stores still empty) and the mature commercial OKR/PM tooling does not yet fill the agent-native gap — see the baseline contrast below.
+
+## The agentic attribution loop
+
+The qte77 estate's `docs/architecture.md` ([qte77/qte77][qte77]) states the loop in one line: **"goals feed specs, specs feed builds, builds emit learnings, learnings flow back into the next goals."** Read top-down it is goal decomposition; read bottom-up it is attribution — every spec traces to a goal, every build to a spec, every learning to a build.
+
+```text
+              top-down decomposition  →
+   Goals ───→ Specs ───→ Builds ───→ Learnings
+     ↑                                    │
+     └──  ←  bottom-up attribution + reflect  ──┘
+```
+
+Two control points recur (the estate credo): **agents drive** the decomposition and tracing machinery; **humans approve and steer** the goals themselves — *"agents propose, humans decide."*
+
+## Estate worked examples
+
+The substance of this landscape is four first-party implementations at different points on the loop. (Files are named in backticks; links point at the public repo roots.)
+
+### qte77/qte77 — the goal store and OKR home
+
+[qte77/qte77][qte77] is the meta-orchestration repo:
+
+- `goals.json` — a minimal machine-writable OKR schema (v0.1.0). It currently holds `goals: []`; the human→agent handoff boundary is explicit (humans set goals, orchestrators read them), and the array stays empty until a cockpit/dashboard consumer pressure-tests the schema.
+- `docs/cto-handbook-mapping.md` — the OKR home: it maps the [Startup CTO Handbook][cto-map]'s "OKRs / measuring success" chapter onto `goals.json`, under the same *"agents propose, humans decide"* boundary.
+- `docs/architecture.md` — states the `goals → specs → builds → learnings` loop above.
+
+### liminal-flux-gh-acc — a self-operating account with per-run attribution
+
+[liminal-flux-gh-acc][liminal] is an 8-agent-role self-operating GitHub account. Its `docs/living-github-account.md` documents four mechanisms that close the loop with cost-gated tracing:
+
+1. **Inbound goals** — `repository_dispatch` events land in a `state/goals.json` registry.
+2. **Idle discovery** — when the work queue is empty, a heartbeat generates a new goal, so the account never sits idle.
+3. **Per-run tracing** — every agent run appends to `state/performance-log.jsonl` with `goal_id`, `task_id`, `agent`, `model`, `tokens_in`/`tokens_out`, `cost_usd`, and `outcome`: the bottom-up attribution record.
+4. **Reflector loop** — a daily pass over a 7-day window of the performance log opens improvement Issues and updates `agent-memory.md`, feeding learnings back into the next goals.
+
+Cost gates bound the autonomy: a ~$5/day hard stop, a `>2×` spend-spike notification, and a `>30%` failure rate routed to a `human-required` label. This is the [agentic-sdlc-patterns][sdlc-patterns] ADLC **Observe → Correct** phase — flagged there as a gap — instantiated.
+
+### research-ralphy — research → PRD attribution
+
+[research-ralphy][research-ralphy]'s `config/prd-generation-prompt.md` chains a research finding → a top-3-to-5 selection → `docs/PRD.md` → `generate_prd_json.py` → a `prd.json` of stories carrying acceptance criteria and target files. Every story is traceable back to the discovery that motivated it.
+
+### ralph-loop template — story-level status tracking
+
+The [ralph-loop-cc-tdd-wt-vibe-kanban-template][ralph-loop]'s `ralph/README.md` defines the `prd.json` story record: `id`, `depends_on`, `acceptance`, `files`, `status` (pending → in_progress → passed/failed), and `wave`. Durable state lives in `prd.json` + `progress.txt` + `LEARNINGS.md` + git commits — no database; the repo *is* the attribution ledger.
+
+## Traditional baseline (brief contrast)
+
+The mature commercial tools target this space, but from the human-ceremony side:
+
+| Tool | Layer | Goal model |
+|---|---|---|
+| [Jira Align][jira-align] (Atlassian) | enterprise portfolio | strategic themes / OKRs cascade to stories; SAFe PI-planning ceremonies |
+| [WorkBoard][workboard] (acquired Quantive / ex-Gtmhub, 2025) | strategy execution | OKR cascade + executive business reviews; human check-in cadence |
+| [Tability][tability] (independent) | lightweight OKR | weekly check-in rituals, manual UI |
+| [Productboard][productboard] | product discovery | customer feedback → prioritized features → roadmap; human insight votes |
+| [LinearB][linearb] | engineering metrics | DORA / cycle-time from Jira + Git; assumes a human author per PR |
+
+**The 2026 wrinkle — and the gap it leaves.** These tools now ship MCP servers (Atlassian's [Rovo MCP Server][atlassian-mcp] is GA; Jira, Productboard, and Linear all expose MCP endpoints), so an agent *can* read and write their work items. But MCP bolts agent **access** onto a human-authored, UI-first goal model — it does not make the goal store machine-native. None expose what the estate pattern needs: a machine-writable goal schema that agents author, a per-run `cost_usd` + `outcome` attribution row, autonomous idle-discovery goal generation, or a spend-based kill switch. As with the [OSS ALM landscape][oss-alm], the verdict is **none fit the agent-native need** — they instrument human goal-setting, not autonomous goal attribution.
+
+## Connections
+
+- [agentic-engineering-disciplines-landscape.md][disciplines] — this doc is the **goals** anchor of the credo's compound loop (its Layer 5, *Compound*).
+- [agentic-sdlc-patterns.md][sdlc-patterns] — the reflector loop + cost gates instantiate the ADLC **Observe → Correct** phase the patterns doc flags as a gap.
+- [Startup CTO Handbook → qte77 mapping][cto-map] — the traditional human-OKR baseline the estate maps its `goals.json` onto.
+- The enterprise "self-operating account / agent-OS" layer around liminal-flux's 8-role account is a sibling subject (a dedicated `non-cc` enterprise-OS landscape is the natural follow-up).
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [qte77/qte77][qte77] | `goals.json` OKR schema, `docs/cto-handbook-mapping.md` (OKR home), `docs/architecture.md` (the goals→specs→builds→learnings loop) |
+| [liminal-flux-gh-acc][liminal] | `docs/living-github-account.md` — inbound goals, idle discovery, `performance-log.jsonl` per-run tracing, reflector loop, cost gates |
+| [research-ralphy][research-ralphy] | `config/prd-generation-prompt.md` — research-finding → PRD → `prd.json` story attribution |
+| [ralph-loop-cc-tdd-wt-vibe-kanban-template][ralph-loop] | `ralph/README.md` — `prd.json` story record (id/depends_on/acceptance/files/status/wave) |
+| [Jira Align][jira-align] | Enterprise portfolio: strategy→execution, OKR hub, SAFe |
+| [WorkBoard][workboard] | Enterprise strategy execution / OKR (absorbed Quantive, ex-Gtmhub, 2025) |
+| [Tability][tability] | Lightweight independent OKR / goal check-ins |
+| [Productboard][productboard] | Product discovery: feedback → prioritized features → roadmap |
+| [LinearB][linearb] | Engineering delivery metrics (DORA, cycle time) over Jira + Git |
+| [Atlassian Rovo MCP Server][atlassian-mcp] | First-party evidence of the 2026 MCP-access layer over a human-authored goal model |
+| [Startup CTO Handbook → qte77 mapping][cto-map] | Traditional human-OKR baseline mapped onto `goals.json` |
+
+[qte77]: https://github.com/qte77/qte77
+[liminal]: https://github.com/qte77/liminal-flux-gh-acc
+[research-ralphy]: https://github.com/qte77/research-ralphy
+[ralph-loop]: https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template
+[cto-map]: https://github.com/qte77/qte77/blob/main/docs/cto-handbook-mapping.md
+[jira-align]: https://www.atlassian.com/software/jira/align
+[workboard]: https://www.workboard.com/
+[tability]: https://www.tability.io/
+[productboard]: https://www.productboard.com/
+[linearb]: https://linearb.io/
+[atlassian-mcp]: https://www.atlassian.com/platform/remote-mcp-server
+[disciplines]: agentic-engineering-disciplines-landscape.md
+[sdlc-patterns]: agentic-sdlc-patterns.md
+[oss-alm]: oss-alm-landscape.md


### PR DESCRIPTION
## What

NEW `docs/sdlc-lcm/goal-tracking-attribution-landscape.md` — **PR A** of Pass 2 (subject-strengthening). Covers the top-down `goal → spec → build → learning` cascade and the bottom-up attribution of every feature/PR/agent-run back to its goal.

- **Estate worked examples** (the substance) — `qte77/qte77` `goals.json` OKR schema + `cto-handbook-mapping.md` + the `architecture.md` loop; `liminal-flux-gh-acc` per-run `performance-log.jsonl` tracing + reflector loop + cost gates; `research-ralphy` research→PRD attribution; `ralph-loop-…` `prd.json` story tracking.
- **Traditional baseline** (brief contrast, oss-alm style) — Jira Align, WorkBoard (absorbed Quantive/ex-Gtmhub, 2025), Tability, Productboard, LinearB. Verdict: **none agent-native** despite the 2026 MCP-access layer (Atlassian Rovo MCP is GA) — they instrument human goal-setting, not autonomous attribution.
- Status: **Assess**. `sdlc-lcm/README.md` index row + changelog fragment added.

## Verification

- **Adversarial check against the live estate repos** (read-only subagent) caught and fixed three slop errors before commit: `qte77#67` is *not* the cockpit-consumer issue (dropped the number); `performance-log.jsonl` uses `tokens_in`/`tokens_out` (not `tokens`); the reflector runs **daily** with a 7-day lookback (not a 7-day cadence).
- Baseline facts re-verified first-party (WorkBoard↔Quantive acquisition; Atlassian Rovo MCP GA; Jira Align product page).
- `make lint` green locally: lychee **0 errors** (2248 OK), markdownlint **0 errors**.
- All estate links use public `github.com/qte77/<repo>` roots (all repos confirmed public).

## Ancillary docs

Per CONTRIBUTING + a repo sweep: root `README.md`, `architecture.md`, `cc-native/README.md` doc-count, and roadmap/userstory docs (none exist; backlog = GitHub Issues) **need no update** for an sdlc-lcm doc addition. Only the subdir README index row + changelog fragment apply.

Related: frontmatter-convention tracking issue #348.

Generated with Claude <noreply@anthropic.com>
