### PR TITLE
docs: repo-native adding-research-source skill (agentskills.io) + track it

### DIFF
--- a/.claude/skills/adding-research-source/SKILL.md
+++ b/.claude/skills/adding-research-source/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: adding-research-source
+description: Research a new source (tool / paper / protocol / agent) first-party and add it to the ai-agents-research corpus as an analysis doc — placement, conventions, lint, one-PR-per-topic. Use when the user drops a URL/tool/paper to "add as a source" or asks to extend coverage. For >~4 sources at once, use the batch workflow.
+compatibility: ai-agents-research repo; needs make, git, gh, and uv (for polyfetch-scrape / doc-pipeline-engine escalation on dynamic/PDF sources). Designed for Claude Code.
+metadata:
+  author: qte77
+  version: "0.1"
+allowed-tools: Agent Bash Read Grep Glob Write Edit WebFetch
+---
+
+# adding-research-source
+
+Add a source the way it's done consistently here: **research first-party → place correctly → write to
+convention → lint → ship one PR per topic.** Judgment lives in *placement* and *sourcing*; the rest is
+mechanical. Reference [CONTRIBUTING.md](../../../CONTRIBUTING.md) — don't duplicate its rules.
+
+## Procedure (per source)
+
+1. **Research first-party.** Dispatch an **Explore subagent** with the brief below (read-only). Never
+   trust marketing — verify license/counts/version against the upstream README/LICENSE/releases
+   (`gh api repos/<o>/<r>`). Dynamic/blocked pages → **polyfetch-scrape**; PDF/Office → **doc-pipeline-engine**
+   (both via `uv run --directory`; see CONTRIBUTING Research Workflow).
+2. **Place it** (decision tree):
+   - Anthropic-native CC feature/internals → `docs/cc-native/<subdir>/CC-<topic>-analysis.md`
+   - CC-**exclusive** community plugin/tool (CC is THE surface) → `docs/cc-community/CC-<topic>-analysis.md`
+   - Cross-vendor tool/protocol/infra (CC = one of many) → `docs/non-cc/<topic>-analysis.md|-landscape.md`
+   - Security / governance / identity / lifecycle → `docs/sdlc-lcm/<topic>-landscape.md`
+   - **Extend, don't create** when a landscape already covers the area (dup-check with `git grep`);
+     synthesis labels (e.g. "company brain") → extend, never standalone. Spans both dirs → deeper
+     analysis in one, cross-ref from the other.
+3. **Write** per CONTRIBUTING: frontmatter (`title/purpose/created/updated/validated_links` + status
+   badge), body sections, a **Sources table with reference-style links**, cross-refs. Hedge unverified
+   claims; flag weak/secondary sources explicitly.
+4. **Index + changelog:** add the subdir README row (+ `cc-native/README` count for cc-native docs);
+   add a `changelog.d/<ts>_<slug>.md` fragment.
+5. **Lint:** `make check_docs` (run it **directly** — `make lint` aborts at the lychee flake before
+   markdownlint) then `make check_links`. A URL you added that 404s/bot-blocks → *propose* a
+   `lychee.toml` exclude with a note; never admin-merge past a broken link you introduced.
+6. **Ship:** branch `<type>/<slug>`; **commit by topic** (doc, then index/meta); PR; green CI → owner
+   `gh pr merge --squash --admin` (lychee not required — merge past *pre-existing* rot only) → prune.
+
+## Research-subagent brief (dispatch verbatim; one per source or tight cluster)
+
+> Read-only. Use WebFetch + `git grep`/Read. Do NOT edit files or invoke skills. For `<URL(s)>`:
+> canonical name; what it is (1–2 lines); **license from the LICENSE file, not marketing**;
+> version/stars/date; 5–7 concrete first-party facts; one line on why it matters for an AI-agents / CC
+> corpus. Then **coverage check**: `git grep -il '<name>'` in `docs/` — already covered? closest doc?
+> Recommend placement (subdir + new-vs-extend) per the tree above. Calibrate grep on a term you know
+> exists. **Flag anything you can't source first-party.** Return prose + compact blocks, no raw dumps.
+
+## Batch mode (>~4 sources at once)
+
+Run the workflow `scripts/batch-sources.workflow.js` (Workflow tool) — parallel first-party research +
+**adversarial verify** across all URLs → structured findings (facts + placement + dup-flags). Then
+write/ship each per steps 3–6. Needs explicit user opt-in (workflows spawn many agents).
+
+## Guardrails (why this exists)
+
+- **Verify first-party** — this discipline caught real errors: stale KV min-token numbers, license/count
+  drift, AP2/Humanity URL rot. A subagent's "fact" is advisory until re-checked.
+- **One PR per topic**; don't mix content additions with reformatting.
+- **Don't over-place** — the cc-vs-non-cc line is judgment. When genuinely unsure, ask the user rather
+  than guess (placement calls get challenged: *opus-in-non-cc*, *firecrawl-in-cc-native*, *agents-cli-within-cc*).
+- **Never trust marketing counts/license** — read LICENSE + live README/releases.

--- a/.claude/skills/adding-research-source/scripts/batch-sources.workflow.js
+++ b/.claude/skills/adding-research-source/scripts/batch-sources.workflow.js
@@ -1,0 +1,61 @@
+// batch-sources.workflow.js — Workflow-tool script for the `adding-research-source` skill.
+// Parallel first-party research + adversarial verify across N new sources, so the main
+// session can then write/place/ship each per SKILL.md steps 3-6.
+//
+// Invoke via the Workflow tool with args = array of URL strings (or {url, hint} objects).
+// Requires explicit user opt-in (spawns many agents). Returns verified findings.
+
+export const meta = {
+  name: 'batch-sources',
+  description: 'Parallel first-party research + adversarial verify for N new sources → structured, placement-tagged findings',
+  phases: [{ title: 'Research', detail: 'one first-party research agent per source' },
+           { title: 'Verify', detail: 'adversarially re-check the riskiest claims (license/counts/version)' }],
+}
+
+const urls = (Array.isArray(args) ? args : (args && args.urls) || [])
+  .map(u => (typeof u === 'string' ? { url: u } : u))
+  .filter(u => u && u.url)
+
+if (!urls.length) { log('No URLs in args — pass args: ["https://…", …]'); return [] }
+log(`Researching ${urls.length} source(s) first-party, then verifying.`)
+
+const FINDING = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' }, what: { type: 'string' },
+    license: { type: 'string' }, version: { type: 'string' },
+    facts: { type: 'array', items: { type: 'string' } },
+    placement: { type: 'string', description: 'cc-native|cc-community|non-cc|sdlc-lcm + subdir + new-vs-extend' },
+    existing_coverage: { type: 'string' }, dup_risk: { type: 'boolean' },
+    unverifiable: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['name', 'what', 'placement'],
+}
+const VERDICT = {
+  type: 'object',
+  properties: { holds: { type: 'boolean' }, corrections: { type: 'string' } },
+  required: ['holds'],
+}
+
+// pipeline: each source flows research → verify independently (no barrier).
+const findings = await pipeline(
+  urls,
+  (u) => agent(
+    `Read-only FIRST-PARTY research on ${u.url}${u.hint ? ` (hint: ${u.hint})` : ''} for the ai-agents-research corpus. `
+    + `Return: canonical name; what it is (1-2 lines); LICENSE from the LICENSE file (not marketing); version/stars/date; `
+    + `5-7 concrete first-party facts; a placement recommendation (cc-native / cc-community / non-cc / sdlc-lcm + subdir + new-vs-extend, `
+    + `per the skill's decision tree); an existing-coverage note (git grep the repo's docs/); and list any claim you could NOT source first-party. `
+    + `Verify counts/license/version against the upstream README/LICENSE/releases. Do not fabricate.`,
+    { label: `research:${u.url}`, phase: 'Research', schema: FINDING }),
+  (f, u) => f
+    ? agent(
+        `Adversarially verify the 2 riskiest claims in this finding (especially LICENSE, counts, and version) by re-fetching first-party. `
+        + `Set holds=false with corrections if any is unsupported.\n\n${JSON.stringify(f)}`,
+        { label: `verify:${f.name}`, phase: 'Verify', schema: VERDICT })
+        .then(v => ({ ...f, url: u.url, verified: v }))
+    : null,
+)
+
+const ok = findings.filter(Boolean)
+log(`Done: ${ok.length}/${urls.length} researched; ${ok.filter(f => f.verified && !f.verified.holds).length} had claims corrected on verify.`)
+return ok

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ Thumbs.db
 
 # Plugin-deployed files (source of truth: claude-code-plugins)
 .claude/scripts/
-.claude/skills/
+.claude/skills/*
 
 # Local-only agent handoff notes (per-session scratch, not shared)
 .claude/handoffs/
@@ -24,7 +24,10 @@ Thumbs.db
 /.bashrc
 /.claude/agents
 /.claude/commands
-/.claude/skills
+/.claude/skills/*
+# Exception: the one repo-native skill we track (ai-agents-research source-onboarding workflow).
+# Direct-child phantom leaks are still caught by the /* rules; only this skill's own subdir is exempt.
+!/.claude/skills/adding-research-source/
 /.env
 /.gitconfig
 /.gitmodules

--- a/changelog.d/20260708_180000_docs_adding_research_source_skill.md
+++ b/changelog.d/20260708_180000_docs_adding_research_source_skill.md
@@ -1,0 +1,3 @@
+### Added
+
+- `.claude/skills/adding-research-source/`: a repo-native Claude Code skill (agentskills.io-conformant) codifying this corpus's source-onboarding workflow — first-party research → placement decision tree (cc-native / cc-community / non-cc / sdlc-lcm) → doc conventions → lint → one-PR-per-topic — with an Explore research-subagent brief and a `scripts/batch-sources.workflow.js` batch workflow (parallel research + adversarial verify) for large source drops. `.gitignore` un-ignores this specific skill; other `.claude/skills/` remain plugin-deployed.


### PR DESCRIPTION
Codifies this corpus's source-onboarding workflow as a Claude Code skill (agentskills.io-conformant), tracked locally because its placement rules are ai-agents-research-specific (not estate-generic → not ported to cc-utils-plugin; extract later if a 2nd corpus-repo needs it).

- `.claude/skills/adding-research-source/SKILL.md` — procedure (first-party research → placement decision tree → conventions → lint → one-PR-per-topic) + the Explore research-subagent brief + guardrails.
- `.claude/skills/adding-research-source/scripts/batch-sources.workflow.js` — Workflow-tool script for large source drops (parallel first-party research + adversarial verify).
- `.gitignore` — un-ignore *only* this skill's subdir. Both the plugin-deployed rule and the bwrap-phantom rule are converted to `/*` form so **direct-child phantom leaks are still caught**; graphify + other skills stay plugin-deployed/ignored (verified via `git check-ignore`).

CC already loads it (appears in the skills list). Docs/skill-only.