### PR TITLE
fix: collapse rxiv index blank lines (#274)

### DIFF
--- a/.github/scripts/build-rxiv-index.py
+++ b/.github/scripts/build-rxiv-index.py
@@ -113,7 +113,26 @@ def render(records: list[dict], week_count: int) -> str:
             lines.append(f"- findings: {'; '.join(ex['key_findings'])}")
         lines.append("")
 
-    return "\n".join(lines).rstrip("\n") + "\n"
+    return _collapse_blank_lines(lines)
+
+
+def _collapse_blank_lines(lines: list[str]) -> str:
+    """Return text with at most one consecutive blank line.
+
+    Some rxiv extraction records may omit all optional bullet fields. The
+    renderer still separates headings and records with blank lines, so sparse
+    records can otherwise produce MD012-triggering double blanks.
+    """
+    collapsed: list[str] = []
+    previous_blank = False
+    for line in lines:
+        is_blank = line == ""
+        # Reason: Markdownlint MD012 allows one separator blank, not repeated blanks.
+        if is_blank and previous_blank:
+            continue
+        collapsed.append(line)
+        previous_blank = is_blank
+    return "\n".join(collapsed).rstrip("\n") + "\n"
 
 
 def main() -> None:

--- a/tests/test_build_rxiv_index.py
+++ b/tests/test_build_rxiv_index.py
@@ -1,0 +1,41 @@
+"""Unit tests for the rxiv cumulative index generator."""
+import importlib.util
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "build-rxiv-index.py"
+_spec = importlib.util.spec_from_file_location("build_rxiv_index", SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+build_rxiv_index = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build_rxiv_index)
+
+
+class RenderTests(unittest.TestCase):
+    def test_sparse_records_do_not_emit_multiple_blank_lines(self):
+        records = [
+            {
+                "title": "Sparse Paper",
+                "doi": "",
+                "extracted": {},
+                "server": "arxiv",
+                "year": 2026,
+                "week": 23,
+            },
+            {
+                "title": "Next Sparse Paper",
+                "doi": "",
+                "extracted": {},
+                "server": "arxiv",
+                "year": 2026,
+                "week": 23,
+            },
+        ]
+
+        rendered = build_rxiv_index.render(records, week_count=1)
+
+        self.assertNotIn("\n\n\n", rendered)
+        self.assertIn("### Sparse Paper\n\n### Next Sparse Paper", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `_collapse_blank_lines()` to normalize rendered markdown to at most one consecutive blank line before writing.
- Route `render()` through that helper.
- Add a stdlib `unittest` regression covering 3+ and 2+ blank line cases.

Closes #274