### PR TITLE
chore: quick-win cleanups (lint ordering, architecture refresh, cocoindex/fastcontext)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ check_actions: ## Lint GitHub Actions workflows + composite actions
 	fi
 	actionlint -color
 
-lint: check_links check_docs check_actions ## Run all linters (links + markdown + actions)
+lint: check_docs check_actions check_links ## Run all linters (markdown + actions first; flaky link check last so it can't mask them)
 
 test: ## Run unit tests (stdlib unittest; covers .github/scripts/lib + scripts/pages_build modules)
 	$(PYTHON) -m unittest discover -s tests -v

--- a/changelog.d/20260705_220000_chore_quick_win_cleanups.md
+++ b/changelog.d/20260705_220000_chore_quick_win_cleanups.md
@@ -1,0 +1,9 @@
+### Changed
+
+- `Makefile`: `lint` now runs `check_docs` + `check_actions` before the network-dependent `check_links`, so a transient lychee failure can no longer mask markdownlint/actionlint locally (root cause of a markdownlint error reaching CI in #366).
+- `docs/architecture.md`: corrected the automated-monitor count (three → four), added root `scripts/`/`tests/`/`ui/`/`changelog.d/` to the directory tree, and documented `link-rot-monitor` as a fifth (health, not content) scheduled workflow.
+
+### Fixed
+
+- `docs/non-cc/cocoindex-analysis.md`: removed a duplicate `**Status**` line inside the Adoption Decision section.
+- `docs/non-cc/fastcontext-analysis.md`: finalized the #362 note — analysis kept (arXiv paper is authoritative; upstream Microsoft repo removed).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ updated: 2026-06-22
 
 ## Overview
 
-This is a research-only repository — no code, only structured markdown documents. The "architecture" is the document hierarchy, naming conventions, and the three automated monitors that keep it current.
+This is a research-only repository — no code, only structured markdown documents. The "architecture" is the document hierarchy, naming conventions, and the four automated monitors that keep it current.
 
 ## Document Hierarchy
 
@@ -40,8 +40,12 @@ ai-agents-research/
 │   ├── community/             # Community-sources triage
 │   ├── status-monitor/        # CC status page incident archive + stats
 │   └── rxiv/                  # ArXiv paper eval triage (filtered by RXIV_TOPIC)
+├── scripts/                   # Graph-page render + font-fetch helpers (stdlib-only)
+├── tests/                     # Unit tests for scripts/ + .github/scripts/lib modules
+├── ui/                        # Branded gh-pages site (index.html, graph.html, assets)
+├── changelog.d/               # scriv changelog fragments (collected on release)
 └── .github/
-    ├── workflows/             # 4 monitor cron jobs + lint workflow
+    ├── workflows/             # 4 content-monitor crons + link-rot monitor + lint workflow
     ├── actions/               # Composite actions (create-triage-pr)
     ├── scripts/               # Monitor scripts + shared lib/monitor_utils.py
     └── state/                 # Per-monitor fingerprint files (committed)
@@ -91,6 +95,8 @@ Four GitHub Actions cron workflows maintain currency by polling external sources
 | ArXiv paper eval | `qte77/gha-rxiv-feed-action` CSVs → LLM relevance filter | `triage/rxiv/` | Tuesday 09:00 UTC |
 
 Each monitor commits its state-fingerprint file in `.github/state/` alongside the triage PR for content-stable dedup across runs. The rxiv eval skips PR creation when the assembled report fingerprint matches the prior emission for the same `(server, year, week)` key.
+
+A fifth scheduled workflow — `link-rot-monitor` (Monday 12:00 UTC) — is a **health** monitor rather than a content monitor: it runs lychee weekly and upserts (then auto-closes) a single `link-rot` issue when external links break. See [Lint Gate](#lint-gate).
 
 ## Lint Gate
 

--- a/docs/non-cc/cocoindex-analysis.md
+++ b/docs/non-cc/cocoindex-analysis.md
@@ -56,8 +56,6 @@ server (not independently verified by this analysis).
 
 ## Adoption Decision
 
-**Status**: Assess
-
 CocoIndex addresses a real gap in the agent-research toolchain: keeping indexed context
 fresh without full recomputation. The Apache 2.0 license and Python-native API lower
 the integration barrier for existing Python-based research workflows.

--- a/docs/non-cc/fastcontext-analysis.md
+++ b/docs/non-cc/fastcontext-analysis.md
@@ -9,7 +9,7 @@ validated_links: 2026-07-05
 
 **Status**: Assess
 
-> **⚠️ Under review ([#362](https://github.com/qte77/ai-agents-research/issues/362), 2026-07-05):** Microsoft's upstream repo (`microsoft/fastcontext`) was **removed** (GitHub 404); the `[repo]` reference below now points to a live community fork, and the HuggingFace model card auth-walls automated link checks (excluded in `lychee.toml`). The arXiv paper remains authoritative — findings pending re-verification.
+> **Note ([#362](https://github.com/qte77/ai-agents-research/issues/362), 2026-07-05):** Microsoft's upstream repo (`microsoft/fastcontext`) was **removed** (GitHub 404); the `[repo]` reference below now points to a live community fork, and the HuggingFace model card auth-walls automated link checks (excluded in `lychee.toml`). This analysis is **kept** (not archived): the [arXiv paper](https://arxiv.org/abs/2606.14066) remains the authoritative source and its findings stand on the paper, not the code repo.
 
 ## What It Is
 


### PR DESCRIPTION
Batched quick wins from the post-session review.

**Changed**
- `Makefile`: `lint` runs `check_docs`+`check_actions` before the network-dependent `check_links` — a transient lychee failure can no longer mask markdownlint/actionlint locally (root cause of the markdownlint error that reached CI in #366). Local-only fix; CI already runs the jobs independently.
- `docs/architecture.md`: monitor count three→four; added root `scripts/`/`tests/`/`ui/`/`changelog.d/` to the tree; documented `link-rot-monitor` as a fifth (health) scheduled workflow.

**Fixed**
- `cocoindex-analysis.md`: removed a duplicate `**Status**` line in Adoption Decision.
- `fastcontext-analysis.md`: finalized the #362 note — analysis kept (arXiv paper authoritative; upstream repo removed). Closes #362.

markdownlint 0 errors; docs-only + a 1-line Makefile reorder.

Generated with Claude <noreply@anthropic.com>