### PR TITLE
docs: new-sources batch B1 — CC workflow/security tooling + orchestration/SDD entries

### DIFF
--- a/changelog.d/20260723_130000_docs_new_sources_b1_tools.md
+++ b/changelog.d/20260723_130000_docs_new_sources_b1_tools.md
@@ -1,0 +1,5 @@
+### Changed
+
+- `docs/cc-community/CC-community-tooling-landscape.md`: added Parry Guard (CC-hook injection/secrets/exfil scanner, local DeBERTa + AST layers; Codex support unreleased-main-only per its own release notes), Dippy (PreToolUse bash auto-approval with steerable deny messages, vendored zero-dep parser), and cc-sessions (DAIC session/workflow enforcement, 1,550★ but dormant since 2025-10) — sections + comparison rows + sources; all facts first-party verified with adversarial re-check (counts/license/version).
+- `docs/non-cc/agent-frameworks-infrastructure-landscape.md`: added sudocode to §1 (git-native spec/issue-graph orchestrator running CC/Codex/Cursor via ACP, Apache-2.0) alongside the comparable multica entry.
+- `docs/non-cc/spec-driven-frameworks-landscape.md`: added AB Method (fractal roadmap→tasks→missions TDD workflow, dual-runtime CC+Codex with runtime-adaptive subagent nesting, v3.7.1) — table row, differ-bullet, sources.

--- a/docs/cc-community/CC-community-tooling-landscape.md
+++ b/docs/cc-community/CC-community-tooling-landscape.md
@@ -1,12 +1,12 @@
 ---
 title: CC Community Tooling Landscape
-purpose: Survey of community developer tools that integrate with or enhance Claude Code — context compression, meta-prompting, spec-driven development, agent frameworks, file-read deduplication, source enrichment, provider management. Memory, code-analysis, and usage-observability tools live in linked topic docs; this doc keeps the cross-tool comparison.
+purpose: Survey of community developer tools that integrate with or enhance Claude Code — context compression, meta-prompting, spec-driven development, agent frameworks, file-read deduplication, source enrichment, provider management, injection scanning, permission auto-approval, session-workflow enforcement. Memory, code-analysis, and usage-observability tools live in linked topic docs; this doc keeps the cross-tool comparison.
 category: landscape
 status: research
 platform_scope: [claude-code, cursor, codex, gemini-cli, opencode, windsurf, zed, antigravity]
 created: 2026-03-13
-updated: 2026-06-28
-validated_links: 2026-06-28
+updated: 2026-07-23
+validated_links: 2026-07-23
 ---
 
 **Status**: Research (informational)
@@ -195,6 +195,75 @@ Cross-ref: [CC-model-provider-configuration.md](../cc-native/configuration/CC-mo
 
 ---
 
+## Parry Guard (vaporif)
+
+**Repo**: [vaporif/parry-guard][parry-guard] | **Stars**: 44 | **License**: MIT (optional Llama Prompt Guard 2 model under a separate Llama Community License) | **Version**: v0.1.5
+
+Rust prompt-injection / secrets / data-exfiltration scanner wired into CC hooks with **local** ML inference plus deterministic checks — no cloud calls at scan time.
+
+### How It Works
+
+1. Six ordered detection layers: Unicode invisible-char/homoglyph/RTL detection → Aho-Corasick known-injection-phrase matching → 40+ secret-pattern regexes → DeBERTa v3 ML classification (256-char chunks, default threshold 0.7) → bash exfiltration detection via tree-sitter AST (network sinks, base64/hex obfuscation, DNS tunneling) → the same source-to-sink analysis across 16 scripting languages
+2. Three hook events: **PreToolUse** (7 ordered checks incl. taint enforcement, CLAUDE.md scanning, exfil/destructive-op/sensitive-path blocking, injection scan of Write/Edit/Bash/MCP input), **PostToolUse** (scans tool *output*, auto-taints the project on hit), **UserPromptSubmit** (audits `.claude/` for dangerous permissions and injected hook scripts)
+3. Fail-closed (undetermined = unsafe); scan cache in `~/.parry-guard/` (~8ms hit vs 70ms+ fresh inference, 30-day TTL)
+
+### Adoption Considerations
+
+- **Claude Code hooks today** — the published v0.1.5 release is Claude-only ("wait for 0.2.0 for Codex support" per its release notes); Codex wiring exists only on unreleased `main`
+- Requires a HuggingFace token: the ProtectAI DeBERTa v3 model is gated (required); Meta's Llama Prompt Guard 2 (`full` mode only) needs separate Meta license approval
+- Latency/speedup numbers are author-self-reported (no independent benchmark); the README itself hedges "early development — bugs and false positives happen"
+- Install: `uvx parry-guard hook`, Nix flake (home-manager module), `cargo install`, or release binaries
+
+Cross-ref: [CC-hooks-system-analysis.md](../cc-native/configuration/CC-hooks-system-analysis.md) — hook mechanism; [agent-frameworks-infrastructure-landscape.md §8](../non-cc/agent-frameworks-infrastructure-landscape.md) — LLM Guard, the library-level (app-side) scanner on the same DeBERTa model family
+
+---
+
+## Dippy (ldayton)
+
+**Repo**: [ldayton/Dippy][dippy] | **Stars**: 242 | **License**: MIT | **Version**: v0.2.7
+
+PreToolUse hook (matcher `Bash`) that statically analyzes shell commands with a hand-written bash parser and **auto-approves** ones classified safe — attacking permission-prompt fatigue from the approve side where Parry Guard attacks it from the block side.
+
+### How It Works
+
+1. Parses the command with the author's own zero-dependency parser (Parable, vendored by pinned commit + sha256 — a deliberate supply-chain pin)
+2. Auto-approves read-only pipelines, chained reads, safe redirects; blocks subshell injection, hidden mutations, cloud-destructive ops
+3. Two-tier config (`~/.dippy/config` global + `.dippy` project root) with directives like `deny python "Use uv run python, which runs in project environment"` — deny rules carry **custom steering messages** that redirect Claude instead of failing silently
+4. Ships a second entry point, `dippy-statusline`
+
+### Adoption Considerations
+
+- Reduces prompts; it is not a security boundary — no published false-allow/false-block rate, only the README's curated approve/block examples
+- The README's "up to 40% faster development" is an unbenchmarked marketing claim — disregard
+- Install via Homebrew tap (`brew tap ldayton/dippy`) or clone; Python ≥3.8, zero runtime dependencies
+
+Cross-ref: [CC-hooks-system-analysis.md](../cc-native/configuration/CC-hooks-system-analysis.md)
+
+---
+
+## cc-sessions (GWUDCAP)
+
+**Repo**: [GWUDCAP/cc-sessions][cc-sessions] | **Stars**: 1,550 | **License**: MIT | **Version**: v0.3.6 (2025-10-17; README banner stale at "v0.3.0")
+
+Opinionated session/workflow manager that gates Edit/Write/MultiEdit behind a **Discussion-Alignment-Implementation-Check (DAIC)** protocol, binds task files to git branches, and delegates heavy work to 5 specialized subagents.
+
+### How It Works
+
+1. Edits are blocked until Claude proposes specific todos and the user approves via a trigger phrase (defaults "mek:", "start^:", "finito", "squish" — all remappable via `sessions config triggers`); mid-plan deviation throws the session back to discussion mode
+2. Tasks are markdown files with frontmatter (status/branch/success-criteria); the installer creates matching git branches and blocks edits/commits off the task's assigned branch
+3. Five subagents installed to `.claude/agents/`: context-gathering, logging, code-review, context-refinement, service-documentation — each in its own context window
+4. Dual-packaged with feature parity: npm and PyPI (`npx cc-sessions` / `pipx run cc-sessions`), installed per-repo; updates/uninstalls are backup-first (`.claude/.backup-*`)
+
+### Adoption Considerations
+
+- Highest adoption in this batch (1,550 stars) but **no main-branch commits or releases since 2025-10-17** (~9 months as of 2026-07-23) — maintenance status unclear
+- DAIC overlaps CC's native plan mode conceptually; the differentiator is *enforcement* (hard tool-gating + branch discipline) vs. guidance
+- Same opinionated-workflow niche as GSD (above) — see Comparison
+
+Cross-ref: [CC-hooks-system-analysis.md](../cc-native/configuration/CC-hooks-system-analysis.md)
+
+---
+
 ## Detailed Tool Landscapes
 
 Per-tool entries for three categories have moved to focused topic docs; the cross-tool comparison below still covers all of them:
@@ -218,6 +287,9 @@ Design-systems / format tooling (awesome-design-md, Google Labs DESIGN.md spec +
 | **ByteRover** | Persistent memory | MCP server | Hierarchical context trees, cloud sync | Active (4.1K stars, 48 releases) |
 | **Claude-Mem** | Persistent memory + compression | Hooks + MCP + plugin | AI-compressed observations, progressive search | Active (45.2K stars, v6.5.0) |
 | **CC Switch** | Multi-CLI provider management | Desktop app (GUI) | Unified config across 5 AI CLIs | Active (38.9K stars, 1,376 commits) |
+| **Parry Guard** | Injection/secrets/exfil scanning | Hooks (PreToolUse + PostToolUse + UserPromptSubmit) | Local ML (DeBERTa v3) + AST/regex layers, fail-closed | Early (44 stars, v0.1.5) |
+| **Dippy** | Permission auto-approval | PreToolUse hook (Bash matcher) | Static bash-AST safe/unsafe classification + steerable deny messages | Active (242 stars, v0.2.7) |
+| **cc-sessions** | Session/workflow enforcement | Hooks + subagents + trigger phrases | DAIC tool-gating, task↔branch binding | Adopted but dormant (1,550 stars, v0.3.6, no commits since 2025-10) |
 | **Graphify** | Code→knowledge graph | Hooks + slash commands + MCP + CLAUDE.md | Semantic knowledge graphs from repos | Active (16.5K stars) |
 | **MemPalace** | Persistent memory | MCP server + plugin marketplace | Verbatim palace-metaphor memory | Active (33.6K stars, v3.0.0) |
 | **MemSearch** | Persistent memory (cross-agent) | Plugin (hooks + skill, no MCP) | Markdown source-of-truth + Milvus hybrid search | Active (~2K stars, v0.4.7) |
@@ -231,7 +303,7 @@ Design-systems / format tooling (awesome-design-md, Google Labs DESIGN.md spec +
 | **ccusage** | Token-usage observability (CC/Codex) | CLI + MCP server + statusline | JSONL analyzer, cache-token split, offline mode | Stable (13.4K stars, v18.0.11) |
 | **Claude-Code-Usage-Monitor** | Predictive usage monitoring | Real-time TUI | P90-based limit prediction, burn-rate analytics, plan-aware | Active (7.8K stars, v3.1.0) |
 
-All nineteen address different layers of the agent stack — complementary, not competing. The five code-analysis tools (graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP) split along precompute-a-graph vs. live-LSP vs. on-demand-structural-search; the two repo packers (Repomix, code2prompt) are one-shot context export rather than a live server. Full per-tool entries for the memory, code-analysis, and usage-observability rows are in the topic docs linked above.
+All twenty-two address different layers of the agent stack — complementary, not competing. The five code-analysis tools (graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP) split along precompute-a-graph vs. live-LSP vs. on-demand-structural-search; the two repo packers (Repomix, code2prompt) are one-shot context export rather than a live server. Full per-tool entries for the memory, code-analysis, and usage-observability rows are in the topic docs linked above.
 
 Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-extended-context-analysis.md) — CC's built-in context compaction
 
@@ -248,6 +320,9 @@ Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-exte
 | [ByteRover paper][byterover-paper] | arXiv:2604.01599 — agent-native memory via hierarchical context |
 | [Claude-Mem][claude-mem] | Persistent memory compression system (45.2K stars) |
 | [CC Switch][cc-switch] | Cross-platform multi-CLI provider management (38.9K stars) |
+| [Parry Guard][parry-guard] | CC-hook injection/secrets/exfil scanner, local DeBERTa + AST layers (44 stars, MIT; optional Llama-licensed model; v0.1.5, PyPI-verified) |
+| [Dippy][dippy] | PreToolUse bash auto-approval hook, zero-dep vendored parser (242 stars, MIT, v0.2.7) |
+| [cc-sessions][cc-sessions] | DAIC session/workflow enforcement, npm+PyPI dual-packaged (1,550 stars, MIT, v0.3.6) |
 | [Graphify][graphify] | Code→knowledge graph via slash commands, hooks, MCP (16.5K stars) |
 | [MemPalace][mempalace] | Local-first AI memory with palace metaphor, 96.6% LongMemEval (33.6K stars) |
 | [MemSearch][memsearch] | Markdown + Milvus persistent memory for CC/OpenCode/Codex, hooks+skill (no MCP), hybrid vector+BM25 (~2K stars, MIT) |
@@ -290,6 +365,9 @@ Cross-ref: [CC-extended-context-analysis.md](../cc-native/context-memory/CC-exte
 [byterover-paper]: https://arxiv.org/abs/2604.01599
 [claude-mem]: https://github.com/thedotmack/claude-mem
 [cc-switch]: https://github.com/farion1231/cc-switch
+[parry-guard]: https://github.com/vaporif/parry-guard
+[dippy]: https://github.com/ldayton/Dippy
+[cc-sessions]: https://github.com/GWUDCAP/cc-sessions
 [hlyr-backpressure]: https://www.hlyr.dev/blog/context-efficient-backpressure
 [skills-landscape]: CC-community-skills-landscape.md
 [codeburn]: https://github.com/getagentseal/codeburn

--- a/docs/cc-community/README.md
+++ b/docs/cc-community/README.md
@@ -8,7 +8,7 @@ Community-built skills, plugins, tooling, workflows, and patterns for Claude Cod
 |----------|----------|
 | [CC-community-skills-landscape.md](CC-community-skills-landscape.md) | Skill libraries: gstack, pm-skills, claude-code-best-practice, BHIL, claude-howto, dispatch, superpowers, agent-skills, caveman, last30days, agent-native |
 | [CC-community-plugins-landscape.md](CC-community-plugins-landscape.md) | Plugin catalogs: awesome-claude-code, awesome-claude-code-plugins |
-| [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) | Dev tooling + cross-tool comparison: RTK, GSD, everything-claude-code, Boucle, CC Switch; token-waste reduction stack |
+| [CC-community-tooling-landscape.md](CC-community-tooling-landscape.md) | Dev tooling + cross-tool comparison: RTK, GSD, everything-claude-code, Boucle, CC Switch, Parry Guard, Dippy, cc-sessions; token-waste reduction stack |
 | [CC-memory-tooling-landscape.md](CC-memory-tooling-landscape.md) | Persistent memory: ByteRover, Claude-Mem, MemPalace, MemSearch |
 | [CC-code-tooling-landscape.md](CC-code-tooling-landscape.md) | Code analysis: Graphify, Code-Review-Graph, codebase-memory-mcp, Serena, ast-grep MCP, Repomix, code2prompt |
 | [CC-usage-tooling-landscape.md](CC-usage-tooling-landscape.md) | Usage observability: CodeBurn, ccusage, Claude-Code-Usage-Monitor |

--- a/docs/non-cc/agent-frameworks-infrastructure-landscape.md
+++ b/docs/non-cc/agent-frameworks-infrastructure-landscape.md
@@ -4,8 +4,8 @@ purpose: Catalog of multi-agent orchestration frameworks, LLM-orchestration/rout
 category: landscape
 status: research
 created: 2026-06-14
-updated: 2026-06-28
-validated_links: 2026-06-28
+updated: 2026-07-23
+validated_links: 2026-07-23
 ---
 
 **Status**: Research (informational)
@@ -31,6 +31,7 @@ Catalog of agent frameworks and supporting infrastructure beyond Claude Code. Re
 - [DeepAgents (LangChain)](https://github.com/langchain-ai/deepagents) — planning + sub-agent harness. Full analysis: [deepagents-analysis.md](deepagents-analysis.md).
 - [Flue (Astro)](https://github.com/withastro/flue) — durable, sandboxed TypeScript agent framework from the Astro team; **1.0 Beta** (~2026-06-16, Apache-2.0, [flueframework.com](https://www.flueframework.com)). Harness-first model on the **Pi** agent loop (via `@flue/runtime`): **Durable Streams** record every prompt/tool-response/model-choice to an append-only log, so a fresh process resumes from the last checkpoint after a crash or provider timeout. Ships a **just-bash** in-memory sandbox (no Docker/VM) plus a `local()` sandbox; MCP-native and model-agnostic; **channels** ingest events from Slack/Teams/Discord/GitHub/Linear; on Cloudflare Workers each agent becomes a Durable Object (SQLite FS, `runFiber`/`stash`/`onFiberRecovered`). Supports **subagents / task delegation** (swarm-style coordination is not documented in first-party sources); `SuperagenticAI/pyflue` is a community Python port, not first-party.
 - [multica](https://github.com/multica-ai/multica) — source-available platform (modified Apache 2.0: no third-party hosted-service/resale + a frontend logo clause — not OSI open-source) that turns coding-agent CLIs into managed teammates: create issues → assign to an agent or a squad, a local daemon executes and streams progress over WebSocket, with autopilot (cron/webhook) scheduling and a reusable skill library. Integrates 13 agent CLIs (Claude Code, Codex, GitHub Copilot CLI, OpenClaw, OpenCode, Hermes, Gemini, Pi, Cursor Agent, Kimi, Kiro CLI, Antigravity, Qoder CLI); Go + Postgres 17/pgvector backend, Next.js 16 UI. Install `brew install multica-ai/tap/multica` or the `install.sh` script; CLI flows `multica login` → `multica daemon start` → `multica issue create` / `multica workspace switch`. Auth is browser-based via `multica login` — no env vars documented.
+- [sudocode](https://github.com/sudocode-ai/sudocode) — git-native agent orchestrator (Apache-2.0, verified from LICENSE; TypeScript): human requirements live as version-controlled **specs**, agent runtime context as **issues**, linked bidirectionally (blocks / related / parent-child / discovered-from) and persisted as JSONL committed to git with a local SQLite cache. Runs Claude Code / Codex / Cursor (+more via Agent Client Protocol, added v0.1.19) in parallel with dependency-ordered (topological) execution and a kanban-style real-time UI. `npm install -g sudocode`; ships CLI + local server/UI + MCP server. v0.2.0 (2026-03-18); 287★, last push 2026-03-18 (`gh api`, 2026-07-23). Directly comparable to multica above (multi-CLI, issue-driven, local daemon) — sudocode is git-repo-resident and OSS where multica is a source-available managed platform.
 
 ## 2. LLM Orchestration & Routing
 

--- a/docs/non-cc/spec-driven-frameworks-landscape.md
+++ b/docs/non-cc/spec-driven-frameworks-landscape.md
@@ -1,10 +1,10 @@
 ---
 title: Spec-Driven Frameworks — Landscape
-purpose: Comparison of spec-driven development (SDD) frameworks — GitHub Spec-Kit, OpenSpec, BMAD-METHOD, Agent-OS, Kiro, Tessl — the standalone deep-dive behind the synthesis entry in the agentic-engineering disciplines landscape.
+purpose: Comparison of spec-driven development (SDD) frameworks — GitHub Spec-Kit, OpenSpec, BMAD-METHOD, Agent-OS, Kiro, Tessl, AB Method — the standalone deep-dive behind the synthesis entry in the agentic-engineering disciplines landscape.
 category: landscape
 created: 2026-06-27
-updated: 2026-06-28
-validated_links: 2026-06-28
+updated: 2026-07-23
+validated_links: 2026-07-23
 ---
 
 **Status**: Research (informational)
@@ -23,6 +23,7 @@ By 2026 every major coding tool shipped a **spec-driven development (SDD)** flav
 | [buildermethods/agent-os][agent-os] | 5.0K | MIT | MCP context-injection layer | composes with any SDD framework rather than replacing it |
 | [kirodotdev/Kiro][kiro-repo] | 3.9K | proprietary | requirements → design → tasks "waves" | full IDE; spec phase is mandatory — see [kiro-analysis.md](kiro-analysis.md) |
 | Tessl (`tile`) | ~41 | MIT | "spec-as-source" | the spec, not the code, is the maintained artifact; main framework closed-beta |
+| [ayoubben18/ab-method][ab-method] | 180 | MIT | grill → roadmap → tasks → missions (TDD) | fractal structure; opt-in-silent critic agents bracket implementation; dual-runtime CC + Codex (v3.7.1; stars via `gh api`, 2026-07-23) |
 
 ## How they differ
 
@@ -31,6 +32,7 @@ By 2026 every major coding tool shipped a **spec-driven development (SDD)** flav
 - **Agent-OS** is a *layer*, not a framework — an MCP context-injection shim that pairs with the others.
 - **Kiro** bakes SDD into a full IDE (the spec phase is mandatory) — covered in depth in its own analysis.
 - **Tessl** pushes "spec-as-source" furthest (the spec is the maintained artifact, code is regenerated), but the main framework is closed-beta.
+- **AB Method** is the lightweight dual-runtime sibling: `npx ab-method` installs into `.claude/` (CC slash commands) *and* `.agents/` (Codex `ab-*` skills). No generated spec docs — "the test is the spec"; plans are grounded in `UBIQUITOUS_LANGUAGE.md`/`CONTEXT.md`, missions are one-line tracker entries, and four critic skills (`critique-plan`, `reconcile-roadmap`, `review-implementation` with three parallel critics, `sync-architecture`) gate each layer. Runtime-adaptive: nests subagents on CC (verified two levels), stays flat on Codex (`spawn_agent` can't nest).
 
 ## Where SDD sits
 
@@ -46,9 +48,11 @@ SDD is the *what* (machine-readable spec → plan → tasks → implement); **ED
 | Source | Content |
 |---|---|
 | [github/spec-kit][spec-kit] · [OpenSpec][openspec] · [BMAD-METHOD][bmad] · [agent-os][agent-os] · [Kiro][kiro-repo] | SDD frameworks (stars via `gh api`, 2026-06-27) |
+| [ayoubben18/ab-method][ab-method] | Fractal CC+Codex workflow method, v3.7.1, MIT from LICENSE (stars via `gh api`, 2026-07-23) |
 | [Martin Fowler — SDD tools][fowler-sdd] | Spec-driven development survey |
 
 [spec-kit]: https://github.com/github/spec-kit
+[ab-method]: https://github.com/ayoubben18/ab-method
 [openspec]: https://github.com/Fission-AI/OpenSpec
 [bmad]: https://github.com/bmadcode/BMAD-METHOD
 [agent-os]: https://github.com/buildermethods/agent-os


### PR DESCRIPTION
Second deliverable of the 2026-07-23 arc (plan lands with #396). Drains 5 of the 13 #374 scout-backlog items — all EXTENDs, no new files:

## Changed
- `CC-community-tooling-landscape.md` — **Parry Guard** (hook-based injection/secrets/exfil scanner, local DeBERTa+AST, fail-closed; v0.1.5 release is Claude-only — Codex wiring is unreleased-main-only per its own release notes), **Dippy** (PreToolUse bash auto-approval, vendored zero-dep parser, steerable deny messages), **cc-sessions** (DAIC edit-gating + task↔branch binding; 1,550★ but dormant since 2025-10, README banner stale vs actual tag) + comparison rows, sources, purpose.
- `agent-frameworks-infrastructure-landscape.md` §1 — **sudocode** (git-native spec/issue-graph orchestrator, CC/Codex/Cursor via ACP, Apache-2.0), placed beside the comparable multica entry. Reclassified non-cc vs the backlog's cc-community guess: agent-agnostic by design.
- `spec-driven-frameworks-landscape.md` — **AB Method** row + differ-bullet (fractal roadmap→tasks→missions TDD, dual-runtime CC+Codex with runtime-adaptive subagent nesting).

## Verification
- Batch research via the skill's `batch-sources` workflow (58 agents: per-source first-party research + adversarial verify). Corrections applied: parry-guard issue-count (GitHub `open_issues_count` conflates PRs) and Codex-scope overstatement caught and fixed pre-write.
- Licenses read from LICENSE files; versions from releases/PyPI; marketing claims ("40% faster", self-reported latency) flagged as unverified in-doc.
- `make check_docs` 0 issues · `make check_status` OK · `make check_links` 2676 links, 0 errors.

Refs #374.

Generated with Claude <noreply@anthropic.com>