### PR TITLE
docs: agentic-AI vulnerability landscape (AIVSS, ATLAS, vendor discovery + tracking)

### DIFF
--- a/changelog.d/20260708_120000_docs_agentic_ai_vulnerability_landscape.md
+++ b/changelog.d/20260708_120000_docs_agentic_ai_vulnerability_landscape.md
@@ -1,0 +1,8 @@
+### Added
+
+- `docs/sdlc-lcm/agentic-ai-vulnerability-landscape.md`: new landscape covering the operational agentic-AI vulnerability layer — OWASP AIVSS scoring, MITRE ATLAS (machine-readable threat KB + AI Incident Sharing), vendor discovery/remediation systems (Microsoft MDASH, Vuln.AI), the Berkeley Vulnerability Initiative tracker, and two arXiv attack/defense surveys. Sectioned by epistemic role; cross-linked with `mas-security-framework.md` and `ai-security-governance-analysis.md` (extends, does not duplicate, their MAESTRO/ATLAS/NIST material).
+
+### Changed
+
+- `lychee.toml`: exclude `ai-incidents.mitre.org` (upstream untrusted SSL cert chain — browser-OK, fails automated verification), cited in the new agentic-AI vulnerability landscape.
+

--- a/docs/sdlc-lcm/README.md
+++ b/docs/sdlc-lcm/README.md
@@ -33,6 +33,7 @@ Lifecycle management specs for the qte77 coding agent ecosystem.
 | [mas-benchmarking-best-practices.md](mas-benchmarking-best-practices.md) | Production best practices for MAS development and benchmarking |
 | [mas-security-framework.md](mas-security-framework.md) | OWASP MAESTRO v1.0 threat modeling (7-layer) for multi-agent systems |
 | [ai-security-governance-analysis.md](ai-security-governance-analysis.md) | NIST AI RMF, EU AI Act, OWASP LLM Top 10, ISO 42001 frameworks |
+| [agentic-ai-vulnerability-landscape.md](agentic-ai-vulnerability-landscape.md) | Operational vuln layer: AIVSS scoring, MITRE ATLAS + AI Incident Sharing, vendor discovery (MDASH/Vuln.AI), Berkeley tracker |
 | [agent-evaluation-metrics-landscape.md](agent-evaluation-metrics-landscape.md) | Agent evaluation metrics survey (task completion, reasoning, safety) |
 | [evaluation-data-resources-landscape.md](evaluation-data-resources-landscape.md) | Eval frameworks, agentic benchmarks, datasets (companion to the metrics survey) |
 

--- a/docs/sdlc-lcm/agentic-ai-vulnerability-landscape.md
+++ b/docs/sdlc-lcm/agentic-ai-vulnerability-landscape.md
@@ -1,0 +1,170 @@
+---
+title: Agentic-AI Vulnerability Landscape — Scoring, Discovery & Tracking
+purpose: Survey of the operational agentic-AI vulnerability layer — how agent/AI vulnerabilities are scored (AIVSS), classified (MITRE ATLAS), discovered at scale (vendor systems), and tracked (academic), distinct from the governance/threat-modeling frameworks.
+category: landscape
+created: 2026-07-08
+updated: 2026-07-08
+validated_links: 2026-07-08
+---
+
+**Status**: Assess
+
+The **operational vulnerability layer** for agentic AI: how vulnerabilities in AI/agent systems are
+*scored*, *classified*, *discovered at scale*, and *tracked* across the ecosystem. This is a different
+axis from the **governance / threat-modeling frameworks** already analysed here — for OWASP MAESTRO,
+NIST AI RMF, EU AI Act, OWASP LLM Top 10, and ISO 42001, see
+[ai-security-governance-analysis.md](ai-security-governance-analysis.md) and the MAESTRO deep-dive
+[mas-security-framework.md](mas-security-framework.md). It is also distinct from **CC-local runtime
+security** (sandbox/permissions), covered under
+[../cc-native/sandboxing/](../cc-native/sandboxing/CC-permissions-bypass-analysis.md).
+
+Cross-ref: [ai-security-governance-analysis.md](ai-security-governance-analysis.md) ·
+[mas-security-framework.md](mas-security-framework.md)
+
+## Landscape by epistemic role
+
+These sources do not collapse into one methodology — they occupy distinct roles with different
+authority. Read severity/benchmark claims through that lens.
+
+| Source | Role | Authority | What it provides |
+|---|---|---|---|
+| OWASP **AIVSS** | Scoring standard | OWASP Foundation | CVSS-like severity scoring for agentic-AI risk |
+| MITRE **ATLAS** | Threat taxonomy / KB | MITRE (CTID) | ATT&CK-style tactics/techniques + case studies for AI/ML |
+| MITRE **AI Incident Sharing** | Incident dataset | MITRE (CTID) | Community-submitted real-world AI incident reports |
+| Microsoft **MDASH** | Vendor discovery system | Microsoft Security | Multi-agent vulnerability *discovery* (product PR) |
+| Microsoft **Vuln.AI** | Vendor ops case study | Microsoft Digital | Internal vulnerability *triage/remediation* at scale |
+| **Berkeley Vulnerability Initiative** | Academic tracker | UC Berkeley | Independent tally of agent-*discovered* CVEs |
+| IBM Community guide | Practitioner commentary | Community author | Enterprise framing (⚠️ weakly sourced — see below) |
+| Survey papers (2× arXiv) | Academic taxonomy | preprints | Attack/defense taxonomies for agentic AI |
+
+## 1. Scoring & classification standards
+
+### OWASP AIVSS (AI Vulnerability Scoring System)
+
+[AIVSS][aivss] is an open OWASP project providing a **quantifiable severity/exploitability scoring
+methodology** for AI risk — a CVSS analogue whose initial scope is "Agentic AI Core Risks," with a
+stated roadmap to a full AI Vulnerability Scoring Framework spanning LLMs, GenAI, and agentic systems
+(current version 0.8; v0.5 archived). Deliverables include an open-source scoring calculator, a
+framework guide, assessment-report templates, SDLC-integration docs, and a crosswalk to AIUC-1. It is
+the only source here that is a *scoring methodology* rather than a product or narrative — useful for
+normalizing the severity claims the vendor sources make. It is a direct sibling of the OWASP
+MAESTRO / LLM Top 10 work already covered in
+[ai-security-governance-analysis.md](ai-security-governance-analysis.md).
+
+### MITRE ATLAS (as machine-readable knowledge base)
+
+[ai-security-governance-analysis.md](ai-security-governance-analysis.md) already introduces ATLAS as
+an attack taxonomy; the operational point here is that ATLAS is a **machine-readable, versioned
+knowledge base**, not just a matrix diagram. [ATLAS][atlas] extends MITRE ATT&CK with an `AML.*` ID
+namespace: **16 tactics** (Reconnaissance → Impact) including two AI-original tactics with no ATT&CK
+equivalent — **AI Model Access** (`AML.TA0000`) and **AI Attack Staging** (`AML.TA0001`) — and **70+
+techniques/sub-techniques**, with LLM/agentic entries such as LLM Prompt Injection, LLM Jailbreak,
+Poison Training Data, and recently web-session-cookie theft and AI-service-interface abuse. The data
+lives in the [`atlas-data`][atlas-data] repo as YAML, exported to STIX 2.1 and ATT&CK-Navigator
+layers; content releases are dated (`v2026.06`, 2026-06-30, on a v6.0.0 schema). It is run by MITRE's
+Center for Threat-Informed Defense under its "Secure AI" project. **ATLAS and AIVSS are
+complementary**: ATLAS *names/classifies* a threat; AIVSS *scores/prioritizes* it.
+
+### MITRE AI Incident Sharing
+
+[AI Incident Sharing][ai-incidents] is a MITRE companion initiative (launched October 2024, same
+"Secure AI" umbrella) — a public submission channel and trusted-community dataset for **real-world AI
+incidents** (attacks and accidents), shared in protected/anonymized form. Founding collaborators
+include Microsoft, CrowdStrike, Intel, JPMorgan Chase, Citigroup, and ~10 more. It informs ATLAS's
+threat picture (case-study material) rather than auto-feeding the `atlas-data` repo.
+
+## 2. Vendor discovery & remediation systems
+
+### Microsoft MDASH — "Defense at AI speed"
+
+[MDASH][mdash] (announced 2026-05-12) is Microsoft Security's multi-model agentic system for
+**vulnerability discovery**, orchestrating 100+ specialized agents across a Prepare → Scan → Validate
+→ Dedupe → Prove pipeline. Microsoft reports **88.45% on the public CyberGym benchmark** (1,507
+real-world vulnerabilities), claimed #1 on that leaderboard, and ties the system to **16 CVEs
+disclosed same-day** (4 Critical RCE, 12 Important) across Windows components (tcpip.sys, http.sys,
+netlogon.dll, …). Underlying model names are not disclosed. Treat the leaderboard/recall figures as
+vendor-reported (normalizable against AIVSS scoring and the Berkeley tracker below).
+
+### Microsoft Vuln.AI — internal vulnerability management
+
+[Vuln.AI][vuln-ai] (Microsoft Digital, 2025-10-16) is the internal-ops counterpart to MDASH:
+where MDASH is offense-style *discovery*, Vuln.AI is defense-style **triage/remediation** across
+Microsoft's own estate (300k+ users, 25k network devices, 560+ buildings; "600M+ threats/day" via an
+Infrastructure Data Lakehouse). Reported outcomes: **~70% reduction** in time-to-vulnerability-insight
+and **>50%** in triage time. A live internal system, no version numbers — a scale/operations data
+point, not a shippable product.
+
+## 3. Academic tracker
+
+### Berkeley Vulnerability Initiative
+
+The [Berkeley Vulnerability Initiative — Agentic Vulnerability Coverage Map][berkeley-vuln] (UC
+Berkeley) is the only **independent, cross-ecosystem** source: an open record of CVEs discovered by
+agentic systems, rebuilt daily from public CVE feeds. Its data shows the CWE classes agentic systems
+most often surface — led by **OS Command Injection (CWE-78, 23), Missing Authentication (CWE-306,
+20), Code Injection (CWE-94, 17), Path Traversal (CWE-22, 13), Improper Input Validation (CWE-20,
+12), and Deserialization (CWE-502, 12)** — and tracks a severity trend (agent-found CVEs scored
+High/Critical ~59.8% of the time vs. lower baselines in prior periods). It lets a reader cross-check
+vendor claims (e.g., MDASH's CyberGym score) against an outside tally. (Data read via a rendered fetch
+of the site's client-side app; figures reflect the coverage map at access time.)
+
+## 4. Practitioner guide (secondary — flagged)
+
+> ⚠️ **Weakly sourced.** The [IBM Community post][ibm-agentic-vuln] (2025-08-01, an individual
+> community author, not an IBM corporate publication) proposes a "MAESTRO" threat-modeling process
+> and cites quantified figures ("67% of agentic attacks succeed at exfiltration," "$4.7M avg
+> incident cost") and specific CVE IDs — none of which are sourced/corroborated in the post. It is
+> included as a data point on how the enterprise vulnerability narrative is *packaged*, not as
+> primary evidence; do not cite its statistics as fact. Note its "MAESTRO" is distinct from the
+> OWASP MAESTRO threat model in [mas-security-framework.md](mas-security-framework.md).
+
+## 5. Survey literature
+
+Two 2026 arXiv surveys give the academic taxonomy backbone (both fold into the auto-generated
+[../research/rxiv-agentic-papers.md](../research/rxiv-agentic-papers.md) if/when the weekly pipeline
+picks them up — not hand-added):
+
+- **[The Attack and Defense Landscape of Agentic AI: A Comprehensive Survey][survey-attack-defense]**
+  (arXiv 2603.11088; Berkeley/UIUC — Dawn Song, Bo Li, et al.) — a 7-dimension agent design framework,
+  a 6-vector attack taxonomy across 3 threat models, and a defense systematization. Likely tied to
+  the Berkeley tracker's research group.
+- **[Agentic AI Security: Threats, Defenses, Evaluation, and Open Challenges][survey-threats-defenses]**
+  (arXiv 2510.23883) — threat taxonomy (prompt injection, autonomous exploitation, multi-agent
+  protocol vulns, governance gaps) with emphasis on **evaluation/benchmarking** and governance-side
+  defenses.
+
+## Takeaways
+
+- **Two anchors:** adopt **MITRE ATLAS** to *name/classify* agent threats and **OWASP AIVSS** to
+  *score/prioritize* them — they compose (classify → quantify).
+- **Vendor benchmark claims need normalization:** MDASH's CyberGym number and Vuln.AI's reductions
+  are vendor-reported; the Berkeley tracker is the independent cross-check.
+- **Agents find *injection-class* bugs most:** the Berkeley CWE distribution (command/code injection,
+  missing auth, path traversal) suggests where agent-discovered risk concentrates today.
+- **This is Assess, not Adopt:** the space is <1 year old, vendor-heavy, and the practitioner layer is
+  weakly sourced — track ATLAS/AIVSS releases and the Berkeley data; treat vendor systems as claims.
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [OWASP AIVSS][aivss] | Agentic-AI severity scoring standard (v0.8) |
+| [MITRE ATLAS][atlas] · [atlas-data][atlas-data] | AI threat taxonomy KB (STIX/YAML, v2026.06) |
+| [MITRE AI Incident Sharing][ai-incidents] | Community AI-incident dataset (2024) |
+| [Microsoft MDASH][mdash] | Agentic vuln-discovery system (CyberGym 88.45%, 16 CVEs) |
+| [Microsoft Vuln.AI][vuln-ai] | Internal vuln triage/remediation (70%↓ insight) |
+| [Berkeley Vulnerability Initiative][berkeley-vuln] | Independent agent-found-CVE coverage map |
+| [IBM Community guide][ibm-agentic-vuln] | Practitioner framing (⚠️ secondary/unverified) |
+| [arXiv 2603.11088][survey-attack-defense] | Attack+defense survey (Berkeley/UIUC) |
+| [arXiv 2510.23883][survey-threats-defenses] | Threats/defenses/eval survey |
+
+[aivss]: https://aivss.owasp.org/
+[atlas]: https://atlas.mitre.org/
+[atlas-data]: https://github.com/mitre-atlas/atlas-data
+[ai-incidents]: https://ai-incidents.mitre.org/
+[mdash]: https://www.microsoft.com/en-us/security/blog/2026/05/12/defense-at-ai-speed-microsofts-new-multi-model-agentic-security-system-tops-leading-industry-benchmark/
+[vuln-ai]: https://www.microsoft.com/insidetrack/blog/vuln-ai-our-ai-powered-leap-into-vulnerability-management-at-microsoft/
+[berkeley-vuln]: https://vuln.cs.berkeley.edu/
+[ibm-agentic-vuln]: https://community.ibm.com/community/user/blogs/matthew-giannelis1/2025/08/01/the-enterprise-it-security-guide-to-agentic-ai-vul
+[survey-attack-defense]: https://arxiv.org/abs/2603.11088
+[survey-threats-defenses]: https://arxiv.org/abs/2510.23883

--- a/lychee.toml
+++ b/lychee.toml
@@ -87,4 +87,5 @@ exclude = [
     "finance.biggo.com",  # times out in CI (slow news aggregator) — secondary source in codebuddy-analysis.md
     "vibekanban.com",  # untrusted SSL cert (UnknownIssuer) upstream as of 2026-06-18 — referenced in CC-office-worker-workflows.md; drop once renewed
     "huggingface.co/microsoft/FastContext-1.0-4B-SFT",  # 401 auth-wall to lychee on a live model page — fastcontext-analysis.md; drop when HF stops 401-ing (see #362)
+    "ai-incidents.mitre.org",  # untrusted SSL cert chain (UnknownIssuer) upstream — MITRE AI Incident Sharing, browser-OK; agentic-ai-vulnerability-landscape.md; drop once MITRE fixes the chain
 ]


### PR DESCRIPTION
PR1 of the new-sources batch. New `docs/sdlc-lcm/agentic-ai-vulnerability-landscape.md` — the **operational** agentic-AI vulnerability layer (distinct from the governance/threat-model docs it cross-links):

- **Scoring/classification:** OWASP AIVSS (v0.8), MITRE ATLAS (KB + AI Incident Sharing).
- **Vendor systems:** Microsoft MDASH (CyberGym 88.45%, 16 CVEs), Vuln.AI (70%↓ insight).
- **Academic tracker:** Berkeley Vulnerability Initiative (agent-found-CVE CWE map — via a polyfetch render of its SPA).
- **Surveys:** arXiv 2603.11088, 2510.23883.

Extends (does **not** duplicate) `mas-security-framework.md` + `ai-security-governance-analysis.md`. IBM source flagged secondary/unverified. `sdlc-lcm/README` row added. Umbrella tracking issue lands in PR3.

`make check_docs` 0 · `make check_links` 0 (excluded ai-incidents.mitre.org — upstream untrusted SSL cert, browser-OK).

Generated with Claude <noreply@anthropic.com>