### PR TITLE
fix(lychee): repoint moved OpenRouter URL + flag fastcontext for review (#362)

### DIFF
--- a/changelog.d/20260705_190000_fix_link_rot_openrouter_fastcontext.md
+++ b/changelog.d/20260705_190000_fix_link_rot_openrouter_fastcontext.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Link rot (surfaced by #361 lychee, blocking all PRs on `main`): repointed the moved OpenRouter Claude Code integration URL (`/docs/guides/`→`/docs/cookbook/`) in `docs/cc-native/configuration/CC-model-provider-configuration.md`.
+
+### Changed
+
+- `docs/non-cc/fastcontext-analysis.md`: flagged **under review** (#362) — Microsoft's upstream `microsoft/fastcontext` repo was removed (GitHub 404); `source:` + `[repo]` repointed to the arXiv paper and a live community fork; the HuggingFace model URL (401 auth-wall on a live page) is excluded in `lychee.toml` pending re-verification.

--- a/docs/cc-native/configuration/CC-model-provider-configuration.md
+++ b/docs/cc-native/configuration/CC-model-provider-configuration.md
@@ -1,10 +1,10 @@
 ---
 title: CC Model & Provider Configuration
-source: https://code.claude.com/docs/en/settings#environment-variables, https://openrouter.ai/docs/guides/coding-agents/claude-code-integration, https://ollama.com/blog/claude, https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models, https://www.infomaniak.com/en/hosting/ai-services/open-source-models
+source: https://code.claude.com/docs/en/settings#environment-variables, https://openrouter.ai/docs/cookbook/coding-agents/claude-code-integration, https://ollama.com/blog/claude, https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models, https://www.infomaniak.com/en/hosting/ai-services/open-source-models
 purpose: Reference for configuring CC with alternative models, endpoints, API keys, third-party providers (OpenRouter, Bedrock, Vertex, Foundry, Infomaniak), local models (Ollama, llama.cpp, LM Studio), and LLM gateway proxies.
 created: 2026-03-07
-updated: 2026-06-22
-validated_links: 2026-06-22
+updated: 2026-07-05
+validated_links: 2026-07-05
 ---
 
 **Status**: Reference (actionable configuration guide)
@@ -447,7 +447,7 @@ When routing through gateways, additionally set ([source][cc-settings]):
 [cc-settings]: https://code.claude.com/docs/en/settings#environment-variables
 [cc-effort]: https://code.claude.com/docs/en/model-config#adjust-effort-level
 [cc-ultrathink]: https://code.claude.com/docs/en/model-config#use-ultrathink-for-one-off-deep-reasoning
-[openrouter]: https://openrouter.ai/docs/guides/coding-agents/claude-code-integration
+[openrouter]: https://openrouter.ai/docs/cookbook/coding-agents/claude-code-integration
 [ollama-claude]: https://ollama.com/blog/claude
 [llamacpp-anthropic]: https://huggingface.co/blog/ggml-org/anthropic-messages-api-in-llamacpp
 [litellm]: https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models

--- a/docs/non-cc/fastcontext-analysis.md
+++ b/docs/non-cc/fastcontext-analysis.md
@@ -1,13 +1,15 @@
 ---
 title: FastContext — Dedicated Repository-Exploration Subagent
-source: https://github.com/microsoft/fastcontext
+source: https://arxiv.org/abs/2606.14066
 purpose: Evaluate FastContext as a token-saving repo-exploration subagent for coding agents
 created: 2026-06-16
-updated: 2026-06-16
-validated_links: 2026-06-16
+updated: 2026-07-05
+validated_links: 2026-07-05
 ---
 
 **Status**: Assess
+
+> **⚠️ Under review ([#362](https://github.com/qte77/ai-agents-research/issues/362), 2026-07-05):** Microsoft's upstream repo (`microsoft/fastcontext`) was **removed** (GitHub 404); the `[repo]` reference below now points to a live community fork, and the HuggingFace model card auth-walls automated link checks (excluded in `lychee.toml`). The arXiv paper remains authoritative — findings pending re-verification.
 
 ## What It Is
 
@@ -89,11 +91,11 @@ Related context-management approaches are catalogued in
 
 | Source | Content |
 |---|---|
-| [GitHub — microsoft/fastcontext][repo] | Architecture, license (MIT), language, stars, README |
+| [GitHub — Cirius1792/fastcontext][repo] (community fork; Microsoft original removed 2026-07-05) | Architecture, license (MIT), language, README |
 | [arXiv 2606.14066][paper] | Paper title, authors, submission date, methodology, benchmark numbers |
 | [HuggingFace — FastContext-1.0-4B-SFT][hf] | Base model (Qwen3-4B-Instruct), license, four-step loop, quantitative results |
 
-[repo]: https://github.com/microsoft/fastcontext
+[repo]: https://github.com/Cirius1792/fastcontext
 [paper]: https://arxiv.org/abs/2606.14066
 [hf]: https://huggingface.co/microsoft/FastContext-1.0-4B-SFT
 [memory]: ../cc-native/context-memory/CC-memory-system-analysis.md

--- a/lychee.toml
+++ b/lychee.toml
@@ -86,4 +86,5 @@ exclude = [
     "orbisius.com",  # 500 to lychee (persists) — pre-existing third-party blog link in CC-error-messages-reference.md
     "finance.biggo.com",  # times out in CI (slow news aggregator) — secondary source in codebuddy-analysis.md
     "vibekanban.com",  # untrusted SSL cert (UnknownIssuer) upstream as of 2026-06-18 — referenced in CC-office-worker-workflows.md; drop once renewed
+    "huggingface.co/microsoft/FastContext-1.0-4B-SFT",  # 401 auth-wall to lychee on a live model page — fastcontext-analysis.md; drop when HF stops 401-ing (see #362)
 ]


### PR DESCRIPTION
## What

Fixes the pre-existing link rot on `main` that #361 surfaced (it was failing lychee for **every** PR), and flags `fastcontext-analysis.md` for review.

**Commit A — openrouter rot fix**
- `openrouter.ai` moved `/docs/guides/coding-agents/claude-code-integration` → `/docs/cookbook/...`. The old path 404s. Repointed both occurrences in `CC-model-provider-configuration.md` (frontmatter `source:` + ref-def); confirmed the new URL is live.

**Commit B — flag fastcontext for review (#362)**
- `microsoft/fastcontext` GitHub repo was **removed** (404, confirmed via `gh api`); the arXiv paper + HF model remain live (HF 401s lychee as an auth-wall on a live page).
- Added an under-review banner, repointed `source:`→arXiv and `[repo]`→the live community fork `Cirius1792/fastcontext`, and excluded the HF model URL in `lychee.toml` (auth-wall — mirrors the existing semanticscholar/codebuddy/vibekanban exclude-and-revisit entries; drop per #362).

## Verification
- `make lint` → the only remaining local lychee errors are the 2 `code.visualstudio.com` **403 bot-blocks that pass on CI** (local-IP-only; untouched by this PR). All 3 CI-failing URLs (openrouter, fastcontext repo, HF) are now fixed/excluded → **CI lychee will be green**.
- markdownlint clean; no new modules → no tests.

Closes the link-rot half of the post-#361 follow-up; `fastcontext` disposition tracked in #362.

Generated with Claude <noreply@anthropic.com>
