### PR TITLE
docs: persist #354 graphify-rebuild plan + handoff

### DIFF
--- a/changelog.d/20260708_160000_docs_graphify_rebuild_plan.md
+++ b/changelog.d/20260708_160000_docs_graphify_rebuild_plan.md
@@ -1,0 +1,3 @@
+### Added
+
+- `docs/plans/2026-07-08-graphify-rebuild-354.md` + `docs/handoffs/2026-07-08-graphify-rebuild-354.md`: execution-ready plan + next-session handoff for the deferred #354 graph rebuild, with a full command/file/source map (graphify runtime, the `--update` flow, `make graph-page` → `ui/graph.html`, gh-pages deploy) so a fresh session runs it without re-gathering context.

--- a/docs/handoffs/2026-07-08-graphify-rebuild-354.md
+++ b/docs/handoffs/2026-07-08-graphify-rebuild-354.md
@@ -1,0 +1,45 @@
+---
+title: Handoff — execute the #354 graphify rebuild
+purpose: Onboard a fresh session to run the deferred graph rebuild end-to-end, using the approved plan.
+created: 2026-07-08
+updated: 2026-07-08
+---
+
+**Status**: Reference (handoff)
+
+## TL;DR
+
+Run the deferred **#354** graph rebuild so the published knowledge graph + gh-pages site include this
+session's new docs (waves 1+2). The **execution-ready plan with the full command/file map** is
+[../plans/2026-07-08-graphify-rebuild-354.md](../plans/2026-07-08-graphify-rebuild-354.md) — read it
+first; it has everything so you don't re-map. Tracker [#374](https://github.com/qte77/ai-agents-research/issues/374).
+
+## Do this
+
+1. **Sanity check** you're at repo root with a clean `main`, and `graphify` resolves:
+   `uv tool run --from graphifyy python -c "import graphify"` (install once: `uv tool install graphifyy`).
+2. **Run `/graphify --update`** — it drives detect → extract (AST ∥ ~4 semantic subagents over ~75
+   changed docs) → `build_merge` → cluster → community-labeling. Expect ~430–470 nodes (**not 583** —
+   key-free is sparser; that's accepted). ~4–5 subagents, token-heavy → you're in a focused session.
+3. **`make graph-page`** → regenerates the committed **`ui/graph.html`** (restyle + prune tooling nodes).
+4. **Verify:** `make test` green; `make preview` renders `ui/graph.html`; graph-diff shows new
+   payments/identity-auth/kv-cache/security/Karpathy nodes.
+5. **Ship:** branch `chore/graphify-rebuild-354`; commit **only `ui/graph.html`** (+ a `### Changed`
+   changelog fragment) — `graphify-out/` is gitignored, never commit it; PR → green CI → admin-merge
+   (lychee may trip on unrelated pre-existing rot, e.g. `usage.ai` in kiro — merge past) → prune. The
+   gh-pages workflow deploys on the `ui/` change.
+6. **Close #354** (comment the node count + that it covers waves 1+2) and tick the graph-rebuild box on #374.
+
+## Don't
+
+- Don't chase 583 nodes — key-free extraction is inherently sparser (the accepted #354 tradeoff).
+- Don't commit `graphify-out/` (gitignored). Don't run `make graph-page` before `graph.json` exists.
+- Don't let the extraction subagents drift — scope them to the graphify extraction-spec only (no
+  skills, no `.claude` edits).
+
+## Gotchas carried from this session
+
+- Sourcing landmines (if you touch the docs): `ap2-protocol.org/specification/` 404s (use the GitHub
+  repo); `docs.humanity.org/introduction/overview` 404s; `x.com` 402s WebFetch; PDFs need
+  doc-pipeline-engine (no local `poppler`). polyfetch-scrape renders JS-SPA/blocked pages.
+- Run `make check_docs` directly; `make lint` aborts at the lychee flake before markdownlint.

--- a/docs/plans/2026-07-08-graphify-rebuild-354.md
+++ b/docs/plans/2026-07-08-graphify-rebuild-354.md
@@ -1,0 +1,93 @@
+---
+title: Graphify rebuild (#354) — incorporate the new-sources docs → gh-pages
+status: approved
+issue: 354
+created: 2026-07-08
+updated: 2026-07-08
+---
+
+**Status**: Reference (plan)
+
+Staged, execution-ready plan for the deferred [#354](https://github.com/qte77/ai-agents-research/issues/354)
+graph rebuild. **Approved but not yet executed** — deliberately handed to a fresh, focused session
+(the extraction is token-heavy). Handoff: [../handoffs/2026-07-08-graphify-rebuild-354.md](../handoffs/2026-07-08-graphify-rebuild-354.md).
+Tracker: [#374](https://github.com/qte77/ai-agents-research/issues/374).
+
+## Context
+
+The key-free `/graphify` rebuild yields fewer concept nodes than a prior graph (427 vs 583) — inherent
+to key-free extraction (session model, no LLM key), and **accepted**. The recorded decision: defer the
+rebuild until new sources are added so it reflects real content, not a parity chase. Waves 1+2 are now
+merged (#372/#373/#375/#376): ~9 new/changed analysis docs (agentic-AI security, KV-cache serving,
+Codex-CC/OpenWiki/company-brain tooling, agentic payments, agent identity/auth, Karpathy). Rebuild so
+the published graph + gh-pages site reflect them.
+
+**Node-count expectation:** ~430–470 (427 baseline + new docs), **not 583**. Sparser is the accepted
+key-free tradeoff, not a regression.
+
+## Approach
+
+Run the **`/graphify --update`** skill flow (re-extract changed files, `build_merge` into the existing
+`graphify-out/graph.json`), then `make graph-page` → commit `ui/graph.html`. Fallback: a full
+`/graphify` rebuild (hits cache for unchanged files).
+
+## Code / file / source map (don't re-gather)
+
+### graphify runtime
+
+- Installed via `uv tool install graphifyy` (package `graphifyy`; executables `graphify`, `graphify-mcp`).
+- Python API interpreter: `~/.local/share/uv/tools/graphifyy/bin/python`, also written to
+  `graphify-out/.graphify_python`. Run headless API as `uv tool run --from graphifyy python -c "…"`.
+- Skill: `.claude/skills/graphify/SKILL.md` (full pipeline) + `references/update.md` (the `--update`
+  flow: `detect_incremental` → populate `.graphify_detect.json` → extract → `build_merge` → Steps 4–8).
+
+**Changed-set (detect_incremental, 2026-07-08):** ~110 files vs a stale manifest — ~75 docs (semantic),
+~31 code/tooling (AST, free, pruned from the published graph), 1 image. Unchanged hit the semantic cache.
+
+### Extraction
+
+- AST: `graphify.extract.extract(code_files, cache_root=Path('.'))` → `.graphify_ast.json`.
+- Semantic: **general-purpose subagents**, ~20 docs/chunk (~4 agents), prompt = `references/extraction-spec.md`
+  verbatim (write each chunk to `graphify-out/.graphify_chunk_NN.json`). Scope tightly: extraction only,
+  no skills, no `.claude` edits (derail risk — AGENT_LEARNINGS).
+- Merge: `graphify.build.build_merge([new_extraction], graph_path='graphify-out/graph.json', prune_sources=changed)`.
+
+### Render / deploy
+
+- `make graph-page` → `graph-html` (`graphify export html`) + `scripts/render-graph-page.py`.
+- `scripts/pages_build.py`: `filter_graph_data()` prunes tooling nodes (`scripts/ tests/ ui/ src/ .github/scripts/`);
+  `restyle_graph()` applies EyeRest theme, injects fonts/favicon/title, vendors vis-network. **Unit-tested** in `tests/` (`make test`).
+- **Committed artifact: `ui/graph.html`** (the gh-pages deploy source — see
+  [../architecture.md](../architecture.md#knowledge-graph-graphify)). `graphify-out/` (graph.json,
+  GRAPH_REPORT.md, caches) is **gitignored** — never commit it.
+- Deploy: pushing `ui/graph.html` to `main` triggers the gh-pages Actions workflow →
+  `qte77.github.io/ai-agents-research/graph.html`.
+
+## Steps
+
+1. Interpreter ready (`graphify-out/.graphify_python`).
+2. `detect_incremental(Path('.'))` → confirm ~110; populate `.graphify_detect.json` (changed + all_files).
+3. Extract: AST (code) ∥ ~4 semantic subagents (docs); cache hits for unchanged.
+4. `build_merge` → cluster → analyze → regenerate `graph.json` + `GRAPH_REPORT.md`.
+5. Label communities (2–5 words each) from node lists.
+6. `make graph-page` → `ui/graph.html`.
+7. Verify (below).
+8. Branch `chore/graphify-rebuild-354`; commit **only `ui/graph.html`** + a changelog fragment
+   (`### Changed`); PR; green CI → admin-merge → prune; gh-pages deploys.
+9. Close #354 (comment: rebuilt, N nodes, waves 1+2) + check the box on #374.
+
+## Verification
+
+1. `graph.json` non-empty; node count ~430–470 (not 583); graph-diff shows new payments/identity-auth/
+   kv-cache/security/Karpathy nodes.
+2. `make test` → pages_build + render tests green.
+3. `make graph-page` regenerates `ui/graph.html`; `make preview` renders; code/tooling nodes pruned;
+   EyeRest theme + fonts + favicon present.
+4. `make check_docs` (only the changelog fragment is new md) → 0.
+5. Post-merge: gh-pages graph reflects the new docs.
+
+## Gotchas
+
+- Key-free = fewer nodes (~430–470, not 583). `graphify-out/` gitignored — ship only `ui/graph.html`.
+  `make graph-page` needs `graph.json` first (build via `/graphify`). Extraction-spec-only subagent
+  prompt. Unique branch name (avoid same-day collisions). Token-heavy → focused session.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -33,3 +33,4 @@ updated: 2026-07-08
 | [2026-07-05-status-frontmatter-migration.md](2026-07-05-status-frontmatter-migration.md) | approved | #348 |
 | [2026-07-08-new-sources-batch.md](2026-07-08-new-sources-batch.md) | done | #374 |
 | [2026-07-08-source-expansion-wave2.md](2026-07-08-source-expansion-wave2.md) | done | #374 |
+| [2026-07-08-graphify-rebuild-354.md](2026-07-08-graphify-rebuild-354.md) | approved | #354 |


### PR DESCRIPTION
Persists the approved-but-deferred #354 graph-rebuild as a durable plan + next-session handoff, so a fresh session executes it without re-mapping.

- `docs/plans/2026-07-08-graphify-rebuild-354.md` — staged plan + **command/file/source map** (graphify runtime + interpreter path, the `--update` flow, extraction subagents, `make graph-page` → committed `ui/graph.html`, gh-pages deploy, verification, gotchas).
- `docs/handoffs/2026-07-08-graphify-rebuild-354.md` — concise do/don't onboarding.

Deferred by design (the rebuild is a ~4–5-subagent, token-heavy re-extraction — best in a focused session). Tracked: #354 / #374.

`make check_docs` 0. Docs-only.

Generated with Claude <noreply@anthropic.com>