### PR TITLE
docs: mark #354 rebuild plan/handoffs done + 2 learnings

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -13,6 +13,20 @@ description: Non-obvious patterns that prevent repeated mistakes across sprints
 
 ## Learned Patterns
 
+### Continued sessions: reconcile git HEAD vs the conversation summary before executing tracked work
+
+- **Context**: A long/continued session whose summary predates recent merges.
+- **Problem**: The session built a full plan to "execute the #354 graph rebuild" when it was already done (PR #379, 637 nodes, #354 closed) — wasted effort and nearly re-ran a completed rebuild.
+- **Solution**: Before executing any tracked/deferred work in a continued session, reconcile the *actual* state — `git log`, the tracking issue's open/closed state, and key artifacts (e.g. `graphify-out/graph.json` node count) — against what the summary claims. On mismatch, surface it; don't act on the stale model.
+- **References**: [docs/plans/2026-07-08-graphify-rebuild-354.md](docs/plans/2026-07-08-graphify-rebuild-354.md), PR #379.
+
+### graphify: never partial-update a uniformly-built graph
+
+- **Context**: Refreshing the corpus graph after a few docs changed.
+- **Problem**: A per-doc `--update` re-extracts with the current (fine) chunking, which is *denser* than the base graph's uniform density (#379 built ~1–2 nodes/doc; a fresh 2-doc extract yielded 43). Merging lopsides the graph — a few docs dense, the rest sparse — worse than leaving it.
+- **Solution**: Refresh only via a **full uniform rebuild**, and only when there's substantial new *concept* content (link-fix/typo edits don't change concepts → skip). Note `build_merge` prunes by `source_file` (stored as a **relative** path in `graph.json`); an absolute-path mismatch silently duplicates nodes.
+- **References**: [docs/plans/2026-07-08-graphify-rebuild-354.md](docs/plans/2026-07-08-graphify-rebuild-354.md); memory `project_graphify_rebuild_354_learnings`.
+
 ### Phantom files in repo root from bwrap sandbox
 
 - **Context**: Claude Code with bubblewrap sandbox on Linux/WSL2/Codespaces.

--- a/changelog.d/20260708_170000_docs_graphify_status_accuracy_learnings.md
+++ b/changelog.d/20260708_170000_docs_graphify_status_accuracy_learnings.md
@@ -1,0 +1,7 @@
+### Changed
+
+- `docs/plans/2026-07-08-graphify-rebuild-354.md` + its handoffs: marked `done` (the rebuild was executed by PR #379 — 637 nodes, #354 closed) so they no longer read as pending work; steps retained as method reference.
+
+### Added
+
+- `AGENT_LEARNINGS.md`: two learnings — reconcile git HEAD/issue state vs the conversation summary before executing tracked work in a continued session; and never partial-update a uniformly-built graphify graph (density lopsiding + `build_merge` source_file matching).

--- a/docs/handoffs/2026-07-08-graphify-rebuild-354.md
+++ b/docs/handoffs/2026-07-08-graphify-rebuild-354.md
@@ -7,6 +7,10 @@ updated: 2026-07-08
 
 **Status**: Reference (handoff)
 
+> **DONE — executed by PR #379 (2026-07-10, 637 nodes; #354 closed).** Retained for method reference
+> only. Do **not** re-run as a per-doc update — a fine-chunk re-extract is denser than the uniform
+> base graph and lopsides it (see AGENT_LEARNINGS). A refresh must be a full uniform rebuild.
+
 ## TL;DR
 
 Run the deferred **#354** graph rebuild so the published knowledge graph + gh-pages site include this

--- a/docs/handoffs/2026-07-08-source-expansion.md
+++ b/docs/handoffs/2026-07-08-source-expansion.md
@@ -20,7 +20,9 @@ Tracker: [#374](https://github.com/qte77/ai-agents-research/issues/374).
 - **Wave 1:** #372 agentic-AI-vulnerability-landscape · #373 kv-cache-serving-landscape (+ CC-prompt-caching min-token fix) · #375 Codex-CC plugin + OpenWiki + company-brain + CONTRIBUTING polyfetch/doc-pipeline pointer.
 - **Wave 2:** agents-cli, agentic-payments, karpathy-agentic-coding, agent-identity-auth (this PR).
 
-## The open action — graph rebuild (#354)
+## Graph rebuild (#354) — DONE
+
+> Executed by PR #379 (2026-07-10, 637 nodes; #354 closed). Steps below retained for method reference.
 
 1. `graphify` is installed: `uv tool install graphifyy` (package `graphifyy`, executable `graphify`).
    Python API via `uv tool run --from graphifyy python …` or the interpreter written to

--- a/docs/plans/2026-07-08-graphify-rebuild-354.md
+++ b/docs/plans/2026-07-08-graphify-rebuild-354.md
@@ -1,6 +1,6 @@
 ---
 title: Graphify rebuild (#354) — incorporate the new-sources docs → gh-pages
-status: approved
+status: done
 issue: 354
 created: 2026-07-08
 updated: 2026-07-08
@@ -9,7 +9,7 @@ updated: 2026-07-08
 **Status**: Reference (plan)
 
 Staged, execution-ready plan for the deferred [#354](https://github.com/qte77/ai-agents-research/issues/354)
-graph rebuild. **Approved but not yet executed** — deliberately handed to a fresh, focused session
+graph rebuild. **Executed by PR #379** (2026-07-10, 637 nodes; #354 closed) — retained as method reference; originally — deliberately handed to a fresh, focused session
 (the extraction is token-heavy). Handoff: [../handoffs/2026-07-08-graphify-rebuild-354.md](../handoffs/2026-07-08-graphify-rebuild-354.md).
 Tracker: [#374](https://github.com/qte77/ai-agents-research/issues/374).
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -33,4 +33,4 @@ updated: 2026-07-08
 | [2026-07-05-status-frontmatter-migration.md](2026-07-05-status-frontmatter-migration.md) | approved | #348 |
 | [2026-07-08-new-sources-batch.md](2026-07-08-new-sources-batch.md) | done | #374 |
 | [2026-07-08-source-expansion-wave2.md](2026-07-08-source-expansion-wave2.md) | done | #374 |
-| [2026-07-08-graphify-rebuild-354.md](2026-07-08-graphify-rebuild-354.md) | approved | #354 |
+| [2026-07-08-graphify-rebuild-354.md](2026-07-08-graphify-rebuild-354.md) | done | #354 |


### PR DESCRIPTION
Small accuracy bundle. The graphify-rebuild plan/handoffs still read as *pending*, but #379 already executed the rebuild (637 nodes, #354 closed) — this session mistook them for open work and nearly re-ran a done task.

- Flip `docs/plans/2026-07-08-graphify-rebuild-354.md` + both handoffs to **done / method-reference** (with a 'do not re-run per-doc' warning).
- `docs/plans/README` row → `done`.
- **AGENT_LEARNINGS.md** ×2: reconcile git HEAD vs the conversation summary before executing tracked work in a continued session; never partial-update a uniformly-built graphify graph.

(#374's graph-rebuild checkbox is already ticked by a prior session.) `make check_docs` 0; docs-only.

Generated with Claude <noreply@anthropic.com>