### PR TITLE
docs: weave Pass 2 cross-subject connections (synthesis)

### DIFF
--- a/changelog.d/20260628_160000_docs_connections_synthesis_pass2.md
+++ b/changelog.d/20260628_160000_docs_connections_synthesis_pass2.md
@@ -1,0 +1,4 @@
+### Changed
+
+- `docs/sdlc-lcm/goal-tracking-attribution-landscape.md`: added a **substrate-thread** synthesis (file/graph/vector memory → KG/GraphRAG/visualization → ontology/semantic-layer → goal graph → enterprise-OS) and a bidirectional cross-ref to the new enterprise-OS landscape; corrected liminal-flux to "six action roles across an 8-phase progression".
+- Pass 2 connections wiring: `multi-agent-onboarding-outlook.md` and `agent-frameworks-infrastructure-landscape.md` now cross-ref `ag-ui-protocol-landscape.md` (the MCP / A2A / AG-UI protocol triangle); `codex-cli-analysis.md` and `gemini-cli-analysis.md` now cross-ref the `AGENTS.md`/`GEMINI.md` convergence in `multi-agent-onboarding-outlook.md`; `CC-community-tooling-landscape.md` cross-refs Superpowers from the everything-claude-code entry.

--- a/docs/cc-community/CC-community-tooling-landscape.md
+++ b/docs/cc-community/CC-community-tooling-landscape.md
@@ -136,6 +136,8 @@ Layered system: skills compose into agents, agents are dispatched by command shi
 - Shim commands may shadow custom slash commands
 - Quality varies across 156 skills — not all independently validated
 
+Cross-ref: [CC-community-skills-landscape.md](CC-community-skills-landscape.md) (§ Superpowers) — the closest peer at equivalent scale (~135K★), methodology-first vs. this collection's framework-first packaging.
+
 ---
 
 ## Boucle Read-Once Framework

--- a/docs/non-cc/agent-frameworks-infrastructure-landscape.md
+++ b/docs/non-cc/agent-frameworks-infrastructure-landscape.md
@@ -191,6 +191,7 @@ Validation is the post-generation sibling of retrieval (§7): enforcing that age
 - [agent-observability-methods-analysis.md](agent-observability-methods-analysis.md) — observability/tracing platforms (separate restore)
 - [research-agents-landscape.md](research-agents-landscape.md) — research/discovery agents
 - [ai-security-governance-analysis.md § MCP Ecosystem Security](../sdlc-lcm/ai-security-governance-analysis.md#mcp-ecosystem-security) — MCP server threat model
+- [ag-ui-protocol-landscape.md](ag-ui-protocol-landscape.md) — the MCP / A2A / AG-UI protocol-interop triangle these frameworks implement
 
 [12fa-blog]: https://www.hlyr.dev/blog/12-factor-agents
 [12fa-gh]: https://github.com/humanlayer/12-factor-agents

--- a/docs/non-cc/codex-cli-analysis.md
+++ b/docs/non-cc/codex-cli-analysis.md
@@ -3,8 +3,8 @@ title: OpenAI Codex CLI (Terminal Agent)
 source: https://github.com/openai/codex
 purpose: Evaluate Codex CLI as an interactive and headless terminal coding agent, distinct from the cloud Codex environment.
 created: 2026-06-16
-updated: 2026-06-16
-validated_links: 2026-06-16
+updated: 2026-06-28
+validated_links: 2026-06-28
 platform_scope: [openai, cli, vscode, cursor, windsurf]
 ---
 
@@ -68,7 +68,7 @@ Codex detects the folder context automatically: version-controlled projects get 
 - **Subagent parallelisation**: explicit fan-out for parallel subtasks (extra token cost)
 - **MCP support**: connect STDIO or streaming-HTTP MCP servers via `config.toml`; launched automatically
 - **Session resume**: `codex resume` restores prior conversation and repository state
-- **AGENTS.md**: honours `AGENTS.md` files for custom per-project instructions ([agents-md][agents-md])
+- **AGENTS.md**: honours `AGENTS.md` files for custom per-project instructions ([agents-md][agents-md]); cross-agent convergence of this convention is tracked in [multi-agent-onboarding-outlook.md](../sdlc-lcm/multi-agent-onboarding-outlook.md)
 - **Shell completions**: bash, zsh, fish
 
 ### Authentication and access

--- a/docs/non-cc/gemini-cli-analysis.md
+++ b/docs/non-cc/gemini-cli-analysis.md
@@ -4,8 +4,8 @@ source: https://github.com/google-gemini/gemini-cli
 purpose: Analysis of Gemini CLI as Google's open-source terminal AI agent, now deprecated for non-enterprise users.
 platform_scope: [cli]
 created: 2026-06-16
-updated: 2026-06-16
-validated_links: 2026-06-16
+updated: 2026-06-28
+validated_links: 2026-06-28
 ---
 
 **Status**: Hold
@@ -65,7 +65,7 @@ server support, configured in `~/.gemini/settings.json`.
 
 Project-specific behavior was customizable via `GEMINI.md` files (analogous to
 `CLAUDE.md` in Claude Code), loaded at session start to inject system-level
-instructions. Conversation checkpointing and token caching were also supported.
+instructions. Conversation checkpointing and token caching were also supported. The cross-agent convergence of these instruction files (`AGENTS.md` / `GEMINI.md` / `CLAUDE.md`) is covered in [multi-agent-onboarding-outlook.md](../sdlc-lcm/multi-agent-onboarding-outlook.md).
 
 ### Headless / scripting mode
 

--- a/docs/sdlc-lcm/goal-tracking-attribution-landscape.md
+++ b/docs/sdlc-lcm/goal-tracking-attribution-landscape.md
@@ -78,7 +78,11 @@ The mature commercial tools target this space, but from the human-ceremony side:
 - [agentic-engineering-disciplines-landscape.md][disciplines] — this doc is the **goals** anchor of the credo's compound loop (its Layer 5, *Compound*).
 - [agentic-sdlc-patterns.md][sdlc-patterns] — the reflector loop + cost gates instantiate the ADLC **Observe → Correct** phase the patterns doc flags as a gap.
 - [Startup CTO Handbook → qte77 mapping][cto-map] — the traditional human-OKR baseline the estate maps its `goals.json` onto.
-- The enterprise "self-operating account / agent-OS" layer around liminal-flux's 8-role account is a sibling subject (a dedicated `non-cc` enterprise-OS landscape is the natural follow-up).
+- [agentic-enterprise-os-landscape.md][enterprise-os] — the operating-environment layer around liminal-flux's self-operating account (six action roles across an 8-phase progression); the enterprise platforms surveyed there govern human-set goals but do not close this attribution loop.
+
+### The substrate thread
+
+Goal attribution is the top of a substrate stack this corpus tracks end-to-end: **file/graph/vector memory** ([agent-frameworks §4][frameworks]) persists agent state → **knowledge graphs / GraphRAG + graph visualization** ([agent-frameworks §7][frameworks]) structure it → **formal ontologies & semantic layers** ([semantic-layers-data-catalog][semantic]) formalize and govern its meaning → the **goal graph** here attributes work back to it → **enterprise agent-OS platforms** ([agentic-enterprise-os][enterprise-os]) operate the whole stack (and reveal the attribution gap). Each rung is one expression of the same *compound, don't drift* credo.
 
 ## Sources
 
@@ -110,3 +114,6 @@ The mature commercial tools target this space, but from the human-ceremony side:
 [disciplines]: agentic-engineering-disciplines-landscape.md
 [sdlc-patterns]: agentic-sdlc-patterns.md
 [oss-alm]: oss-alm-landscape.md
+[enterprise-os]: ../non-cc/agentic-enterprise-os-landscape.md
+[frameworks]: ../non-cc/agent-frameworks-infrastructure-landscape.md
+[semantic]: ../non-cc/semantic-layers-data-catalog-landscape.md

--- a/docs/sdlc-lcm/multi-agent-onboarding-outlook.md
+++ b/docs/sdlc-lcm/multi-agent-onboarding-outlook.md
@@ -98,6 +98,8 @@ agents. No architectural changes needed to support Kiro-like workflows.
 | **ACP** | IBM | Enterprise governance | Compliance/audit (Phase 3) |
 | **AG-UI** | Community | Human-in-the-loop UX | RAPID cockpit — *RAPID is legacy (archived 2026-04-26, superseded by [qte77/qte77](https://github.com/qte77/qte77))* |
 
+The frontend / agent / tool **protocol triangle** (AG-UI · A2A · MCP) is mapped in detail in [ag-ui-protocol-landscape.md](../non-cc/ag-ui-protocol-landscape.md).
+
 ## Summary
 
 The sdlc-lcm-manager design is already agent-agnostic by using file artifacts


### PR DESCRIPTION
## What

**PR D** of Pass 2 — the connective tissue. No new files; cross-refs + one synthesis note.

- **Core five-subject thread** — `goal-tracking-attribution-landscape.md` gains a **substrate-thread** synthesis paragraph (file/graph/vector memory → KG/GraphRAG/visualization → formal ontologies & semantic layers → goal graph → enterprise-OS) and a **bidirectional back-ref** to the enterprise-OS landscape (closing the link PR A left forward-only). Also corrects liminal-flux to "six action roles across an 8-phase progression".
- **Protocol spine** — `multi-agent-onboarding-outlook.md` and `agent-frameworks-infrastructure-landscape.md` now cross-ref `ag-ui-protocol-landscape.md` (the MCP / A2A / AG-UI triangle).
- **Instruction-file convergence** — `codex-cli-analysis.md` and `gemini-cli-analysis.md` now cross-ref the `AGENTS.md`/`GEMINI.md` convergence doc.
- **Skill collections** — `CC-community-tooling-landscape.md` cross-refs Superpowers as everything-claude-code's closest peer.

## Verification

- All four "graph-surfaced" connections were **adversarially verified** (read-only subagent) for *genuine + not-already-linked* before adding. The **Aider repo-map ↔ CC 1M context** candidate was **deliberately skipped** — verified too tangential (no shared infrastructure).
- Uncertain `#fragment` anchors dropped (linked whole docs + named sections in prose) to stay lychee-safe.
- `updated`/`validated_links` bumped on the two edited agent analyses (codex-cli, gemini-cli).
- `make lint` clean: **0 lychee errors, 0 markdownlint errors**.

## Pass 2 complete

Chain: PR A #349 (goal-attribution) · PR B #350 (enterprise-OS) · PR C #351 (memory + graph-viz + ontologies) · this PR D. Frontmatter convention tracking issue: #348.

After merge, I'll optionally re-run `/graphify` + `make graph-page` so the published knowledge graph reflects the four new/extended docs (per your earlier question).

Generated with Claude <noreply@anthropic.com>
