### PR TITLE
docs: tooling batch — Codex-CC plugin, OpenWiki, company-brain + polyfetch/doc-pipeline pointer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,7 @@ Cross-ref: [CC-agent-teams-orchestration.md](../agents-skills/CC-agent-teams-orc
 - **Soften or remove unverified claims** — explicit hedging beats unsourced numbers; "up to N" without a first-party source is not acceptable
 - **Cite a version gate** when behavior is version-specific (e.g., `@anthropic-ai/claude-code@2.1.88, 2026-03-31`, `CC v2.1.96+`)
 - **Shell tooling**: prefix shell calls with `rtk` (Rust Token Killer) when a shell call is genuinely needed — see `/workspaces/.claude-files/RTK.md`. Shell is a fallback, not the default
+- **Dynamic / unparsable sources**: when WebFetch can't render a page (JS-SPA, TLS- or bot-blocked) or parse a document (PDF/Office/image), escalate to the estate tools via `uv run --directory <clone>` (runs in the clone's own venv — no poison): [polyfetch-scrape](https://github.com/qte77/polyfetch-scrape) to **fetch** dynamic/blocked pages (see its `USING.md`), and [doc-pipeline-engine](https://github.com/qte77/doc-pipeline-engine) to **process** documents to text/markdown (offline `local` leg; one-off `uv sync --extra extract`)
 
 ## Directory Structure
 

--- a/changelog.d/20260708_140000_docs_tooling_sources_batch.md
+++ b/changelog.d/20260708_140000_docs_tooling_sources_batch.md
@@ -1,0 +1,10 @@
+### Added
+
+- `docs/cc-community/CC-codex-plugin-cc-analysis.md`: analysis of OpenAI's official Codex→CC plugin (Apache-2.0) — slash commands, `codex-rescue` subagent, `Stop`-hook review gate, background delegation, session transfer; a rival lab building on CC's own extension surface.
+- `docs/plans/2026-07-08-new-sources-batch.md`: durable plan record for the new-sources batch (tracker #374).
+
+### Changed
+
+- `docs/non-cc/repo-to-docs-tools-landscape.md`: added OpenWiki (LangChain, MIT) — an agent-oriented repo→docs generator that appends pointers into `AGENTS.md`/`CLAUDE.md`, distinct from human-facing DeepWiki-style tools.
+- `docs/non-cc/agentic-enterprise-os-landscape.md`: added a "company brain" subsection (a synthesis label over agent-memory + KG/ontology + permissioning + write-back; cross-linked to the memory/semantic-layer docs, not a standalone doc).
+- `CONTRIBUTING.md`: Research Workflow now points to `polyfetch-scrape` (fetch dynamic/blocked pages) and `doc-pipeline-engine` (process PDF/Office → text) via `uv run --directory`, alongside the existing `rtk` pointer.

--- a/docs/cc-community/CC-codex-plugin-cc-analysis.md
+++ b/docs/cc-community/CC-codex-plugin-cc-analysis.md
@@ -1,0 +1,63 @@
+---
+title: "Codex Plugin for Claude Code (openai/codex-plugin-cc)"
+source: https://github.com/openai/codex-plugin-cc
+purpose: Analysis of OpenAI's official Claude Code plugin that delegates to Codex — a rival lab building on CC's own hook/slash-command/subagent extension surface.
+category: analysis
+platform_scope: [claude-code, codex]
+created: 2026-07-08
+updated: 2026-07-08
+validated_links: 2026-07-08
+---
+
+**Status**: Assess
+
+## What It Is
+
+[codex-plugin-cc][repo] is an **official OpenAI** Claude Code plugin (Apache-2.0; ~26.9k stars, v1.0.6
+as of 2026-07-08) that lets a Claude Code user invoke **OpenAI Codex from inside their CC session** —
+for code review or task delegation — without switching tools. Its README opener: *"Use Codex from
+inside Claude Code for code reviews or to delegate tasks to Codex."*
+
+Its research interest for this corpus is less the feature and more the **surface**: a competing lab
+built a first-party integration entirely on Claude Code's *own* extension primitives — a concrete,
+maintained reference for how the plugin + hook + subagent surface is meant to be composed. It is the
+inverse direction of the community reimplementations catalogued in
+[CC-community-reimplementations-landscape.md](CC-community-reimplementations-landscape.md) (which
+rebuild CC), and distinct from `clawcodex` (a cleanroom Codex *reimplementation*) — this bridges an
+external agent *into* CC.
+
+## How It Works
+
+Installed via the CC plugin marketplace, it wires into three extension mechanisms:
+
+- **Slash commands:** `/codex:review`, `/codex:adversarial-review`, `/codex:rescue`,
+  `/codex:transfer`, `/codex:status`, `/codex:result`, `/codex:cancel`, `/codex:setup`.
+- **A registered subagent:** `codex:codex-rescue` (appears in `/agents`).
+- **Hooks:** a `SessionStart` hook, plus an optional **`Stop` hook used as a review gate** — it can
+  *block Claude's response* if Codex flags issues. This is the notable pattern: one agent gating
+  another via the Stop hook.
+
+Beyond synchronous review it supports **background task delegation** to Codex with job-status polling,
+and **full session transfer** (conversation history) from CC into Codex. Requirements: a local Codex
+CLI + `codex login`, a ChatGPT subscription or OpenAI API key, and Node.js ≥ 18.18.
+
+## Adoption Decision
+
+**Assess.** Not something this docs corpus *adopts*, but a high-signal artifact: it demonstrates the
+Stop-hook-as-review-gate and subagent-registration patterns on a real, high-profile plugin, and shows
+how cross-agent delegation is being productized on CC's surface. Watch it as a reference when
+documenting CC's hook/plugin architecture; the cross-lab-delegation trend (CC ↔ Codex) is worth
+tracking. Using it in practice couples a CC session to an OpenAI subscription/CLI — a dependency and
+data-flow consideration, not a fit for key-free/offline workflows.
+
+Cross-ref: [CC-community-plugins-landscape.md](CC-community-plugins-landscape.md) ·
+[CC-official-plugins-landscape.md](../cc-native/plugins-ecosystem/CC-official-plugins-landscape.md) ·
+[codex-cli-analysis.md](../non-cc/codex-cli-analysis.md)
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [openai/codex-plugin-cc][repo] | Plugin repo: README, slash commands, hooks, releases (Apache-2.0, v1.0.6, 2026-07-08) |
+
+[repo]: https://github.com/openai/codex-plugin-cc

--- a/docs/cc-community/CC-community-plugins-landscape.md
+++ b/docs/cc-community/CC-community-plugins-landscape.md
@@ -251,6 +251,10 @@ npx skills add iusztinpaul/squid
 
 **Notable pattern**: the ADR layer (architectural memory) and the Tasks Plan (feature → task decomposition) make squid a worked example of memory + goal-tracking *inside* a CC pipeline — threads picked up in the deferred agentic-memory / goal-attribution research. Relevant to [CC-agent-teams-orchestration](../cc-native/agents-skills/CC-agent-teams-orchestration.md).
 
+## Notable Plugin Profile: codex-plugin-cc (OpenAI Codex → CC delegation)
+
+[openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) — an **official OpenAI** plugin (Apache-2.0, ~26.9k★, v1.0.6) that runs Codex from inside a CC session for review or task delegation. Notable for building entirely on CC's own extension surface: slash commands (`/codex:review`, `/codex:adversarial-review`, `/codex:rescue`, `/codex:transfer`, …), a `codex-rescue` subagent, and a **`Stop`-hook review gate** that can block Claude's response when Codex flags issues; plus background delegation and full session transfer. A rival lab productizing cross-agent delegation on CC primitives. Full analysis: [CC-codex-plugin-cc-analysis.md](CC-codex-plugin-cc-analysis.md).
+
 ## Ecosystem Observations
 
 1. **Business-function plugins** (Sales, Marketing, Legal) exist only in the ccplugins registry — the awesome-claude-code list is developer-focused

--- a/docs/cc-community/README.md
+++ b/docs/cc-community/README.md
@@ -19,3 +19,4 @@ Community-built skills, plugins, tooling, workflows, and patterns for Claude Cod
 | [CC-openmontage-analysis.md](CC-openmontage-analysis.md) | OpenMontage: agentic video production as a CLAUDE.md-driven workspace (three-layer skills, checkpoint pipelines); + Palmier concepts & coding-agent→video pivot signal |
 | [CC-compass-mcp-analysis.md](CC-compass-mcp-analysis.md) | Compass MCP: cross-surface task/context bridge (architecture, status, alignment) |
 | [CC-vlm-screen-sharing-landscape.md](CC-vlm-screen-sharing-landscape.md) | VLM + screen-sharing landscape: vision models, local runtimes, image token math, visual-context integration patterns |
+| [CC-codex-plugin-cc-analysis.md](CC-codex-plugin-cc-analysis.md) | OpenAI Codex→CC plugin (Apache-2.0): slash commands, codex-rescue subagent, Stop-hook review gate, session transfer |

--- a/docs/non-cc/agentic-enterprise-os-landscape.md
+++ b/docs/non-cc/agentic-enterprise-os-landscape.md
@@ -4,8 +4,8 @@ purpose: Survey of the "agentic enterprise OS" pattern — the operating-environ
 category: landscape
 platform_scope: [salesforce-agentforce, microsoft-copilot-studio, servicenow, sap-joule, databricks-genie, self-hosted-oss, claude-code]
 created: 2026-06-28
-updated: 2026-06-28
-validated_links: 2026-06-28
+updated: 2026-07-08
+validated_links: 2026-07-08
 ---
 
 **Status**: Assess
@@ -46,6 +46,27 @@ The qte77 estate assembles the self-operating environment from primitives rather
 - **[polyforge-orchestrator][polyforge]** — orchestrates parallel coding agents across a polyrepo from one devcontainer/workspace; it bridges the VS Code multi-root lifecycle gap by replaying each sibling repo's `onCreateCommand`/`postCreateCommand` hooks and generating a `workspace.code-workspace` with per-repo terminal tasks.
 - **[office-forge-orchestrator][office-forge]** — the same pattern applied to office/business workflows, in three layers: `.claude/skills` (deterministic invoice/contract/report workflows) + `mcp/` (a business-API MCP catalog) + `config/` (project and credential definitions).
 - **[liminal-flux-gh-acc][liminal]** ("Lim Sid") — a self-evolving, agent-operated GitHub account where agents **plan, code, review, reflect, supervise, and evolve** their own infrastructure (six action roles) across an **8-phase autonomy progression** (Phase 0–7; Phase 0 is deployment-ready, no live infra running yet). Humans set goals and handle security escalations. Its per-run attribution and cost gates are detailed in [goal-tracking-attribution-landscape][goal-attr].
+
+## Company brain (adjacent synthesis label)
+
+"Company brain" is a fresh (mid-2026; YC-Summer-2026-RFS- and essayist-coined) umbrella for a
+**shared, permissioned, continuously-updated operational memory/context layer** over an organization's
+data and decisions that both humans and agents query and act through: ingest → consolidate (typed
+entities, contradictions auto-resolved, provenance + temporal tags) → retrieve (semantic + entity +
+graph, permissioned at query time) → act (agents read/act/write outcomes back). It is **not a distinct
+technology** but a *synthesis* of layers this repo already tracks — agent-memory infrastructure
+([agent-frameworks-infrastructure-landscape.md](agent-frameworks-infrastructure-landscape.md) §4),
+knowledge-graph/GraphRAG + informal ontology
+([semantic-layers-data-catalog-landscape.md](semantic-layers-data-catalog-landscape.md)) — plus
+retrieval-time permissioning and a write-back loop, applied org-wide.
+
+Two of the four canonical sources are vendor marketing (a LinkedIn "context graph" pitch; a
+Vectorize build-guide plugging its own ecosystem); the more substantive are an early OSS prototype
+([caelstewart/company-brain](https://github.com/caelstewart/company-brain) — a temporal-KG engine on
+Postgres+pgvector with an MCP server, ~alpha) and a concept note in
+[hornof/llm-wiki](https://github.com/hornof/llm-wiki) (Karpathy-pattern KB). Treated here as an
+**adjacent framing** of the same goal-attribution gap the enterprise platforms leave — not a separate
+category. A standalone doc is deferred until the term accrues non-vendor traction.
 
 ## Synthesis
 

--- a/docs/non-cc/repo-to-docs-tools-landscape.md
+++ b/docs/non-cc/repo-to-docs-tools-landscape.md
@@ -5,8 +5,8 @@ purpose: Survey of AI-powered tools that generate documentation from GitHub repo
 category: landscape
 status: research
 created: 2026-04-06
-updated: 2026-06-27
-validated_links: 2026-06-27
+updated: 2026-07-08
+validated_links: 2026-07-08
 ---
 
 **Status**: Research (informational)
@@ -18,6 +18,8 @@ Three tools represent an emerging category of **AI-powered repo-to-documentation
 **Relevance to agent workflows**: These tools can serve as context sources for coding agents -- pre-generated documentation reduces the need for expensive runtime codebase analysis. The repo-to-docs pattern also overlaps with the `llms.txt` standard and context engineering approaches documented in this repository.
 
 A fourth tool, **Understand Anything** (Egonex-AI, 57.4k stars), sits at the graph end of this space: it emits an interactive knowledge graph rather than prose -- the external analogue to this repo's own [graphify integration](../architecture.md#knowledge-graph-graphify).
+
+A fifth entrant, **OpenWiki** (LangChain), targets a different *consumer*: it writes docs **for coding agents**, appending pointers into `AGENTS.md`/`CLAUDE.md`, rather than human-browsable wikis.
 
 ## Comparison
 
@@ -102,6 +104,19 @@ Three output levels: system architecture, directory-level summaries, file-level 
 
 **Tech stack**: Next.js + Tailwind (Vercel), FastAPI (Render), PostgreSQL (Supabase), Gemini 2.5 Pro, PostHog analytics.
 
+## OpenWiki (LangChain)
+
+**URL**: [github.com/langchain-ai/openwiki](https://github.com/langchain-ai/openwiki) | **Stars**: 9.7k | **License**: MIT | **Version**: v0.0.3 (2026-07-08, pre-1.0)
+
+A CLI that "writes and maintains documentation for your codebase, **built specifically for agents**." Unlike the human-facing generators above, its output is *agent context*, not a browsable wiki:
+
+- `npm install -g openwiki`; bootstrap with `openwiki --init`, refresh on change.
+- Writes generated docs into an `openwiki/` directory, and **auto-appends pointers into `AGENTS.md` and `CLAUDE.md`** so coding agents find the context.
+- CI/CD integration opens PRs with documentation refreshes as the repo changes.
+- TypeScript-heavy; very early (v0.0.3).
+
+**Relevance**: the "repo → machine-readable agent context" corner of this space — directly adjacent to CC's own `CLAUDE.md`/`AGENTS.md` conventions, and the agent-oriented contrast to human-facing DeepWiki-style tools.
+
 ## Pattern Analysis
 
 All three doc-generators share a common pipeline:
@@ -140,6 +155,7 @@ Differentiation happens at the output stage:
 - [gitsummarize.com](https://gitsummarize.com)
 - [GitHub: antarixxx/gitsummarize](https://github.com/antarixxx/gitsummarize)
 - [GitHub: egonex-ai/understand-anything](https://github.com/egonex-ai/understand-anything)
+- [GitHub: langchain-ai/openwiki](https://github.com/langchain-ai/openwiki)
 
 ## Action Items
 

--- a/docs/plans/2026-07-08-new-sources-batch.md
+++ b/docs/plans/2026-07-08-new-sources-batch.md
@@ -1,0 +1,40 @@
+---
+title: New-sources batch — agentic-AI security, KV-cache, tooling
+status: done
+issue: 374
+created: 2026-07-08
+updated: 2026-07-08
+---
+
+**Status**: Reference (plan)
+
+Durable record of the 2026-07-08 new-sources batch — analysis docs added to the corpus ahead of the
+[#354](https://github.com/qte77/ai-agents-research/issues/354) graph rebuild, so the regenerated graph
+reflects real new content. Tracker: [#374](https://github.com/qte77/ai-agents-research/issues/374).
+
+## Context
+
+User supplied ~14 links (heavily agentic-AI security) + "company brain" + KV caches; a backlog scout
+also surfaced triage/rxiv candidates. All researched first-party (multi-agent fan-out; dynamic/SPA
+sources rendered via [polyfetch-scrape](https://github.com/qte77/polyfetch-scrape), e.g. the Berkeley
+coverage-map). Routing verified against existing coverage to extend/cross-ref rather than duplicate.
+
+## Delivered (3 PRs)
+
+| PR | Deliverable |
+|---|---|
+| #372 | NEW `sdlc-lcm/agentic-ai-vulnerability-landscape.md` — operational vuln layer: OWASP AIVSS, MITRE ATLAS (+ AI Incident Sharing), Microsoft MDASH/Vuln.AI, Berkeley Vulnerability Initiative, 2 arXiv surveys. Cross-links (not dup) the MAESTRO/governance docs. |
+| #373 | NEW `non-cc/kv-cache-serving-landscape.md` — cross-vendor prompt-caching (Anthropic/OpenAI/Gemini) + serving internals (PagedAttention, RadixAttention, quantization, GQA/MLA, Mooncake/LMCache). Fixed a stale fact in `CC-prompt-caching-behavior.md` (Opus 4.8 min = 1,024, not 4,096). |
+| this | NEW `cc-community/CC-codex-plugin-cc-analysis.md`; EXTEND `repo-to-docs-tools-landscape.md` (OpenWiki) + `agentic-enterprise-os-landscape.md` (company brain); CONTRIBUTING polyfetch/doc-pipeline pointer; this plan. |
+
+## Placement decisions (rationale)
+
+- **Security → `sdlc-lcm/`** (not non-cc): joins the existing security cluster (MAESTRO, governance); new doc takes the *vuln-discovery/scoring* angle, cross-refs the *governance-framework* angle.
+- **KV-cache → `non-cc/`**: cross-vendor serving infra (Anthropic = one of three vendor rows); the CC-specific caching view stays in cc-native.
+- **Company brain → EXTEND `agentic-enterprise-os-landscape.md`**: a synthesis label (agent-memory + KG/GraphRAG + informal ontology + permissioning + write-back), not a distinct category; 2 of 4 sources are vendor marketing. No standalone doc unless it gains non-vendor traction.
+- **Papers**: folded into the security landscape; `docs/research/rxiv-agentic-papers.md` left untouched (auto-generated).
+
+## Follow-ups (tracked in #374)
+
+- [#354](https://github.com/qte77/ai-agents-research/issues/354) graph rebuild once these land.
+- Scout backlog (13 candidates) — checklist in #374; write when picked up, re-verify first-party.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -2,7 +2,7 @@
 title: Plans — Design & Decision Docs
 purpose: Convention for docs/plans/ — durable plan/design docs (the saved output of plan-mode work). GitHub Issues remain the authoritative backlog/roadmap; each plan doc links its tracking issue.
 created: 2026-06-14
-updated: 2026-07-05
+updated: 2026-07-08
 ---
 
 **Status**: Reference (convention)
@@ -31,3 +31,4 @@ updated: 2026-07-05
 |---|---|---|
 | [2026-06-14-planning-workflow-and-open-task-triage.md](2026-06-14-planning-workflow-and-open-task-triage.md) | done | #242, #243 |
 | [2026-07-05-status-frontmatter-migration.md](2026-07-05-status-frontmatter-migration.md) | approved | #348 |
+| [2026-07-08-new-sources-batch.md](2026-07-08-new-sources-batch.md) | done | #374 |


### PR DESCRIPTION
PR3 (final docs PR) of the new-sources batch. Tracker: #374.

- **NEW `cc-community/CC-codex-plugin-cc-analysis.md`** — OpenAI Codex→CC plugin (Apache-2.0, 26.9k★): slash commands, codex-rescue subagent, Stop-hook review gate, session transfer. + landscape profile + README row.
- **EXTEND `repo-to-docs-tools-landscape.md`** — OpenWiki (LangChain, MIT): agent-oriented repo→docs (appends to AGENTS.md/CLAUDE.md), distinct from DeepWiki.
- **EXTEND `agentic-enterprise-os-landscape.md`** — 'company brain' subsection (synthesis label, not a standalone doc; 2/4 sources flagged vendor-marketing).
- **META** — CONTRIBUTING Research-Workflow pointer to polyfetch-scrape (fetch) + doc-pipeline-engine (process) via `uv run --directory`; persisted the batch plan to `docs/plans/2026-07-08-new-sources-batch.md` (+ index row).

`make check_docs` 0 · `make check_links` 0. After merge: the #354 graph rebuild.

Generated with Claude <noreply@anthropic.com>