### PR TITLE
docs: source expansion — agents-cli, agentic payments, Karpathy, agent identity/auth

### DIFF
--- a/changelog.d/20260708_150000_docs_agents_cli_payments_identity_karpathy.md
+++ b/changelog.d/20260708_150000_docs_agents_cli_payments_identity_karpathy.md
@@ -1,0 +1,6 @@
+### Added
+
+- `docs/non-cc/agents-cli-analysis.md`: Google agents-cli — a skill-pack that upskills a coding agent (Claude Code, Antigravity, Codex) to build/evaluate/deploy ADK agents on the Gemini Enterprise Platform (Apache-2.0; v1.0.0 but Pre-GA). Cross-ref'd from the CC-community skills landscape (it installs as a CC skill-pack).
+- `docs/non-cc/agentic-payments-landscape.md`: new landscape on machine-native agent payment rails — x402 (Coinbase → Linux Foundation; HTTP 402; USDC/Base), Google AP2 (Mandates = W3C Verifiable Credentials), Stripe MPP, Fetch.ai — with the Apify x402 case study.
+- `docs/non-cc/karpathy-agentic-coding-analysis.md`: primary-source map of Andrej Karpathy's agentic-coding arc (LLM OS → vibe coding → Software 3.0 / autonomy slider → agentic engineering).
+- `docs/sdlc-lcm/agent-identity-auth-landscape.md`: new landscape on agent identity / authentication / personhood — SPIFFE, Microsoft Entra Agent ID, MCP-OAuth, Okta Cross-App Access, AP2 Mandates, World ID / Humanity Protocol, Cloudflare Web Bot Auth — organized by the authenticate-the-agent / authorize-on-behalf-of-human / personhood axes, plus one-time/JIT permissions. Joins the sdlc-lcm security cluster.

--- a/docs/cc-community/CC-community-skills-landscape.md
+++ b/docs/cc-community/CC-community-skills-landscape.md
@@ -458,6 +458,7 @@ Cross-ref: Dispatch (above) fans out *work* to background agents; `/agent-watchd
 - [CC-official-plugins-landscape.md](../cc-native/plugins-ecosystem/CC-official-plugins-landscape.md) — official plugin ecosystem
 - [CC-community-plugins-landscape.md](CC-community-plugins-landscape.md) — plugin catalogs
 - [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) — claude-mem persistent memory
+- [agents-cli-analysis.md](../non-cc/agents-cli-analysis.md) — Google agents-cli installs as a CC skill-pack (`npx skills add`) but is cross-agent; deeper analysis lives in non-cc
 
 ## Sources
 

--- a/docs/handoffs/2026-07-08-source-expansion.md
+++ b/docs/handoffs/2026-07-08-source-expansion.md
@@ -1,0 +1,49 @@
+---
+title: Handoff — 2026-07-08 source expansion + deferred graph rebuild (#354/#374)
+purpose: Onboard a fresh session to finish the source-expansion effort — mainly the deferred graph rebuild that must now include all of this session's new docs.
+created: 2026-07-08
+updated: 2026-07-08
+---
+
+**Status**: Reference (handoff)
+
+## TL;DR
+
+Two waves of new sources landed 2026-07-08 (all merged to `main`). The **one open action** is the
+deferred **#354 graph rebuild** — it must now incorporate *all* of them. Full map + rationale:
+[../plans/2026-07-08-new-sources-batch.md](../plans/2026-07-08-new-sources-batch.md) (wave 1) and
+[../plans/2026-07-08-source-expansion-wave2.md](../plans/2026-07-08-source-expansion-wave2.md) (wave 2).
+Tracker: [#374](https://github.com/qte77/ai-agents-research/issues/374).
+
+## Done (merged)
+
+- **Wave 1:** #372 agentic-AI-vulnerability-landscape · #373 kv-cache-serving-landscape (+ CC-prompt-caching min-token fix) · #375 Codex-CC plugin + OpenWiki + company-brain + CONTRIBUTING polyfetch/doc-pipeline pointer.
+- **Wave 2:** agents-cli, agentic-payments, karpathy-agentic-coding, agent-identity-auth (this PR).
+
+## The open action — graph rebuild (#354)
+
+1. `graphify` is installed: `uv tool install graphifyy` (package `graphifyy`, executable `graphify`).
+   Python API via `uv tool run --from graphifyy python …` or the interpreter written to
+   `graphify-out/.graphify_python` (`~/.local/share/uv/tools/graphifyy/bin/python`).
+2. **Scope is near-full, not incremental:** `detect_incremental` (2026-07-08) already reported ~110+
+   changed files vs a stale manifest (75+ docs → ~4-5 semantic subagents; 31 code/tooling files that
+   `make graph-page` prunes anyway). Wave 2 adds ~4 more docs on top.
+3. Flow: `/graphify --update` (or a full rebuild) → label the communities → `make graph-page` →
+   commit `ui/graph.html` → push to `main` (gh-pages deploy) → check the box in #374 + comment #354.
+4. It was deliberately deferred to a fresh session (context-exhaustion at the tail of a long build
+   session) — run it with room to do the community-labeling + viz steps properly.
+
+## Also open (lower priority)
+
+- **Scout backlog** — 13 promotable triage/rxiv candidates as a checklist in #374 (parry, MOSS,
+  silent-failure taxonomy, Probe-and-Refine, …; 4 flagged as borderline-dups to verify first). Write
+  as new analysis docs when picked up; re-research first-party.
+
+## Gotchas
+
+- New scraping/PDF tooling is now documented in CONTRIBUTING's Research Workflow: **polyfetch-scrape**
+  (fetch JS-SPA/blocked pages) and **doc-pipeline-engine** (PDF/Office → text), both via
+  `uv run --directory`. Use them for dynamic/unparsable sources.
+- Sourcing landmines recorded in the wave-2 plan: `ap2-protocol.org/specification/` 404s (use the
+  GitHub repo); `docs.humanity.org/introduction/overview` 404s; x.com 402s automated fetch.
+- Pre-existing unrelated link-rot to fix opportunistically: `usage.ai` 301 in `kiro-analysis.md`.

--- a/docs/non-cc/README.md
+++ b/docs/non-cc/README.md
@@ -66,6 +66,7 @@ Terminal/CLI agents and agentic IDEs beyond Claude Code — the former "Planned"
 |---|---|---|
 | [intro-autonomous-robots-analysis.md](intro-autonomous-robots-analysis.md) | Introduction to Autonomous Robots (open textbook, MIT Press) | Open access |
 | [harnessx-analysis.md](harnessx-analysis.md) | HarnessX — composable/evolvable agent harness foundry (arXiv 2606.14249) | Preprint (code TBD) |
+| [karpathy-agentic-coding-analysis.md](karpathy-agentic-coding-analysis.md) | Karpathy's agentic-coding arc (vibe coding → Software 3.0 / autonomy slider → agentic engineering) | Blog + talks |
 
 ## Context & Memory Infrastructure
 
@@ -104,6 +105,7 @@ Terminal/CLI agents and agentic IDEs beyond Claude Code — the former "Planned"
 | [spec-driven-frameworks-landscape.md](spec-driven-frameworks-landscape.md) | Spec-driven development frameworks (spec-kit, OpenSpec, BMAD, Agent-OS, Kiro, Tessl); standalone deep-dive behind the disciplines §3 synthesis | — | Mixed |
 | [openai-swarm-analysis.md](openai-swarm-analysis.md) | OpenAI Swarm (deprecated educational multi-agent; superseded by Agents SDK) | Yes | Yes (MIT) |
 | [openai-agents-sdk-analysis.md](openai-agents-sdk-analysis.md) | OpenAI Agents SDK (multi-agent: handoffs, guardrails, sessions, tracing; GA successor to Swarm) | Yes | Yes (MIT) |
+| [agents-cli-analysis.md](agents-cli-analysis.md) | Google agents-cli (skill-pack that upskills a coding agent — Claude Code/Antigravity/Codex — to build/eval/deploy ADK agents on Gemini Enterprise) | — | Yes (Apache-2.0) |
 
 ## Protocols & Interfaces
 
@@ -112,6 +114,7 @@ Terminal/CLI agents and agentic IDEs beyond Claude Code — the former "Planned"
 | [ag-ui-protocol-landscape.md](ag-ui-protocol-landscape.md) | AG-UI (Agent-User Interaction protocol), A2UI (Google declarative generative-UI spec), OpenGenerativeUI (CopilotKit reference framework); 2026 ecosystem adoption + Salesforce non-adoption note |
 | [agentcanvas-analysis.md](agentcanvas-analysis.md) | AgentCanvas — renders Pydantic AI + Logfire execution traces as interactive HTML diagrams (OTel agent observability) |
 | [agent-observability-methods-analysis.md](agent-observability-methods-analysis.md) | Survey of 18 OTel observability platforms + 5 tracing patterns for agent behavior (Langfuse, Arize Phoenix, Logfire, …); CC's own first-party telemetry split to cc-native |
+| [agentic-payments-landscape.md](agentic-payments-landscape.md) | Machine-native agent payment rails: x402 (Coinbase/Linux Foundation), Google AP2, Stripe MPP, Fetch.ai |
 
 ## Backlog status
 

--- a/docs/non-cc/agentic-payments-landscape.md
+++ b/docs/non-cc/agentic-payments-landscape.md
@@ -1,0 +1,93 @@
+---
+title: Agentic Payments Landscape — Machine-Native Payment Rails for Agents
+purpose: Survey of emerging agent-to-machine payment protocols (x402, Google AP2, Stripe MPP) that let autonomous agents pay for API/tool access without a human in the loop per transaction.
+category: landscape
+created: 2026-07-08
+updated: 2026-07-08
+validated_links: 2026-07-08
+---
+
+**Status**: Research (informational)
+
+**Machine-native payment rails** let an autonomous agent discover a paid tool/API, pay for it, and use
+it — with no human provisioning a key per purchase. This is the "agent economics" plumbing beneath
+autonomous multi-agent systems: *agent hits a paywall → wallet authorizes → agent retries and gets the
+resource*. The corpus had **zero** coverage of this before (only a one-line Fetch.ai mention); this doc
+catalogs the emerging, competing standards. It is tightly coupled to **agent identity/authentication**
+(a payer needs a verifiable identity) — see
+[../sdlc-lcm/agent-identity-auth-landscape.md](../sdlc-lcm/agent-identity-auth-landscape.md) (AP2's
+Mandates *are* the authorization primitive) and the security angle in
+[../sdlc-lcm/agentic-ai-vulnerability-landscape.md](../sdlc-lcm/agentic-ai-vulnerability-landscape.md).
+
+## The standards
+
+| Protocol | Backer / governance | Mechanism | Settlement | Maturity |
+|---|---|---|---|---|
+| **x402** | Coinbase-originated → **Linux Foundation** | HTTP `402` challenge/response; signed payment header | USDC on **Base** (EIP-3009 / Permit2) | Live, 20k+ payable endpoints (Apify) |
+| **Google AP2** | Google (`google-agentic-commerce`) | **Mandates** (W3C VC): Intent→Cart→Payment, ECDSA/P-256 — an authorization layer, not a rail | Payment-method-agnostic | Early (v0.2.0, 2026-04-28) |
+| **Stripe MPP** | Stripe (Machine Payments Protocol) | Named as x402's alternative in an Apify MCP RFC | (not verified here) | Emerging |
+| **Fetch.ai uAgents** | Fetch.ai (Agentverse) | On-chain agent payments | On-chain | Shipped (niche) |
+
+### x402 (the anchor)
+
+[x402][x402-repo] repurposes the dormant **HTTP 402 "Payment Required"** code: an agent requests a paid
+resource, the server replies `402` with a payment challenge, the agent's wallet signs a blockchain
+authorization (**EIP-3009 `TransferWithAuthorization`** or **Permit2**), retries with a payment header,
+and the server verifies/settles. Originally built by **Coinbase**, it is now an **open-source protocol
+under the Linux Foundation** — a real maturity signal (single-vendor → neutral governance). Settlement
+is **USDC on Base**; two pricing schemes (`exact` fixed-price, `upto` capped-variable).
+
+**Apify case study** ([blog][x402-apify-blog] · [docs][x402-apify-docs]): Apify made its Actor
+marketplace payable via x402 without API keys — an agent funds a **Coinbase Agentic Wallet** (`awal`)
+with USDC on Base, buys a **prepaid token balance** (`npx awal x402 pay`, $1 minimum, acts as a hard
+spending cap), and each Actor run draws it down. Apify reports **~20,000+ x402-enabled Actors** (≈10×
+growth) as of 2026-06-30; eligible Actors must be "pay-per-event," limited-permission, no Standby.
+A prior community RFC to gate payments *inside the MCP server* per-tool-call
+([apify-mcp-server#626][x402-mcp-issue], via a `@tomopay/gateway` supporting both x402 and Stripe MPP)
+was **closed as superseded** by this platform-level integration — i.e., agent payments are landing at
+the API/Actor layer, not (yet) inside MCP tool calls.
+
+### Google AP2 (Agent Payments Protocol)
+
+[AP2][ap2] (Apache-2.0; `v0.2.0`, 2026-04-28; Google `google-agentic-commerce` org) is a
+**trust/authorization layer, not a settlement rail**: its core primitive is the **Mandate**, a
+**W3C Verifiable Credential**, chained **Intent → Cart → Payment Mandate** and ECDSA/P-256-signed to
+cryptographically prove a purchase was human-authorized ([AP2 repo][ap2]). It is payment-method-agnostic
+(it rides on top of a rail rather than being one). Because Mandates are the "authorize on behalf of a
+human" primitive, AP2 sits at the seam of payments and **agent identity/auth** — see
+[../sdlc-lcm/agent-identity-auth-landscape.md](../sdlc-lcm/agent-identity-auth-landscape.md).
+
+### Stripe MPP & Fetch.ai
+
+**Stripe's Machine Payments Protocol (MPP)** appears as x402's named alternative in the Apify RFC
+above — a competing rail from the traditional-payments incumbent; not independently characterized here.
+**Fetch.ai uAgents** already appears as a one-line mention in
+[agent-frameworks-infrastructure-landscape.md](agent-frameworks-infrastructure-landscape.md)
+(blockchain-integrated agents with on-chain payments via Agentverse).
+
+## Why it matters / takeaways
+
+- **New primitive, moving fast:** foundation governance (x402), a Google entrant (AP2), and a Stripe
+  entrant (MPP) all within ~one quarter — autonomous agent-to-service payment is consolidating from
+  research into rails.
+- **Crypto vs card rails split:** x402 is USDC/Base (onchain); AP2/MPP aim payment-method-agnostic /
+  card-inclusive. Watch which agent frameworks adopt which.
+- **Distinct from human-account SaaS billing:** this is *not* Claude Code calling a Stripe MCP server
+  on a human's account (see [../cc-native/plugins-ecosystem/CC-business-api-integrations.md](../cc-native/plugins-ecosystem/CC-business-api-integrations.md)) — it's the agent itself as the payer.
+- **Assess:** early, standards-in-flux, crypto-settlement caveats. Track x402/AP2 releases; revisit as
+  MCP-level payment gating (deferred in #626) reappears.
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [x402 (Coinbase/LF)][x402-repo] | x402 protocol home |
+| [Apify: introducing x402][x402-apify-blog] · [Apify x402 docs][x402-apify-docs] | Live x402 integration + case study |
+| [apify-mcp-server#626][x402-mcp-issue] | Closed RFC: MCP-level payment gating (x402 + Stripe MPP) |
+| [google-agentic-commerce/AP2][ap2] | Google Agent Payments Protocol (v0.2.0) |
+
+[x402-repo]: https://github.com/coinbase/x402
+[x402-apify-blog]: https://blog.apify.com/introducing-x402-agentic-payments/
+[x402-apify-docs]: https://docs.apify.com/platform/integrations/x402
+[x402-mcp-issue]: https://github.com/apify/apify-mcp-server/issues/626
+[ap2]: https://github.com/google-agentic-commerce/AP2

--- a/docs/non-cc/agents-cli-analysis.md
+++ b/docs/non-cc/agents-cli-analysis.md
@@ -1,0 +1,74 @@
+---
+title: "Google agents-cli — Skill Layer for Building ADK Agents"
+source: https://github.com/google/agents-cli
+purpose: Analysis of Google's agents-cli — a CLI + skill-pack that turns a coding agent (Claude Code, Antigravity, Codex) into an expert at scaffolding, evaluating, and deploying ADK agents on the Gemini Enterprise Agent Platform.
+category: analysis
+platform_scope: [claude-code, antigravity, codex, google-adk]
+created: 2026-07-08
+updated: 2026-07-08
+validated_links: 2026-07-08
+---
+
+**Status**: Assess
+
+## What It Is
+
+[agents-cli][repo] (PyPI `google-agents-cli`; Apache-2.0; ~4.9k stars; `v1.0.0` published 2026-07-01,
+repo created 2026-04-08) is, in its own README's words, *"a tool **for** coding agents, not a coding
+agent itself."* It is a CLI plus a bundled skill-pack that turns an existing coding agent — **Claude
+Code**, Antigravity CLI, Codex, or any other — into an expert at scaffolding, evaluating, deploying,
+and publishing agents built on Google's **Agent Development Kit (ADK)**, targeting the **Gemini
+Enterprise Agent Platform** / Google Cloud. It also runs standalone from a terminal.
+
+**Maturity caveat:** despite the `v1.0.0` tag, the README flags it as **Pre-GA / Preview** ("subject
+to the 'Pre-GA Offerings Terms'… available 'as is'"). Treat the 1.0 as a version string, not a GA
+guarantee.
+
+It is distinct from everything already in the corpus: not a coding agent (unlike
+[gemini-cli-analysis.md](gemini-cli-analysis.md), which is **Hold**), not a host IDE (unlike
+[antigravity-analysis.md](antigravity-analysis.md), a *named host* for agents-cli), and a level up
+from the one-line **Google ADK** entry in
+[agent-frameworks-infrastructure-landscape.md](agent-frameworks-infrastructure-landscape.md). ADK is
+the agent *framework*; agents-cli is the lifecycle tooling around it.
+
+## How It Works
+
+Two install/use modes:
+
+- **With a coding agent** (`npx skills add google/agents-cli`, skills only): prompt the host agent,
+  e.g. *"Use agents-cli to build a caveman-style agent…"* — the 7 bundled skills
+  (`…-workflow`, `-adk-code`, `-scaffold`, `-eval`, `-deploy`, `-publish`, `-observability`) drive it.
+- **Standalone** (`uvx google-agents-cli setup`, full CLI): `agents-cli create <name> --prototype`,
+  `install`, `playground`.
+
+Core commands span the ADK-agent lifecycle: `scaffold` (+ `enhance`/`upgrade`), `run`,
+`eval` (`generate`/`grade`/`dataset synthesize`/`compare`/`analyze`/`optimize`), `deploy`,
+`publish gemini-enterprise`, `infra` (`single-project`/`cicd`/`datastore`), `data-ingestion`. Prereqs:
+Python 3.11+, `uv`, Node.js; Google Cloud creds or an AI Studio API key (local `create`/`run`/`eval`
+work without GCP; only deploy needs the Cloud SDK/Terraform).
+
+## Adoption Decision
+
+**Assess.** Research interest for this corpus is twofold: (1) it's a concrete instance of the
+**"skill layer for coding agents"** pattern — a vendor shipping *skills that ride inside Claude Code
+et al.* to specialize them for a target platform, rather than building yet another agent; and (2) it
+names **Claude Code as a first-class host**, a data point on cross-vendor skill portability. Not
+something to adopt (it's Google-Cloud/ADK-specific and Pre-GA), but worth tracking as the pattern of
+"agent-building tooling delivered as portable skills" matures. Contrast with the OpenAI Codex→CC
+plugin ([../cc-community/CC-codex-plugin-cc-analysis.md](../cc-community/CC-codex-plugin-cc-analysis.md)),
+which delegates *between* agents; agents-cli instead *upskills* the host agent for ADK work.
+
+Cross-ref: [agent-frameworks-infrastructure-landscape.md](agent-frameworks-infrastructure-landscape.md) (Google ADK) ·
+[gemini-cli-analysis.md](gemini-cli-analysis.md) · [antigravity-analysis.md](antigravity-analysis.md)
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [google/agents-cli][repo] | Repo: README, skills, commands, releases (Apache-2.0, v1.0.0, 2026-07-01) |
+| [agents-cli getting started][getstarted] | Install + usage modes |
+| [agents-cli docs][docs] | Scope: "CLI and skills for building agents on Gemini Enterprise Agent Platform" |
+
+[repo]: https://github.com/google/agents-cli
+[getstarted]: https://google.github.io/agents-cli/guide/getting-started/
+[docs]: https://google.github.io/agents-cli/

--- a/docs/non-cc/karpathy-agentic-coding-analysis.md
+++ b/docs/non-cc/karpathy-agentic-coding-analysis.md
@@ -1,0 +1,81 @@
+---
+title: "Karpathy on Agentic Coding — Vibe Coding to Agentic Engineering"
+source: https://karpathy.bearblog.dev/
+purpose: Primary-source map of Andrej Karpathy's agentic-coding arc (2023 LLM OS → 2025 Software 3.0 / vibe coding → 2026 agentic engineering) and its relevance to agentic-SDLC and harness design.
+category: analysis
+created: 2026-07-08
+updated: 2026-07-08
+validated_links: 2026-07-08
+---
+
+**Status**: Research (informational)
+
+A curated map of Andrej Karpathy's **agentic-coding** thinking as it evolved 2023→2026 — distinct from
+his LLM-wiki/knowledge-base artifact already covered in
+[karpathy-llm-kb-analysis.md](karpathy-llm-kb-analysis.md). The through-line: the programmer as an
+**orchestrator of fallible agents** on a controllable **autonomy dial**, not a code author. It grounds
+the discipline framing in [../sdlc-lcm/agentic-engineering-disciplines-landscape.md](../sdlc-lcm/agentic-engineering-disciplines-landscape.md).
+
+> **Sourcing note:** the blog posts ([bearblog][menugen]) and the talks (YouTube / YC Library) are
+> first-party. The essay-tweets (vibe-coding coinage, LLM OS) are cited **by date**; x.com returns
+> HTTP 402 to automated fetches, so their wording is corroborated via secondary write-ups, not a
+> first-party fetch — flagged rather than asserted.
+
+## The arc
+
+- **LLM OS** (essay-tweet, 2023-09-28; developed in the *"Intro to Large Language Models"* talk,
+  [YouTube][llm-intro], 2023-11): the LLM as an **OS kernel** orchestrating tools, memory
+  (context window as RAM), and multimodal I/O — the conceptual seed of agent-as-orchestrator.
+- **"Vibe coding"** (essay-tweet, 2025-02-02): coins the term — "giving in to the vibes," describing
+  intent and running LLM-generated code without close review. The low-rigor end of the spectrum he
+  later contrasts with agentic engineering.
+- **"Vibe Coding MenuGen"** ([bearblog][menugen], 2025-04-27): field report — prototyping is fast, but
+  the grind moves to browser-only SaaS dashboards (Vercel/Clerk/Stripe) "not accessible or manipulable
+  by an LLM." Seeds the **"build for agents too"** (CLI/curl/markdown, not just GUIs) argument.
+- **"Software Is Changing (Again)" / Software 3.0** (YC AI Startup School talk, 2025-06-17 —
+  [YouTube][sw3-talk], [YC Library][sw3-yc]): the core talk. LLMs as a new computer programmed in
+  English; the **autonomy slider** (tab-complete → select-edit → full-file → agent-mode, from his
+  Tesla Autopilot experience); **"Iron Man suit, not Iron Man robot"** (augmentation with a dial, not
+  full autonomy); keep the generation→verification loop with **"AI on a tight leash"**; *"demo is
+  `works.any()`, product is `works.all()`"*; and redesign software/infra for **three audiences —
+  humans, computers, and agents** (llms.txt, machine-readable docs). "The decade of agents."
+- **"2025 LLM Year in Review"** ([bearblog][year-review], 2025-12-19): names **Claude Code** "the first
+  convincing demonstration of what an LLM Agent looks like" — chained tool-use + reasoning running
+  **locally** with the user's own environment/credentials (not a cloud sandbox).
+- **"Sequoia Ascent 2026"** ([bearblog][sequoia], 2026-04-30): his sharpest statement — **vibe coding
+  "raises the floor"** (no quality bar, ships slop) vs **agentic engineering "raises the ceiling"** (a
+  professional discipline: spec design, plan supervision, diff review, permission/worktree management,
+  eval-loop construction). *"You can outsource your thinking, but you can't outsource your
+  understanding."*
+
+## Why it matters
+
+- **The autonomy slider + "keep AI on a leash"** is the conceptual backbone of this repo's harness and
+  permission-model analyses (agent-mode gating, worktree isolation, approval loops) —
+  [../cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md](../cc-native/agents-skills/CC-agentic-harness-patterns-analysis.md).
+- **"Build for agents too"** anticipates the `llms.txt` / `AGENTS.md` / machine-readable-docs thread
+  (and OpenWiki-style agent-context tooling) cataloged elsewhere in the corpus.
+- **"Agentic engineering as a discipline"** is the same thesis the estate's SDLC docs operationalize —
+  spec-driven, eval-looped, review-gated agent work.
+- CC-as-first-convincing-agent is a notable outside validation of this corpus's CC focus.
+
+Cross-ref: [../sdlc-lcm/agentic-engineering-disciplines-landscape.md](../sdlc-lcm/agentic-engineering-disciplines-landscape.md) ·
+[karpathy-llm-kb-analysis.md](karpathy-llm-kb-analysis.md)
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [Vibe Coding MenuGen][menugen] | Field report; infra-not-model bottleneck; "build for agents" |
+| [2025 LLM Year in Review][year-review] | Claude Code as the first convincing LLM agent |
+| [Sequoia Ascent 2026][sequoia] | Vibe coding (floor) vs agentic engineering (ceiling) |
+| [Software Is Changing (Again)][sw3-talk] · [YC Library][sw3-yc] | Software 3.0, autonomy slider, decade of agents |
+| [Intro to Large Language Models][llm-intro] | LLM OS (agent-as-kernel) precursor |
+| Karpathy essay-tweets (2025-02-02 vibe coding; 2023-09-28 LLM OS) | Term coinage — dated, x.com fetch blocked (secondary-corroborated) |
+
+[menugen]: https://karpathy.bearblog.dev/vibe-coding-menugen/
+[year-review]: https://karpathy.bearblog.dev/year-in-review-2025/
+[sequoia]: https://karpathy.bearblog.dev/sequoia-ascent-2026/
+[sw3-talk]: https://www.youtube.com/watch?v=LCEmiRjPEtQ
+[sw3-yc]: https://www.ycombinator.com/library/MW-andrej-karpathy-software-is-changing-again
+[llm-intro]: https://www.youtube.com/watch?v=zjkBMFhNj_g

--- a/docs/plans/2026-07-08-source-expansion-wave2.md
+++ b/docs/plans/2026-07-08-source-expansion-wave2.md
@@ -1,0 +1,47 @@
+---
+title: Source expansion (wave 2) — agents-cli, agentic payments, Karpathy, agent identity/auth
+status: done
+issue: 374
+created: 2026-07-08
+updated: 2026-07-08
+---
+
+**Status**: Reference (plan)
+
+Durable record + source map for the **second wave** of new sources added 2026-07-08, ahead of the
+deferred [#354](https://github.com/qte77/ai-agents-research/issues/354) graph rebuild. Wave 1 is
+[2026-07-08-new-sources-batch.md](2026-07-08-new-sources-batch.md); umbrella tracker
+[#374](https://github.com/qte77/ai-agents-research/issues/374). Handoff:
+[../handoffs/2026-07-08-source-expansion.md](../handoffs/2026-07-08-source-expansion.md).
+
+## What was added (wave 2)
+
+| Doc | Home | Anchor sources (first-party) |
+|---|---|---|
+| `non-cc/agents-cli-analysis.md` | non-cc / Frameworks | github.com/google/agents-cli; google.github.io/agents-cli (Apache-2.0, v1.0.0 Pre-GA) |
+| `non-cc/agentic-payments-landscape.md` | non-cc / Protocols & Interfaces | github.com/coinbase/x402; blog.apify.com/introducing-x402-agentic-payments; docs.apify.com/platform/integrations/x402; apify/apify-mcp-server#626; github.com/google-agentic-commerce/AP2 |
+| `non-cc/karpathy-agentic-coding-analysis.md` | non-cc / Reference & Background | karpathy.bearblog.dev (menugen, year-in-review-2025, sequoia-ascent-2026); YT `LCEmiRjPEtQ`; YC Library "software-is-changing-again" |
+| `sdlc-lcm/agent-identity-auth-landscape.md` | sdlc-lcm (security cluster) | spiffe.io; learn.microsoft.com Entra Agent ID; eips.ethereum.org/EIPS/eip-8004; privado.id; modelcontextprotocol.io authz; developer.okta.com XAA; github.com/google-agentic-commerce/AP2; world.org; humanity.org; blog.cloudflare.com web-bot-auth + pay-per-crawl; beyondtrust.com JIT; code.claude.com/docs/en/permissions |
+
+## Placement rationale (verified against coverage)
+
+- **agents-cli → non-cc/Frameworks** (not cc-community): cross-agent tool (CC one of 3+ hosts), subject is ADK/Gemini-Enterprise. Cross-ref added from `cc-community/CC-community-skills-landscape.md` (it ships as a CC skill-pack) per CONTRIBUTING's "spans-both → deeper analysis + cross-ref."
+- **agentic payments → non-cc/Protocols & Interfaces**: new topic (zero prior coverage). x402 anchor + AP2 (Mandate = W3C VC, *authorization* layer not a rail) + Stripe MPP (via #626, closed RFC) + Fetch.ai cross-link.
+- **agent identity/auth → sdlc-lcm** (security cluster): new topic; different axis from CC-local sandbox perms. Three axes — authenticate-the-agent / authorize-on-behalf-of-human / personhood — + one-time/JIT. Bidirectionally cross-linked with the payments doc (AP2 Mandates are the payments↔identity seam).
+- **Karpathy agentic-coding → new doc** (distinct from the existing KB-pattern `karpathy-llm-kb-analysis.md`); essay-tweets cited by date (x.com 402s automated fetch — blogs/talks are the first-party anchors).
+
+## Sourcing caveats (for re-verification)
+
+- **AP2 canonical = the GitHub repo** `google-agentic-commerce/AP2`; `ap2-protocol.org/specification/` **404s** (do not use).
+- **Humanity Protocol**: `docs.humanity.org/introduction/overview` 404s → homepage used; project is rebranding away from "proof-of-personhood" (Biometric Update, Feb 2026) — recheck.
+- **Karpathy x.com tweets**: content secondary-corroborated (x.com returns 402 to WebFetch).
+
+## Full session source set for the graph rebuild
+
+Wave 1 (merged): #372 `agentic-ai-vulnerability-landscape`, #373 `kv-cache-serving-landscape` (+ CC-prompt-caching refresh), #375 (Codex-CC plugin, OpenWiki, company-brain, CONTRIBUTING polyfetch/doc-pipeline pointer).
+Wave 2 (this PR): the four above. **All of these must be in scope for the #354 rebuild.**
+
+## Follow-ups (tracked in #374)
+
+- [ ] **#354 graph rebuild** — see the handoff; `detect_incremental` already shows ~110+ changed files vs a stale manifest → near-full re-extraction (~4-5 semantic subagents).
+- [ ] Scout backlog (13 candidates) — checklist in #374.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -32,3 +32,4 @@ updated: 2026-07-08
 | [2026-06-14-planning-workflow-and-open-task-triage.md](2026-06-14-planning-workflow-and-open-task-triage.md) | done | #242, #243 |
 | [2026-07-05-status-frontmatter-migration.md](2026-07-05-status-frontmatter-migration.md) | approved | #348 |
 | [2026-07-08-new-sources-batch.md](2026-07-08-new-sources-batch.md) | done | #374 |
+| [2026-07-08-source-expansion-wave2.md](2026-07-08-source-expansion-wave2.md) | done | #374 |

--- a/docs/sdlc-lcm/README.md
+++ b/docs/sdlc-lcm/README.md
@@ -34,6 +34,7 @@ Lifecycle management specs for the qte77 coding agent ecosystem.
 | [mas-security-framework.md](mas-security-framework.md) | OWASP MAESTRO v1.0 threat modeling (7-layer) for multi-agent systems |
 | [ai-security-governance-analysis.md](ai-security-governance-analysis.md) | NIST AI RMF, EU AI Act, OWASP LLM Top 10, ISO 42001 frameworks |
 | [agentic-ai-vulnerability-landscape.md](agentic-ai-vulnerability-landscape.md) | Operational vuln layer: AIVSS scoring, MITRE ATLAS + AI Incident Sharing, vendor discovery (MDASH/Vuln.AI), Berkeley tracker |
+| [agent-identity-auth-landscape.md](agent-identity-auth-landscape.md) | Agent identity/auth/personhood: SPIFFE, Entra Agent ID, MCP-OAuth, Okta XAA, AP2 Mandates, World ID, Cloudflare Web Bot Auth |
 | [agent-evaluation-metrics-landscape.md](agent-evaluation-metrics-landscape.md) | Agent evaluation metrics survey (task completion, reasoning, safety) |
 | [evaluation-data-resources-landscape.md](evaluation-data-resources-landscape.md) | Eval frameworks, agentic benchmarks, datasets (companion to the metrics survey) |
 

--- a/docs/sdlc-lcm/agent-identity-auth-landscape.md
+++ b/docs/sdlc-lcm/agent-identity-auth-landscape.md
@@ -1,0 +1,132 @@
+---
+title: Agent Identity, Authentication & Personhood Landscape
+purpose: Survey of how agents get identity and authorization, and how human-vs-agent is proven — the "who may act, and how is it proven" layer, distinct from CC-local runtime permissions.
+category: landscape
+created: 2026-07-08
+updated: 2026-07-08
+validated_links: 2026-07-08
+---
+
+**Status**: Assess
+
+The **identity / authorization / personhood** layer for agents: *who is allowed to act, on whose
+authority, and how is human-vs-agent proven.* This is a different axis from two things already in the
+corpus — **CC-local runtime permissions** (allow/deny/ask + OS sandbox, see
+[../cc-native/sandboxing/CC-permissions-bypass-analysis.md](../cc-native/sandboxing/CC-permissions-bypass-analysis.md)
+and [CC-sandboxing-analysis.md](../cc-native/sandboxing/CC-sandboxing-analysis.md)) and **CC's own
+product auth** ([../cc-native/ci-remote/CC-web-auth-setup-analysis.md](../cc-native/ci-remote/CC-web-auth-setup-analysis.md))
+— which answer "how does *Claude Code itself* authenticate," whereas this doc is "how do *agents in
+general* get identity/authorization, and how is human-vs-agent distinguished."
+
+It joins the security cluster: [agentic-ai-vulnerability-landscape.md](agentic-ai-vulnerability-landscape.md)
+(vuln scoring/discovery), [ai-security-governance-analysis.md](ai-security-governance-analysis.md)
+(governance frameworks), [mas-security-framework.md](mas-security-framework.md) (MAESTRO). It is also
+the substrate under [../non-cc/agentic-payments-landscape.md](../non-cc/agentic-payments-landscape.md)
+— x402 needs a payer identity; AP2's Mandates *are* the "authorize on behalf of a human" instance of
+this topic.
+
+Three axes structure the space (most 2026 systems combine them):
+
+## 1. Authenticate the agent (agent as a first-class principal)
+
+The agent has its own identity, independent of any human.
+
+- **SPIFFE / SPIRE** — workload identity: SPIRE issues short-lived, auto-rotating **SVIDs** (X.509 or
+  JWT) asserting "this workload, this context, this identity," independent of any OAuth session.
+  Increasingly proposed as the substrate under agentic systems. [spiffe.io][spiffe].
+- **Microsoft Entra Agent ID** (GA April 2026) — an agent identity is a dedicated **service principal**
+  in Entra ID (a genuine non-human identity that may also be "authorized to impersonate" a user);
+  agents built in Azure AI Foundry / Copilot Studio auto-register. [learn.microsoft.com][entra].
+- **ERC-8004 "Trustless Agents"** (Draft EIP) — on-chain Identity / Reputation / Validation registries
+  (ERC-721 identity handle → off-chain agent registration JSON) for cross-org agent discovery/trust
+  without pre-existing trust. Contracts deployed, EIP still Draft. [eips.ethereum.org][erc8004].
+- **Privado ID "Know Your Agent" (KYA)** — gives agents a verifiable identity tied to a creator, with
+  public reputation (W3C DIDs + ZK verifiable credentials); a SingularityNET trust registry. Bridges
+  "is this a human" and "is this agent accountable." [privado.id][privado].
+
+## 2. Authorize the agent on behalf of a human (delegated, scoped, auditable)
+
+- **MCP Authorization (OAuth 2.1)** — MCP servers act as OAuth 2.1 **resource servers** validating
+  tokens from an external authorization server; MUST implement RFC 9728 (Protected Resource Metadata),
+  PKCE mandatory. Delegated human authority, not a durable agent identity. [modelcontextprotocol.io][mcp-authz].
+- **Okta Cross-App Access (XAA) / Auth for GenAI** — an OAuth/OIDC extension using the IETF
+  "Identity Assertion Authorization Grant" (ID-JAG); an enterprise IdP mediates agent-to-app and
+  app-to-app connections, replacing long-lived API keys with real-time, revocable delegation + audit.
+  [okta.com][xaa].
+- **Google AP2 Mandates** — AP2's core primitive is the **Mandate**, a W3C Verifiable Credential;
+  Intent → Cart → Payment Mandate chain, ECDSA/P-256-signed, cryptographically proving a purchase was
+  human-authorized. A trust/authorization layer feeding [agentic payments](../non-cc/agentic-payments-landscape.md).
+  [AP2 repo][ap2].
+
+## 3. Personhood & the bot-vs-authorized-agent distinction
+
+As agents pass CAPTCHAs, sites need a stronger signal than behavioral heuristics.
+
+- **World ID / World (Worldcoin)** — one-time in-person **Orb** (iris) enrollment yields a reusable,
+  ZK "proof of human" (no biometric template revealed on reuse); ~40M signed up; "Orb Mini" targeted
+  2026. Explicitly framed against the agent era eroding anti-bot defenses. [world.org][worldid].
+- **Humanity Protocol** — palm-vein biometric → "Proof-of-Trust"; zkProofer on-chain verification, no
+  central raw-biometric storage; Mastercard partnership. ⚠️ Per Biometric Update (Feb 2026) it has
+  pivoted *messaging* away from "proof-of-personhood" while keeping the tech — a moving target.
+  [docs.humanity.org][humanity].
+- **Cloudflare Web Bot Auth / signed agents** — an IETF-draft standard on **HTTP Message Signatures**
+  (RFC 9421): an operator publishes a public key at a well-known URL
+  (e.g. `anthropic.com/.well-known/http-message-signatures-directory`); requests are signed per-origin
+  and verified server-side — cryptographic proof of *which* bot, replacing spoofable UA/IP. AWS WAF
+  added support Nov 2025; OpenAI signs Operator requests this way. [blog.cloudflare.com][webbotauth].
+- **Pay-or-authenticate (pay-per-crawl)** — repurposes HTTP 402: a crawler must both **pay** and
+  **authenticate** (via Web Bot Auth) to proceed — a literal fusion of the identity and payment axes.
+  [blog.cloudflare.com][paypercrawl].
+
+## One-time / just-in-time permissions
+
+- **Zero Standing Privileges / JIT access** — no standing privileged credentials; access (and, for
+  agents, sometimes the identity itself) is provisioned at task start, scoped, and auto-revoked at
+  completion. [beyondtrust.com][jit].
+- **Human-in-the-loop approval gates** — HumanLayer's approval-gate SDK (12-Factor Agents "Factor 7")
+  is already cited in [mas-design-principles.md](mas-design-principles.md).
+- **Claude Code's permission model** (local reference anchor, *not* an instance of the above) —
+  per-tool-call allow / ask / deny, evaluated deny → ask → allow, managed via `/permissions` and
+  `.claude/settings.json`. A single-vendor, local, pre-configured rule-gate — no external IdP, no token
+  exchange, no cross-org delegation. [code.claude.com][cc-perms].
+
+## Takeaways
+
+- **Two questions, often conflated:** *authenticate the agent* (SPIFFE, Entra Agent ID, ERC-8004) vs
+  *authorize it for a human* (MCP-OAuth, XAA, AP2 Mandates). Pick the axis a given standard actually
+  addresses before comparing.
+- **Personhood is now infrastructure, not research:** World ID's scale + Cloudflare's Sept-15-2026
+  default bot policy give the human-vs-agent line real commercial/legal weight.
+- **Identity underpins payments:** AP2 Mandates and x402 payer identities make this doc a prerequisite
+  read for [../non-cc/agentic-payments-landscape.md](../non-cc/agentic-payments-landscape.md).
+- **Assess:** standards are early and fragmented (OAuth-vs-workload-identity-vs-onchain), several EIPs
+  Draft, one vendor already rebranding. Track MCP-OAuth, Entra Agent ID, and Web Bot Auth adoption.
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [SPIFFE/SPIRE][spiffe] | Workload identity (SVIDs) |
+| [Microsoft Entra Agent ID][entra] | Agent service-principal identity (GA 2026-04) |
+| [ERC-8004][erc8004] | On-chain trustless-agent identity/reputation (Draft) |
+| [Privado ID — Know Your Agent][privado] | DID + ZK-VC agent identity/reputation |
+| [MCP Authorization][mcp-authz] | OAuth 2.1 resource-server model |
+| [Okta Cross-App Access][xaa] | ID-JAG delegated agent authorization |
+| [Google AP2 spec][ap2] | Mandate (W3C VC) authorization chain |
+| [World ID][worldid] · [Humanity Protocol][humanity] | Proof-of-personhood credentials |
+| [Cloudflare Web Bot Auth][webbotauth] · [pay-per-crawl][paypercrawl] | Signed agents; 402+auth fusion |
+| [JIT / ZSP][jit] · [CC permissions][cc-perms] | Ephemeral perms; CC local rule-gate anchor |
+
+[spiffe]: https://spiffe.io/docs/latest/spire-about/spire-concepts/
+[entra]: https://learn.microsoft.com/en-us/entra/agent-id/what-is-microsoft-entra-agent-id
+[erc8004]: https://eips.ethereum.org/EIPS/eip-8004
+[privado]: https://www.privado.id/blog/privado-know-your-agent
+[mcp-authz]: https://modelcontextprotocol.io/specification/draft/basic/authorization
+[xaa]: https://developer.okta.com/blog/2025/09/03/cross-app-access
+[ap2]: https://github.com/google-agentic-commerce/AP2
+[worldid]: https://world.org/world-id
+[humanity]: https://www.humanity.org/
+[webbotauth]: https://blog.cloudflare.com/web-bot-auth/
+[paypercrawl]: https://blog.cloudflare.com/introducing-pay-per-crawl/
+[jit]: https://www.beyondtrust.com/resources/glossary/just-in-time-access
+[cc-perms]: https://code.claude.com/docs/en/permissions


### PR DESCRIPTION
Second wave of new sources (ahead of the deferred #354 graph rebuild). Tracker #374.

**New docs**
- `non-cc/agents-cli-analysis.md` — Google agents-cli (Apache-2.0, v1.0.0 Pre-GA): a skill-pack that upskills a coding agent (Claude Code/Antigravity/Codex) to build ADK agents on Gemini Enterprise. Cross-ref'd from cc-community skills landscape.
- `non-cc/agentic-payments-landscape.md` — machine-native agent payment rails: **x402** (Coinbase→Linux Foundation, HTTP 402, USDC/Base) + Apify case study, **Google AP2** (Mandate = W3C VC), **Stripe MPP**, Fetch.ai. New topic.
- `non-cc/karpathy-agentic-coding-analysis.md` — Karpathy's agentic-coding arc (LLM OS → vibe coding → Software 3.0/autonomy slider → agentic engineering); first-party blogs/talks.
- `sdlc-lcm/agent-identity-auth-landscape.md` — agent identity/auth/personhood (SPIFFE, Entra Agent ID, MCP-OAuth, Okta XAA, AP2 Mandates, World ID, Cloudflare Web Bot Auth); joins the security cluster, bidirectionally linked with the payments doc. New topic.

**Meta** — README index rows; wave-2 plan (`docs/plans/2026-07-08-source-expansion-wave2.md`) + next-session handoff (`docs/handoffs/`) for the deferred graph rebuild; changelog fragment; CONTRIBUTING already carries the polyfetch/doc-pipeline pointer from the prior PR.

`make check_docs` 0 · `make check_links` clean for this batch (fixed AP2/Humanity URLs). The one remaining lychee error is a **pre-existing** `usage.ai` 301 in `kiro-analysis.md` (unrelated; not in this batch).

Generated with Claude <noreply@anthropic.com>