### PR TITLE
ci: bump eval_ref to v0.4.0 (lockstep with reusable-workflow pin)

### DIFF
--- a/.github/workflows/rxiv-paper-eval.yaml
+++ b/.github/workflows/rxiv-paper-eval.yaml
@@ -110,7 +110,7 @@ jobs:
       model: openai/gpt-4o-mini
       enrich: true
       eval_repo: qte77/gha-rxiv-paper-eval
-      eval_ref: 6a4bb87ea02a9bfbb837fa7d500eec0d9c24172f  # v0.2.2
+      eval_ref: c748a066744876b4ef07ca28cc072f8b41449555  # v0.4.0 — keep in lockstep with the workflow pin above (qte77/gha-rxiv-paper-eval#80)
 
   triage:
     needs: [resolve, eval]

--- a/changelog.d/20260723_000000_ci_eval_ref_lockstep.md
+++ b/changelog.d/20260723_000000_ci_eval_ref_lockstep.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `.github/workflows/rxiv-paper-eval.yaml`: bump `eval_ref` v0.2.2 → v0.4.0, in lockstep with the reusable-workflow pin — the v0.4.0 workflow unconditionally passes `--max-llm-calls`, which the v0.2.2 script rejects (exit 2), leaving the PR-path eval permanently red (bit #390). Upstream skew-guard tracked in qte77/gha-rxiv-paper-eval#80; GitHub Models retirement (2026-07-30) migration tracked in qte77/gha-rxiv-paper-eval#81.


### PR DESCRIPTION
## What

Bumps `eval_ref` **v0.2.2 (`6a4bb87`) → v0.4.0 (`c748a06`)** so the script pin is in
lockstep with the reusable-workflow pin.

## Why

The v0.4.0 reusable workflow **unconditionally** passes `--max-llm-calls` (input
default 0); the v0.2.2 script predates the flag and rejects it:

```
eval_papers.py: error: unrecognized arguments: --max-llm-calls 0   → exit 2
```

Result: every PR touching this workflow had a permanently red `eval / evaluate`
check — #390 (dependabot setup-node bump) hit exactly this and needed a manual
log-dig + admin override. Verified: `max_llm_calls` has 0 occurrences in
`scripts/eval_papers.py@6a4bb87` and is implemented at `@c748a06`.

## Related

- Upstream skew-guard (pass flag only when set / default `eval_ref` to the
  workflow's own ref): [gha-rxiv-paper-eval#80](https://github.com/qte77/gha-rxiv-paper-eval/issues/80)
- **GitHub Models retires 2026-07-30** (this workflow's whole inference path):
  [gha-rxiv-paper-eval#81](https://github.com/qte77/gha-rxiv-paper-eval/issues/81) —
  this PR is a band-aid for the PR path; the provider migration is the real work.

## CI note

This PR itself triggers the self-run eval (5-paper cap). **2026-07-23 is a
scheduled GitHub Models brownout day** — if `eval / evaluate` fails today with
quota/5xx errors, that is the brownout, not this change; re-run after the window
or judge accordingly.

Generated with Claude <noreply@anthropic.com>
