### PR TITLE
fix: repoint two 404'd external links (link rot)

### DIFF
--- a/changelog.d/20260710_130000_fix_link_rot_404s.md
+++ b/changelog.d/20260710_130000_fix_link_rot_404s.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `docs/cc-native/CC-first-party-docs-index.md`: "Building effective agents" URL 404'd (`platform.claude.com/docs/en/docs/build-with-claude/prompt-engineering/building-effective-agents` — page moved) → repointed to the canonical `https://www.anthropic.com/engineering/building-effective-agents`.
+- `docs/non-cc/amp-analysis.md`: `[amp-pricing]` 404'd (`ampcode.com/pricing` removed) → repointed to `https://ampcode.com/manual`, which now carries the credit/pricing model. These two dead links were failing the repo-wide lychee check on every PR.

--- a/docs/cc-native/CC-first-party-docs-index.md
+++ b/docs/cc-native/CC-first-party-docs-index.md
@@ -2,7 +2,7 @@
 title: CC First-Party Documentation Index
 purpose: Canonical Anthropic URLs for CC, Agent SDK, Anthropic SDK, API, and best practices.
 created: 2026-03-28
-updated: 2026-06-11
+updated: 2026-07-10
 validated_links: 2026-06-11
 ---
 
@@ -60,7 +60,7 @@ validated_links: 2026-06-11
 |-------|-----|
 | Tool use overview | <https://platform.claude.com/docs/en/docs/agents-and-tools/tool-use/overview> |
 | Text editor tool | <https://platform.claude.com/docs/en/docs/build-with-claude/tool-use/text-editor-tool> |
-| Building effective agents | <https://platform.claude.com/docs/en/docs/build-with-claude/prompt-engineering/building-effective-agents> |
+| Building effective agents | <https://www.anthropic.com/engineering/building-effective-agents> |
 
 ## GitHub Resources
 

--- a/docs/non-cc/amp-analysis.md
+++ b/docs/non-cc/amp-analysis.md
@@ -3,7 +3,7 @@ title: Amp Analysis
 source: https://ampcode.com/
 purpose: Analysis of Amp (Sourcegraph spinoff) as a terminal-first agentic coding tool with pay-as-you-go model pricing.
 created: 2026-06-16
-updated: 2026-06-16
+updated: 2026-07-10
 validated_links: 2026-06-16
 ---
 
@@ -140,7 +140,7 @@ product.
 | [Sourcegraph Wikipedia][sg-wiki] | Organizational background; Cody → Amp transition (accessed 2026-06-16) |
 
 [amp-home]: https://ampcode.com/
-[amp-pricing]: https://ampcode.com/pricing
+[amp-pricing]: https://ampcode.com/manual
 [amp-news]: https://ampcode.com/news
 [amp-manual-cli]: https://github.com/sourcegraph/amp-examples-and-guides/blob/main/guides/cli/README.md
 [amp-examples]: https://github.com/sourcegraph/amp-examples-and-guides


### PR DESCRIPTION
## What & why

Two external links 404 and were failing the **repo-wide lychee check on every open PR** (this blocks the merge train, including #378 and #380). Lychee scans the whole repo on every PR, so these had to be fixed on `main` to unblock anything.

| File | Old (404) | New (200 ✓) |
|---|---|---|
| `CC-first-party-docs-index.md:63` | `platform.claude.com/docs/en/docs/build-with-claude/prompt-engineering/building-effective-agents` (moved) | `https://www.anthropic.com/engineering/building-effective-agents` |
| `amp-analysis.md` `[amp-pricing]` | `ampcode.com/pricing` (removed) | `https://ampcode.com/manual` (now hosts the credit/pricing model) |

Both replacements verified 200. Bumped `updated:` on both docs (left `validated_links:` untouched — only these two URLs were re-checked, not every link in the files).

Separate topic from #348; kept as its own PR per the commit-by-topic convention.