### PR TITLE
docs: CC multi-account switching landscape + CLAUDE_CONFIG_DIR reference

### DIFF
--- a/.claude/skills/adding-research-source/scripts/batch-sources.workflow.js
+++ b/.claude/skills/adding-research-source/scripts/batch-sources.workflow.js
@@ -12,7 +12,10 @@ export const meta = {
            { title: 'Verify', detail: 'adversarially re-check the riskiest claims (license/counts/version)' }],
 }
 
-const urls = (Array.isArray(args) ? args : (args && args.urls) || [])
+// Some harnesses deliver args as a JSON-encoded string — tolerate both shapes.
+let input = args
+if (typeof input === 'string') { try { input = JSON.parse(input) } catch { log('args string is not valid JSON') } }
+const urls = (Array.isArray(input) ? input : (input && input.urls) || [])
   .map(u => (typeof u === 'string' ? { url: u } : u))
   .filter(u => u && u.url)
 

--- a/changelog.d/20260723_120000_docs_multi_account_switching.md
+++ b/changelog.d/20260723_120000_docs_multi_account_switching.md
@@ -1,0 +1,10 @@
+### Added
+
+- `docs/cc-community/CC-multi-account-switching-landscape.md`: multi-account/profile switching for CC — native `CLAUDE_CONFIG_DIR` mechanism (first-party-verified: documented only in the debug-your-config guide; per-platform credential isolation — Linux/Windows per-dir, macOS Keychain carries over), tool table (claude-swap, claude-code-profiles, claude-multiprofile, claude-multisession), disambiguation vs CC Switch (provider mgmt) and CLIProxyAPI (gateway quota harvesting).
+- `docs/plans/2026-07-23-corpus-update-new-sources.md`: durable plan for the 2026-07-23 corpus-update + new-sources arc (backlog drain #374, fresh mining, stale-fact refresh cohort).
+
+### Changed
+
+- `docs/cc-native/configuration/CC-env-vars-reference.md`: added `CLAUDE_CONFIG_DIR` (verified zero-coverage gap; noted its absence from the official env-vars list as of 2026-07-23) + cross-ref to the new landscape.
+- `docs/cc-native/configuration/CC-model-provider-configuration.md`: CLIProxyAPI entry now disambiguates gateway-level multi-account from native CLI multi-account sessions.
+- `.claude/skills/adding-research-source/scripts/batch-sources.workflow.js`: tolerate args delivered as a JSON-encoded string (harness stringification made the workflow no-op).

--- a/docs/cc-community/CC-multi-account-switching-landscape.md
+++ b/docs/cc-community/CC-multi-account-switching-landscape.md
@@ -1,0 +1,94 @@
+---
+title: CC Multi-Account & Profile Switching Landscape
+purpose: How to run multiple Claude Code subscription accounts — concurrently or switched — in one OS environment, via the native CLAUDE_CONFIG_DIR mechanism and community tools built on it.
+created: 2026-07-23
+updated: 2026-07-23
+validated_links: 2026-07-23
+---
+
+**Status**: Assess
+
+## What It Is
+
+Claude Code supports **one authenticated account per configuration directory**. There is no
+native profile or account switcher — the capability has been requested upstream repeatedly
+([#44687][gh-44687] (closed as duplicate), [#35856][gh-35856], [#64376][gh-64376],
+[#37554][gh-37554]; all closed, none resulted in a documented feature as of 2026-07-23). This doc
+covers the first-party isolation mechanism and the community tools that build multi-account
+workflows — including **concurrent** sessions on different subscriptions — on top of it.
+
+## First-Party Mechanism: `CLAUDE_CONFIG_DIR`
+
+The [debug-your-config guide][debug-config] documents pointing `CLAUDE_CONFIG_DIR` at another
+directory to "bypass everything under `~/.claude`" — settings, hooks, plugins, memory, and
+(platform-dependent) credentials:
+
+```bash
+cd /tmp && CLAUDE_CONFIG_DIR=/tmp/claude-clean claude
+```
+
+**Credential isolation is platform-dependent** (per the same page):
+
+| Platform | Credential storage | Per-config-dir account isolation |
+|---|---|---|
+| Linux / Windows | Under the configuration directory | **Yes** — each dir prompts its own login |
+| macOS | Keychain | **No** — credentials "carry over to the clean session"; tools below implement their own isolation |
+
+On Linux/Windows this yields a zero-install concurrent multi-account pattern — one alias per
+account, one terminal each, N independent sessions:
+
+```bash
+alias claude-work='CLAUDE_CONFIG_DIR=$HOME/.claude-work command claude'
+alias claude-personal='CLAUDE_CONFIG_DIR=$HOME/.claude-personal command claude'
+```
+
+Note the variable is absent from the [official env vars reference][env-vars] as of 2026-07-23 —
+the debug guide links to that page for it, but only the debug guide documents the behavior.
+Cross-ref: [CC-env-vars-reference.md](../cc-native/configuration/CC-env-vars-reference.md).
+
+## Tools
+
+| Tool | Mechanism | Concurrent? | Signals (2026-07-23) | License |
+|---|---|---|---|---|
+| [claude-swap][claude-swap] | Backs up/rotates OAuth credentials per account (Keychain/file); scopes a terminal to one account; **auto-rotation on rate-limit** + usage TUI | **Yes** — explicit design goal | 1,276★, pushed 2026-07-23 | MIT |
+| [claude-code-profiles][cc-profiles] | Shell wrapper setting `CLAUDE_CONFIG_DIR` per named profile; one active profile per shell | Sequential switching by design (separate shells parallelize incidentally) | 56★, v1.1.0 2026-07-06 | MIT |
+| [claude-multiprofile][multiprofile] | Native `CLAUDE_CONFIG_DIR` + per-profile macOS Keychain handling; also isolates Claude **Desktop** via `open -n` + `--user-data-dir` | **Yes** — incl. Desktop instances | 42★, v0.1.4 ~2026-05 | MIT |
+| [claude-multisession][multisession] | Per-session dirs under `~/.claude-sessions/` (own creds/history/memory); settings shareable via symlink | **Yes** | 1★, single push 2026-02 — stale | MIT |
+
+**Recommendation shape**: Linux/Windows + no tool trust required → the alias pattern.
+Concurrency with rotation/observability → claude-swap. Claude Desktop profiles too →
+claude-multiprofile.
+
+## What This Is Not (Disambiguation)
+
+Adjacent categories that look similar but solve different problems:
+
+| Category | Tool(s) | Difference |
+|---|---|---|
+| Multi-CLI **provider/API-key** management | CC Switch — see [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md#cc-switch-farion1231) | Which provider/model/key a CLI uses — not which *subscription account* is logged in |
+| Gateway-level **quota harvesting** | CLIProxyAPI — see [CC-model-provider-configuration.md](../cc-native/configuration/CC-model-provider-configuration.md) | Wraps CC accounts into an API endpoint for downstream clients — not N interactive CC sessions |
+| Usage/cost **observability** | [CC-usage-tooling-landscape.md](CC-usage-tooling-landscape.md) | Watches spend; claude-swap's usage TUI overlaps here but its core is account rotation |
+
+## Sources
+
+| Source | Content |
+|---|---|
+| [CC debug-your-config guide][debug-config] | `CLAUDE_CONFIG_DIR` behavior, per-platform credential storage (primary first-party source) |
+| [CC env vars reference][env-vars] | Confirmed gap: variable not listed (checked 2026-07-23) |
+| [claude-swap][claude-swap] | Concurrent multi-account rotation; repo metadata via GitHub API, 2026-07-23 |
+| [claude-code-profiles][cc-profiles] | Profile-switching wrapper; repo metadata via GitHub API, 2026-07-23 |
+| [claude-multiprofile][multiprofile] | CLI + Desktop profile isolation; repo metadata via GitHub API, 2026-07-23 |
+| [claude-multisession][multisession] | Per-session config dirs; repo metadata via GitHub API, 2026-07-23 |
+| [anthropics/claude-code#44687][gh-44687] | Upstream FR: multi-account support (closed as duplicate) |
+| [anthropics/claude-code#35856][gh-35856], [#64376][gh-64376], [#37554][gh-37554] | Further upstream FRs, all closed unimplemented |
+
+[debug-config]: https://code.claude.com/docs/en/debug-your-config
+[env-vars]: https://code.claude.com/docs/en/env-vars
+[claude-swap]: https://github.com/realiti4/claude-swap
+[cc-profiles]: https://github.com/quinnjr/claude-code-profiles
+[multiprofile]: https://github.com/jmdarre-v/claude-multiprofile
+[multisession]: https://github.com/israads/claude-multisession
+[gh-44687]: https://github.com/anthropics/claude-code/issues/44687
+[gh-35856]: https://github.com/anthropics/claude-code/issues/35856
+[gh-64376]: https://github.com/anthropics/claude-code/issues/64376
+[gh-37554]: https://github.com/anthropics/claude-code/issues/37554

--- a/docs/cc-community/README.md
+++ b/docs/cc-community/README.md
@@ -20,3 +20,4 @@ Community-built skills, plugins, tooling, workflows, and patterns for Claude Cod
 | [CC-compass-mcp-analysis.md](CC-compass-mcp-analysis.md) | Compass MCP: cross-surface task/context bridge (architecture, status, alignment) |
 | [CC-vlm-screen-sharing-landscape.md](CC-vlm-screen-sharing-landscape.md) | VLM + screen-sharing landscape: vision models, local runtimes, image token math, visual-context integration patterns |
 | [CC-codex-plugin-cc-analysis.md](CC-codex-plugin-cc-analysis.md) | OpenAI Codex→CC plugin (Apache-2.0): slash commands, codex-rescue subagent, Stop-hook review gate, session transfer |
+| [CC-multi-account-switching-landscape.md](CC-multi-account-switching-landscape.md) | Multi-account/profile switching: native `CLAUDE_CONFIG_DIR` mechanism, per-platform credential isolation, claude-swap, claude-code-profiles, claude-multiprofile |

--- a/docs/cc-native/configuration/CC-env-vars-reference.md
+++ b/docs/cc-native/configuration/CC-env-vars-reference.md
@@ -2,8 +2,8 @@
 title: CC Environment Variables Reference
 purpose: Consolidated reference for CLAUDE_CODE_* and related env vars relevant to autonomous agent workflows, including undocumented vars from binary string extraction.
 created: 2026-03-27
-updated: 2026-06-11
-validated_links: 2026-06-11
+updated: 2026-07-23
+validated_links: 2026-07-23
 ---
 
 **Status**: Adopt
@@ -118,11 +118,12 @@ Toggle metric attributes to trade granularity for storage cost. Source: [monitor
 | Variable | Default | Purpose | Source |
 |---|---|---|---|
 | `CLAUDECODE` | Set by CC | Session guard — set to `1` in shells CC spawns. Clear to enable recursive spawning | [env-vars][env-vars] |
+| `CLAUDE_CONFIG_DIR` | `~/.claude` | Override the configuration directory (settings, hooks, plugins, memory; on Linux/Windows also credentials → per-dir login = one account per dir, enabling concurrent multi-account sessions; macOS credentials stay in Keychain and carry over). **Documented only in the [debug-config guide][debug-config]** — absent from the official env vars list as of 2026-07-23 | [debug-config][debug-config] |
 | `CLAUDE_CODE_TMPDIR` | `/tmp` (Unix) | Override temp directory. CC appends `/claude/` | [env-vars][env-vars] |
 | `CLAUDE_CODE_SIMPLE` | `0` | Minimal mode (set by `--bare` flag). Disables hooks, plugins, MCP, auto memory, CLAUDE.md | [env-vars][env-vars] |
 | `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR` | (unset) | Return to the original working directory after each Bash command. `1` = reset cwd to project root after each command; unset = cwd persists across Bash calls. **Note**: `=0` behavior is undocumented — only `1` is confirmed. See [tools-reference § Bash tool behavior][tools-ref], [#9359][gh-9359], [#11067][gh-11067] | [env-vars][env-vars], [tools-ref][tools-ref] |
 
-Cross-ref: [CC-recursive-spawning-patterns.md](../agents-skills/CC-recursive-spawning-patterns.md), [CC-bash-mode-analysis.md](CC-bash-mode-analysis.md)
+Cross-ref: [CC-recursive-spawning-patterns.md](../agents-skills/CC-recursive-spawning-patterns.md), [CC-bash-mode-analysis.md](CC-bash-mode-analysis.md), [CC-multi-account-switching-landscape.md](../../cc-community/CC-multi-account-switching-landscape.md) (multi-account patterns on `CLAUDE_CONFIG_DIR`)
 
 ### Runtime-Injected Variables (Not User-Configurable)
 
@@ -332,6 +333,7 @@ Cross-ref: [CC-binary-architecture.md](CC-binary-architecture.md), [CC RE landsc
 |---|---|
 | [CC env vars reference][env-vars] | Official complete list (80+ vars) |
 | [CC settings reference][settings] | `settings.json` keys and `env` block |
+| [CC debug-your-config guide][debug-config] | `CLAUDE_CONFIG_DIR` behavior + per-platform credential storage |
 | [CC monitoring docs][monitoring] | OTel configuration and metrics |
 | [CC statusline docs][statusline] | Statusline JSON schema and examples |
 | CC 2.1.83 `env` output, Codespaces, 2026-03-27 | Runtime-injected vars observation |
@@ -343,6 +345,7 @@ Cross-ref: [CC-binary-architecture.md](CC-binary-architecture.md), [CC RE landsc
 
 [env-vars]: https://code.claude.com/docs/en/env-vars
 [settings]: https://code.claude.com/docs/en/settings
+[debug-config]: https://code.claude.com/docs/en/debug-your-config
 [tools-ref]: https://code.claude.com/docs/en/tools-reference#bash-tool-behavior
 [monitoring]: https://code.claude.com/docs/en/monitoring-usage
 [otel-spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options

--- a/docs/cc-native/configuration/CC-model-provider-configuration.md
+++ b/docs/cc-native/configuration/CC-model-provider-configuration.md
@@ -3,8 +3,8 @@ title: CC Model & Provider Configuration
 source: https://code.claude.com/docs/en/settings#environment-variables, https://openrouter.ai/docs/cookbook/coding-agents/claude-code-integration, https://ollama.com/blog/claude, https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models, https://www.infomaniak.com/en/hosting/ai-services/open-source-models
 purpose: Reference for configuring CC with alternative models, endpoints, API keys, third-party providers (OpenRouter, Bedrock, Vertex, Foundry, Infomaniak), local models (Ollama, llama.cpp, LM Studio), and LLM gateway proxies.
 created: 2026-03-07
-updated: 2026-07-05
-validated_links: 2026-07-05
+updated: 2026-07-23
+validated_links: 2026-07-23
 ---
 
 **Status**: Reference (actionable configuration guide)
@@ -268,7 +268,7 @@ export ANTHROPIC_AUTH_TOKEN=<cliproxy-key>
 ```
 
 - **Stars / version**: 37.6K stars, v7.2.7 (MIT, Go)
-- **CC story**: wraps `claude` via OAuth account; supports multi-account switching, per-credential circuit breakers, quota management
+- **CC story**: wraps `claude` via OAuth account; supports multi-account switching, per-credential circuit breakers, quota management. Note this is *gateway-level* multi-account (quota harvesting for downstream clients) — for running N interactive CC sessions on N subscription accounts, see [CC-multi-account-switching-landscape.md](../../cc-community/CC-multi-account-switching-landscape.md)
 - **Also routes**: Gemini CLI, Codex, Grok Build, Antigravity — plus OpenAI-compatible upstream relay (e.g. OpenRouter)
 - **Companion GUI**: [EasyCLI][easycli] (Rust/Tauri desktop app)
 

--- a/docs/plans/2026-07-23-corpus-update-new-sources.md
+++ b/docs/plans/2026-07-23-corpus-update-new-sources.md
@@ -1,0 +1,139 @@
+---
+title: Corpus update + new-sources arc — backlog drain, fresh mining, stale-fact refresh
+status: active
+issue: 374
+created: 2026-07-23
+updated: 2026-07-23
+---
+
+**Status**: Reference (plan)
+
+Two workstreams decided 2026-07-23: (1) **add new sources** from three channels — the
+[#374](https://github.com/qte77/ai-agents-research/issues/374) scout backlog, fresh triage/rxiv
+mining, owner-supplied URLs; (2) **update the corpus** — stale-fact refresh + open trackers
+[#383](https://github.com/qte77/ai-agents-research/issues/383)/[#382](https://github.com/qte77/ai-agents-research/issues/382)
+and [#321](https://github.com/qte77/ai-agents-research/issues/321). Graph rebuild happens **once,
+at the end** (full uniform rebuild only — never partial-update; see AGENT_LEARNINGS).
+
+## Source map
+
+### Channel 1 — #374 scout backlog (13 items, placements pre-decided)
+
+Dup-checks executed 2026-07-23 (calibrated `git grep`, 12 known hits for control term): all four
+flagged items hit only the auto-generated `docs/research/rxiv-agentic-papers.md` → resolution is
+**extend the named landscape, no new doc**.
+
+| Item | Action | Target |
+|---|---|---|
+| parry (prompt-injection scanner) | new/extend | `docs/cc-community/` |
+| Dippy (auto-approve safe bash) | new/extend | `docs/cc-community/` |
+| sudocode (agent-orchestration DSL) | new/extend | `docs/cc-community/` |
+| cc-sessions (production session tool) | new/extend | `docs/cc-community/` |
+| AB Method | **extend** | `docs/non-cc/spec-driven-frameworks-landscape.md` |
+| MOSS (arXiv 2605.22794) | new | `docs/non-cc/` |
+| When Errors Become Narratives (2606.14589) | new | `docs/sdlc-lcm/` |
+| Sovereign Execution Brokers (2606.20520) | new | `docs/sdlc-lcm/` |
+| LedgerAgent (2606.20529) | new | `docs/sdlc-lcm/` |
+| Every Eval Ever (2606.14516) | **extend** | `docs/sdlc-lcm/evaluation-data-resources-landscape.md` |
+| Contagion Networks (2606.20493) | **extend** | `docs/sdlc-lcm/mas-benchmarking-best-practices.md` |
+| Probe-and-Refine Tuning (2606.20512) | new | `docs/cc-native/context-memory/` |
+| Perplexity Computer study (2606.07489) | **extend** | `docs/non-cc/research-agents-landscape.md` |
+
+"new/extend" for CC tools: default is extending
+`docs/cc-community/CC-community-tooling-landscape.md`; a standalone
+`CC-<tool>-analysis.md` only if first-party research shows analysis depth (per
+prefer-extending convention).
+
+### Channel 2 — fresh mining (scout DONE 2026-07-23, awaiting owner OK)
+
+Swept: `triage/` 2026-07-20 outputs + rxiv index W22–W25 (W25 = newest, late-June 2026).
+Changelog-triage and outage archive yielded no new-source candidates (CC's own feature stream →
+routes to existing cc-native doc updates, not new docs). All 15 candidates grep-verified
+zero-coverage (index stubs in `rxiv-agentic-papers.md` don't count as coverage).
+
+| # | Candidate | Placement |
+|---|---|---|
+| T1.1 | Probabilistic Verification for AI Agents (2606.20510) | `sdlc-lcm/` new |
+| T1.2 | Defensive Misdirection vs automated attacks (2606.20470) | extend `sdlc-lcm/agentic-ai-vulnerability-landscape.md` |
+| T1.3 | DoS on LLM Agent Guardrails (2606.14517) | extend `sdlc-lcm/agentic-ai-vulnerability-landscape.md` |
+| T1.4 | Code-Correctness Signals in Hidden States (2606.14530) | `cc-native/model-internals/` |
+| T1.5 | Hierarchical Recovery, Cross-Device Agents (2606.20487) | extend `non-cc/agent-frameworks-infrastructure-landscape.md` |
+| T2.1 | MemoryWAM (2606.20562) | `non-cc/agent-frameworks-infrastructure-landscape.md` |
+| T2.2 | Marginal Advantage Accumulation (2606.20475) | `non-cc/agent-frameworks-infrastructure-landscape.md` |
+| T2.3 | StreamMemBench (2606.14571) | extend `sdlc-lcm/agent-evaluation-metrics-landscape.md` |
+| T2.4 | UltraQuant 4-bit KV caching (2606.20474) | extend `non-cc/kv-cache-serving-landscape.md` |
+| T2.5 | Multi-LCB / LiveCodeBench multi-lang (2606.20517) | extend `sdlc-lcm/mas-benchmarking-best-practices.md` |
+| T2.6 | SIMMER latent-planning-failure bench (2606.14574) | `sdlc-lcm/agent-evaluation-metrics-landscape.md` |
+| T3.1 | Execution-State Capsules (2606.20537) | `non-cc/` (robotics-flavored, low priority) |
+| C1 | roampal-core (memory MCP for CC) | `cc-community/` — **URL truncated in triage, re-resolve from live awesome-claude-code** |
+| C2 | cc-costline (spend statusline) | `cc-community/` — URL truncated, re-resolve |
+| C3 | agents-md-cookbook (AGENTS.md templates) | `cc-community/` — URL truncated, re-resolve |
+
+### Channel 3 — owner URLs (gate, non-blocking) + multi-account ask (scout DONE)
+
+Owner drops URLs anytime; batch runs when they land.
+
+**Multi-account CC research (2026-07-23, verified first-party + `gh api` repo metadata):**
+mechanism = `CLAUDE_CONFIG_DIR` per shell → N independent `claude` processes with independent
+`.credentials.json`; no native profile switcher (upstream FRs #44687/#35856/#64376/#37554 open).
+Tools: **claude-swap** (realiti4, 1,276★, pushed 2026-07-23, MIT — concurrent + rate-limit
+rotation + usage TUI; top pick), claude-multiprofile (42★, adds Claude Desktop via
+`--user-data-dir`), claude-code-profiles (56★, sequential switching, not the concurrency case),
+claude-multisession (1★, stale), manual alias/direnv gists. Intake items (folded into A2-B1):
+
+- NEW `docs/cc-community/CC-multi-account-switching-landscape.md` — mechanism + tool table
+  (distinct category from `CC-usage-tooling-landscape.md` = cost observability)
+- EXTEND `docs/cc-native/configuration/CC-env-vars-reference.md` — add `CLAUDE_CONFIG_DIR`
+  (verified zero-coverage gap, `git grep -c` 2026-07-23)
+- Cross-ref from `CC-model-provider-configuration.md:260` (CLIProxyAPI = gateway-level
+  multi-account quota harvesting) → new landscape (native CLI multi-account) to disambiguate
+
+## Phases
+
+### Phase A — intake (agent-only, one PR per topic batch)
+
+- [x] A1: dup-checks (4/4) + both scouts fired AND reported (2026-07-23; findings persisted above)
+- [ ] A2-B1: cc-community CC tools — parry, Dippy, sudocode, cc-sessions, AB Method +
+      multi-account trio (new landscape, env-vars extend, model-provider cross-ref)
+- [ ] A2-B2: sdlc-lcm papers — Errors-Narratives, Sovereign Execution Brokers, LedgerAgent (new);
+      Every Eval Ever, Contagion Networks (extends)
+- [ ] A2-B3: non-cc + cc-native — MOSS (new), Perplexity Computer (extend), Probe-and-Refine (new)
+- [ ] A2-B4: mined shortlist — owner APPROVED ALL 15 (2026-07-23): T1 (5) + T2 (6) + T3 (1) +
+      CC tools C1–C3 (URLs re-resolved from live awesome-claude-code first)
+- [ ] A2-B5: owner URLs (when supplied)
+
+**Done-when per source**: first-party verified (license from LICENSE, counts from live README) ·
+Sources table + reference-style links · both subdir README and `cc-native/README.md` counts (where
+applicable) · changelog fragment · `make lint` green · squash-merged.
+
+### Phase B — corpus update
+
+- [ ] Stale-fact refresh — target cohort identified 2026-07-23: 27 live docs with
+      `validated_links: 2026-03-*` (`git grep -l "validated_links: 2026-03" -- docs/`, minus 2
+      `docs/archive/` files which stay frozen). Link liveness is already covered by the weekly
+      link-rot monitor — the refresh targets **content drift**. Priority order: CC vendor-behavior
+      docs first (CC ships weekly): `configuration/CC-fast-mode-analysis.md`,
+      `CC-bash-mode-analysis.md`, `CC-hooks-system-analysis.md`, the `sandboxing/` trio,
+      `sessions/CC-session-cost-analysis.md`, `ci-remote/CC-cloud-sessions-analysis.md`,
+      `plugins-ecosystem/CC-connectors-overview.md` + `CC-chrome-extension-analysis.md`; then the
+      remaining cohort. Per doc: re-fetch first-party page, update version gates, bump `updated:`
+      (+`validated_links:` if lychee re-run)
+- [ ] Tracker #383/#382: on-device semantic-search landscape (new doc, Technology-Radar verdicts)
+- [ ] Tracker #321: spec-frameworks follow-ups (surgical adds)
+
+### Phase C — close-out
+
+- [ ] Graph rebuild: `/graphify` full uniform rebuild (scope `docs/` only) + `make graph-page`,
+      commit `ui/graph.html` — only if Phase A landed substantial new *concept* content
+- [ ] Advance #374 (check off shipped backlog items; close if drained), advance/close #383, #321
+- [ ] Update this plan `status: done`
+
+## Standing decisions & watch-outs
+
+- **Own/bot PRs+issues only** (owner directive 2026-07-23): foreign-authored issues/PRs → ask
+  owner first, never autonomous triage.
+- Extend-over-create for the 4 dup-flagged items (decided, above).
+- Verify subagent findings with own `git grep` + `Read` before acting (read-discipline).
+- Never fire two same-day `rxiv-paper-eval` dispatches (CONTRIBUTING).
+- Lychee flakes: known intermittents (skywork.ai, cohere.com/rerank) — do not add excludes.
+- Merge routine: squash-merge; owner `--admin` for signature gate; serialize via update-branch.

--- a/docs/plans/2026-07-23-corpus-update-new-sources.md
+++ b/docs/plans/2026-07-23-corpus-update-new-sources.md
@@ -1,6 +1,6 @@
 ---
 title: Corpus update + new-sources arc — backlog drain, fresh mining, stale-fact refresh
-status: active
+status: approved
 issue: 374
 created: 2026-07-23
 updated: 2026-07-23


### PR DESCRIPTION
First deliverable of the 2026-07-23 corpus-update + new-sources arc (plan: `docs/plans/2026-07-23-corpus-update-new-sources.md`).

## Added
- `docs/cc-community/CC-multi-account-switching-landscape.md` — running multiple CC subscription accounts (concurrently or switched) in one OS: native `CLAUDE_CONFIG_DIR` mechanism, per-platform credential isolation (Linux/Windows per-dir; macOS Keychain carries over), tool table (claude-swap, claude-code-profiles, claude-multiprofile, claude-multisession), disambiguation vs CC Switch / CLIProxyAPI / usage tooling.
- Arc plan doc (source map, phases, stale-refresh cohort).

## Changed
- `CC-env-vars-reference.md` — adds `CLAUDE_CONFIG_DIR` (verified zero-coverage gap; documented upstream only in debug-your-config, absent from the official env-vars list as of 2026-07-23).
- `CC-model-provider-configuration.md` — CLIProxyAPI entry disambiguates gateway-level vs native CLI multi-account.
- `batch-sources.workflow.js` — tolerate JSON-string args (fixes silent no-op observed twice).

## Verification
- Mechanism + platform behavior verified first-party (debug-your-config, settings, env-vars pages fetched 2026-07-23); upstream FRs #44687/#35856/#64376/#37554 verified via API (all closed, unimplemented); repo metadata via GitHub API 2026-07-23.
- `make check_docs`: 0 issues · `make check_links`: 2692 links, 0 errors.

Generated with Claude <noreply@anthropic.com>