### PR TITLE
docs: extend frameworks (memory + graph-viz) & semantic-layers (ontologies)

### DIFF
--- a/changelog.d/20260628_150000_docs_extend_landscapes_pass2.md
+++ b/changelog.d/20260628_150000_docs_extend_landscapes_pass2.md
@@ -1,0 +1,5 @@
+### Added
+
+- `docs/non-cc/agent-frameworks-infrastructure-landscape.md` (§4): **estate file-based compound-learning memory** bullet — plain-Markdown `CLAUDE.md`/`AGENT_LEARNINGS.md`/`LEARNINGS.md` as durable git-versioned agent memory with an explicit promotion path, distilled cross-repo by `learnings-ralphy`; the filesystem-as-memory complement to the graph/vector memory engines.
+- `docs/non-cc/agent-frameworks-infrastructure-landscape.md` (§7): new **Graph visualization** subsection — vis-network, D3.js, Cytoscape.js, Sigma.js, Gephi, PyGraphistry/Graphistry, Neo4j Bloom/Browser (licenses verified first-party; this repo's `ui/graph.html` is the vis-network worked example).
+- `docs/non-cc/semantic-layers-data-catalog-landscape.md`: new **Formal Ontologies & Semantic Web** section — RDF/OWL/SKOS/SPARQL/SHACL, open- vs closed-world, and the connect/exclude/enhance framing vs LLM-embedded KGs.

--- a/docs/non-cc/agent-frameworks-infrastructure-landscape.md
+++ b/docs/non-cc/agent-frameworks-infrastructure-landscape.md
@@ -67,6 +67,7 @@ The field has reframed memory as **context engineering** — assembling persiste
 - [EverOS (EverMind-AI)](https://github.com/EverMind-AI/EverOS) — **Markdown-native, local-first** portable memory layer (9.4K★, Apache-2.0): plain Markdown files as source of truth over a SQLite + LanceDB hybrid index, file-watch cascade sync, multimodal ingest (text/image/PDF/audio/office), LLM-driven extraction/ranking, and an OpenAI-compatible endpoint; user-owned and self-evolving across apps — a files-first contrast to Mem0's graph-first and MemoryOS's hierarchical designs.
 - [Gulp.ai (Osmosis)](https://docs.gulp.ai/introduction) — agent-improvement API enriching prompts with past-interaction knowledge.
 - [ACE — Agentic Context Engine (Kayba)](https://github.com/kayba-ai/agentic-context-engine) — self-improving context layer: a three-role loop (Agent / Reflector / SkillManager) curates a persistent "Skillbook" of strategies that evolves with every task, so agents stop repeating mistakes without fine-tuning or a vector DB (Apache-2.0, [paper](https://arxiv.org/abs/2510.04618)). PydanticAI-based; ships an MCP server (`ace-mcp`) and a Claude Code runner. Offline benchmark-driven counterpart: autoharness (§3).
+- [learnings-ralphy (qte77 estate)](https://github.com/qte77/learnings-ralphy) — **file-based compound-learning memory**, the filesystem-as-memory complement to the graph/vector engines above: plain-Markdown `CLAUDE.md` + `AGENT_LEARNINGS.md` / `LEARNINGS.md` as durable, git-versioned agent memory with an explicit promotion path (inline fix → `AGENT_LEARNINGS.md` → always-loaded `.claude/rules/` → skills). `learnings-ralphy` distills these **across the whole repo estate** on a weekly loop (synthesize → PRD → TDD → write-back PR). EverOS (above) is the productized markdown-native analog; the trade-off vs the graph engines is recall (grep/LLM over files) for zero infra and full git auditability.
 
 ## 5. Foundation Models for Agents
 
@@ -136,6 +137,18 @@ Retrieval is the sibling of memory (§4): §4 persists evolving agent *state*; t
 - [RAGAs](https://github.com/explodinggradients/ragas) — reference-free metrics (faithfulness, answer relevancy, context precision/recall) via LLM-as-judge (Apache-2.0; [arXiv:2309.15217](https://arxiv.org/abs/2309.15217)).
 - [TruLens](https://github.com/truera/trulens) — OTel tracing + LLM-as-judge feedback with agentic evaluators (MIT).
 - [DeepEval](https://github.com/confident-ai/deepeval) — pytest-style LLM-output tests: RAG metrics + G-Eval + hallucination detection (Apache-2.0). Eval cross-ref: [evaluation-data-resources-landscape.md](../sdlc-lcm/evaluation-data-resources-landscape.md).
+
+### Graph visualization
+
+The post-retrieval / analysis layer: once a GraphRAG pipeline or knowledge graph (the GraphRAG family above) is built, these render it for inspection. JS browser libraries dominate for embeddable / static-site graphs; desktop and GPU tools handle large-scale exploration. Licenses verified first-party 2026-06-28.
+
+- [vis-network](https://github.com/visjs/vis-network) — force-directed interactive renderer with physics layout out of the box (dual **Apache-2.0 OR MIT**); this repo's own knowledge graph ships as a static `ui/graph.html` rendered by vis-network (graphify output).
+- [D3.js](https://github.com/d3/d3) — low-level SVG/Canvas toolkit (**ISC**, formerly BSD); maximal control, but you author the force-simulation and layout yourself — not a drop-in graph renderer.
+- [Cytoscape.js](https://github.com/cytoscape/cytoscape.js) — graph-theory library with built-in layouts for browser + Node (**MIT**); strong for biological / network analysis.
+- [Sigma.js](https://github.com/jacomyal/sigma.js) — WebGL-accelerated renderer for large graphs in the browser (**MIT**).
+- [Gephi](https://github.com/gephi/gephi) — open-source desktop graph-analysis app (**GPL-3.0**; some NetBeans modules CDDL); ForceAtlas2 layout + interactive exploration for big static graphs.
+- [PyGraphistry](https://github.com/graphistry/pygraphistry) — **BSD-3-Clause** Python client that pushes data to a **Graphistry** GPU server whose rendering engine is **commercial / closed** (open-core: the client alone is just data-shaping).
+- [Neo4j Bloom](https://neo4j.com/product/bloom/) — codeless graph-exploration UI bundled with Neo4j; **freemium** (local DB only — remote/sharing/perspectives require paid Neo4j Enterprise). OSS alternative: [Neo4j Browser](https://github.com/neo4j/neo4j-browser) (**GPL-3.0** Cypher IDE).
 
 ## 8. Output Validation, Guardrails & Verification
 

--- a/docs/non-cc/semantic-layers-data-catalog-landscape.md
+++ b/docs/non-cc/semantic-layers-data-catalog-landscape.md
@@ -41,6 +41,25 @@ Discovery, lineage, ownership, and permissions across the data estate.
 | [Apache Atlas][atlas] | Apache-2.0 (~2.1k★) | None (pre-MCP; REST only) | Hadoop-era lineage backend; no LLM-facing surface |
 | [Google Dataplex / Universal Catalog][dataplex] | Proprietary (Google) | Gemini NL querying; underpins the OKF reference impl | Managed GCP governance + metadata |
 
+## Formal Ontologies & Semantic Web
+
+Before LLM-embedded knowledge graphs, the W3C Semantic Web stack formalized machine-readable meaning. These standards predate agents but increasingly **connect to, are excluded by, or enhance** the LLM-native layers below:
+
+- **[RDF][rdf]** — subject–predicate–object triples; the base data model for graph-structured facts.
+- **[OWL][owl]** — Web Ontology Language: classes, properties, and logical constraints enabling automated inference (open-world assumption — unstated ≠ false).
+- **[SKOS][skos]** — lightweight taxonomy/thesaurus vocabulary (broader/narrower/related) for concept schemes; the pragmatic middle between flat tags and a full OWL ontology.
+- **[SPARQL][sparql]** — the query language for RDF graphs (the "SQL of the Semantic Web"); an MCP-wrappable agent surface alongside the catalogs above.
+
+**Open- vs closed-world.** OWL/RDF assume an *open world* (absent ≠ false), which fits the web's incompleteness but makes hard validation awkward; [SHACL][shacl] adds closed-world *shape* constraints for validation. SQL catalogs and most semantic layers above are closed-world — an agent reasoning across both must know which regime applies.
+
+**connect / exclude / enhance** — how formal ontologies relate to the LLM-embedded KGs (Genie Ontology, GraphRAG) and the catalog/semantic layers above:
+
+- **Connect** — an existing OWL/SKOS ontology can seed or constrain an LLM KG's entity/relation types instead of extracting them from scratch; a SPARQL endpoint is a queryable tool surface (MCP-wrappable) next to the catalogs above.
+- **Exclude** — for many agent tasks full OWL reasoning is overkill: LLMs approximate semantic relations statistically, and a heavyweight ontology adds authoring/maintenance cost without payoff; the pragmatic stack often stops at SKOS + a catalog.
+- **Enhance** — where correctness must be *provable* (compliance, finance, clinical), formal ontologies + SHACL give the deterministic backbone probabilistic LLM KGs lack; the two compose (LLM for recall/extraction, ontology for precision/validation).
+
+This is the formal-semantics counterpart to [The Agent-Native Layer](#the-agent-native-layer) below: Genie Ontology and OKF are the *LLM-native* curation of the same verified business meaning that OWL/SKOS encode *formally*.
+
 ## The Agent-Native Layer
 
 The generic layers above solve the *plumbing* — governed APIs an agent can query. But an agent hitting a raw semantic API still re-derives business meaning on every call (and can still get it wrong). Two efforts go further, and are analyzed in depth elsewhere in this repo:
@@ -69,6 +88,7 @@ Together they mark the shift from "query the catalog at runtime" to "pre-loaded,
 | [Unity Catalog OSS][unity-catalog] | LF open catalog + `unitycatalog-ai` SDK |
 | [Apache Atlas][atlas] | Hadoop-era governance framework |
 | [Google Dataplex][dataplex] | GCP governance/metadata + Gemini |
+| [RDF][rdf] · [OWL][owl] · [SKOS][skos] · [SPARQL][sparql] · [SHACL][shacl] | W3C Semantic Web standards — formal ontologies, query, validation; open- vs closed-world; connect/exclude/enhance vs LLM KGs |
 
 [cube]: https://cube.dev/docs/product/apis-integrations/mcp-server
 [metricflow]: https://github.com/dbt-labs/metricflow
@@ -81,3 +101,8 @@ Together they mark the shift from "query the catalog at runtime" to "pre-loaded,
 [unity-catalog]: https://github.com/unitycatalog/unitycatalog
 [atlas]: https://github.com/apache/atlas
 [dataplex]: https://cloud.google.com/dataplex
+[rdf]: https://www.w3.org/RDF/
+[owl]: https://www.w3.org/OWL/
+[skos]: https://www.w3.org/2004/02/skos/
+[sparql]: https://www.w3.org/TR/sparql11-overview/
+[shacl]: https://www.w3.org/TR/shacl/


### PR DESCRIPTION
## What

**PR C** of Pass 2 — three landscape extensions, **no new files**:

1. **`agent-frameworks-infrastructure-landscape.md` §4** — estate **file-based compound-learning memory** bullet: plain-Markdown `CLAUDE.md`/`AGENT_LEARNINGS.md`/`LEARNINGS.md` as durable, git-versioned agent memory with a promotion path (inline → `AGENT_LEARNINGS.md` → `.claude/rules/` → skills), distilled cross-repo by `learnings-ralphy` on a weekly loop. The filesystem-as-memory complement to the ACE/Mem0/Graphiti engines already listed.
2. **`agent-frameworks-infrastructure-landscape.md` §7** — new **Graph visualization** subsection: vis-network, D3.js, Cytoscape.js, Sigma.js, Gephi, PyGraphistry/Graphistry, Neo4j Bloom/Browser. The post-retrieval/analysis layer over the GraphRAG family above; this repo's `ui/graph.html` is the vis-network worked example.
3. **`semantic-layers-data-catalog-landscape.md`** — new **Formal Ontologies & Semantic Web** section between Catalogs and the Agent-Native Layer: RDF/OWL/SKOS/SPARQL/SHACL, open- vs closed-world, and the **connect / exclude / enhance** framing vs LLM-embedded KGs (Genie Ontology, GraphRAG).

## Verification

- **Graph-viz licenses adversarially verified first-party** (GitHub LICENSE files), catching several stale/marketing claims: vis-network is **Apache-2.0 OR MIT** (dual, not ISC), D3 is **ISC** (not BSD), **PyGraphistry is BSD-3** while the Graphistry server is commercial/closed (open-core), Neo4j Bloom is **freemium** (local-only free), Gephi GPL-3.0.
- **Estate memory facts verified against live repos**: `learnings-ralphy` does weekly cross-repo LEARNINGS distillation (synthesize → PRD → TDD → write-back PR); the promotion path lives in `.claude/rules/compound-learning.md`.
- `make lint` clean for all touched files. (One unrelated transient `503` on `ampcode.com/pricing` in the pre-existing `amp-analysis.md` — not introduced here; will re-run if it recurs in CI.)
- No index-row/changelog-beyond-fragment churn — extensions only, per the documented maintenance rules for `non-cc/`.

Pass 2 chain: PR A #349 (merged), PR B #350 (merged), this is PR C. PR D (connections synthesis) follows. Frontmatter issue #348.

Generated with Claude <noreply@anthropic.com>
