### PR TITLE
feat(scripts): dual-mode CLI dispatch for cc-multi-account.sh (-h/--help/no-args)

### DIFF
--- a/changelog.d/20260723_230000_feat_cc_multi_account_cli_dispatch.md
+++ b/changelog.d/20260723_230000_feat_cc_multi_account_cli_dispatch.md
@@ -1,0 +1,3 @@
+### Added
+
+- `scripts/cc-multi-account.sh`: direct-execution dispatch — `./cc-multi-account.sh <profile>` launches, `list`/`ls` lists profiles, `usage <profile>` shows per-account stats, and `-h`/`--help`/no-args print the usage header (unknown options exit 2 with help on stderr). Sourcing is unchanged and still defines `ccp`/`ccu`/`ccl`; the header now documents both modes and why sourcing is required for the short commands.

--- a/scripts/cc-multi-account.sh
+++ b/scripts/cc-multi-account.sh
@@ -23,11 +23,25 @@
 # first run of each prompts /login for that account; they run concurrently.
 # ─────────────────────────────────────────────────────────────────────────────
 #
-# HELPERS (source this file from ~/.bashrc:  source /path/to/cc-multi-account.sh):
-#   ccp work            # launch CC on the "work" account (first run → /login)
-#   ccp personal        # launch CC on the "personal" account
-#   ccu work            # per-account usage/cost stats (needs: npm i -g ccusage)
-#   ccl                 # list configured profiles
+# TWO WAYS TO USE IT
+#
+# 1. Executed directly (one-off, no setup):
+#      ./cc-multi-account.sh work        # launch CC on the "work" account
+#      ./cc-multi-account.sh usage work  # that account's usage/cost stats
+#      ./cc-multi-account.sh list        # list configured profiles
+#      ./cc-multi-account.sh --help      # this help
+#
+# 2. Sourced (persistent short commands — put in ~/.bashrc):
+#      source /path/to/cc-multi-account.sh
+#    then:
+#      ccp work            # launch CC on the "work" account (first run → /login)
+#      ccp personal        # launch CC on the "personal" account
+#      ccu work            # per-account usage/cost stats (needs: npm i -g ccusage)
+#      ccl                 # list configured profiles
+#
+# Sourcing is required for the short `ccp`/`ccu`/`ccl` commands because the file
+# defines shell functions — running it in a child shell would define them there
+# and discard them on exit.
 
 : "${CC_PROFILE_HOME:=$HOME/.claude-profiles}"   # where per-account dirs live
 
@@ -54,3 +68,19 @@ ccl() {
   echo "profiles in $CC_PROFILE_HOME:"
   find "$CC_PROFILE_HOME" -maxdepth 1 -mindepth 1 -type d -printf '  %f\n' 2>/dev/null || echo "  (none yet)"
 }
+
+# Print the usage header (everything between the shebang and the first blank
+# line after the comment block) — used for --help and bare invocation.
+cch() { sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+# Dispatch when EXECUTED rather than sourced. Sourcing skips this entirely and
+# just leaves ccp/ccu/ccl defined in your shell.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  case "${1:-}" in
+    ""|-h|--help|help) cch; exit 0 ;;
+    list|ls)           ccl ;;
+    usage|stats)       shift; ccu "$@" ;;
+    -*)                echo "unknown option: $1" >&2; echo >&2; cch >&2; exit 2 ;;
+    *)                 ccp "$@" ;;
+  esac
+fi


### PR DESCRIPTION
Fixes a wart in #405: the script was shebanged and `chmod +x` — advertising "run me" — but running it did nothing, because it only *defines* shell functions (a child shell defines them, then exits).

## Now both modes work

```bash
./cc-multi-account.sh                 # no args  -> usage header, exit 0
./cc-multi-account.sh -h | --help     # same
./cc-multi-account.sh work            # -> ccp work  (launch that account)
./cc-multi-account.sh usage work      # -> ccu work  (per-account stats)
./cc-multi-account.sh list | ls       # -> ccl       (list profiles)
./cc-multi-account.sh --bogus         # error + help on stderr, exit 2
source cc-multi-account.sh            # unchanged: defines ccp/ccu/ccl
```

Implemented with a `[ "${BASH_SOURCE[0]}" = "$0" ]` guard, so **sourcing skips the dispatch entirely** — existing behaviour is untouched. Help text is derived from the file's own header comment (single source of truth, can't drift). The header now also documents both modes and *why* sourcing is required for the short commands.

## Verified
`bash -n` clean; all six paths exercised (no-args, `-h`, `list`, unknown-option exit 2, and `type -t ccp ccu ccl` → `function` after sourcing).

Generated with Claude <noreply@anthropic.com>